### PR TITLE
chore(ci): fix PYTHONPATH in pr-review and issue-refinement workflows

### DIFF
--- a/.github/workflows/issue-refinement.yml
+++ b/.github/workflows/issue-refinement.yml
@@ -37,7 +37,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python scripts/run_issue_refinement.py \
+          PYTHONPATH=. python scripts/run_issue_refinement.py \
             --issue ${{ github.event.issue.number }} \
             --post-comment \
             --update-labels

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -38,6 +38,6 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python scripts/run_pr_review.py \
+          PYTHONPATH=. python scripts/run_pr_review.py \
             --pr ${{ github.event.pull_request.number }} \
             --post-comment


### PR DESCRIPTION
## Summary

- Both workflow `run` steps were missing `PYTHONPATH=.`, causing `ModuleNotFoundError: No module named 'src'` when the agent scripts tried to import `from src.agents.*`
- Fix: prepend `PYTHONPATH=.` (repo root) to both `python scripts/run_pr_review.py` and `python scripts/run_issue_refinement.py` invocations

## Root Cause

The agent scripts use `from src.agents.pr_review.models import ...` style imports. When run directly with `python scripts/...`, Python only has the project root on `sys.path` if the runner is in the right directory — but it does **not** automatically add the repo root. Setting `PYTHONPATH=.` exposes the repo root so `src.*` is resolvable.

Note: `PYTHONPATH=src` would be wrong — that would expose `agents.*` not `src.*`.

## Test plan

- [ ] Trigger a PR event — confirm pr-review workflow completes without `ModuleNotFoundError`
- [ ] Apply `needs-review` label to an issue — confirm issue-refinement workflow completes without `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)