### PR TITLE
chore: add .github/CODEOWNERS to confirm single maintainer (#1)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jeisenback


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `* @jeisenback` to satisfy the final open AC item on issue #1
- Branch protection for `main` was configured manually (require PR + required status checks)

## Test plan
- [ ] Confirm `.github/CODEOWNERS` exists and contains `* @jeisenback`
- [ ] Confirm `main` branch protection shows required PR reviews and status checks in GitHub Settings → Branches
- [ ] Merge and close issue #1

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)