### PR TITLE
fix(ingestion): restore write_option_records import — close #26

### DIFF
--- a/src/agents/ingestion/ingestion_agent.py
+++ b/src/agents/ingestion/ingestion_agent.py
@@ -22,6 +22,7 @@ import os
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+from src.agents.ingestion.db import write_option_records  # noqa: F401
 from src.agents.ingestion.models import MarketState, OptionRecord, RawPriceRecord
 
 # Do NOT call logging.basicConfig() here — configuration belongs in the entry point.


### PR DESCRIPTION
## Summary

- Restores `from src.agents.ingestion.db import write_option_records  # noqa: F401` to `ingestion_agent.py`
- This satisfies AC item 3 from issue #26, which was the single unresolved item after PR #37 merged
- The import is annotated `# noqa: F401` per standard scaffold practice — it will be actively used once `run_ingestion()` is implemented

## AC Verification

- [x] `fetch_options_chain()` stub added with `@retry`, `list[OptionRecord]` return type, Yahoo Finance/Polygon.io docstring, `NotImplementedError` + POLYGON_API_KEY TODO *(merged in #37)*
- [x] `run_ingestion()` TODO references `fetch_options_chain` *(merged in #37)*
- [x] `write_option_records` import present *(this PR)*
- [x] `logging.basicConfig()` block removed *(merged in #37)*
- [x] `ruff` passes — no unused-import warnings (`# noqa: F401` suppresses scaffold-stage warning)
- [x] All existing tests pass (9 xfailed as expected)

## Test plan

- [x] `pytest -m "not integration"` — 9 xfailed, 0 failed
- [x] `bash scripts/local_check.sh` — all 4 stages PASS (ruff, black, mypy, import scan)

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)