### PR TITLE
feat(strategy_evaluation): implement compute_edge_score Phase 1 heuristic scoring (#17)

### DIFF
--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -27,6 +27,29 @@ logger = logging.getLogger(__name__)
 # Instruments in scope for Phase 1 (PRD Section 3.1)
 INSTRUMENTS_IN_SCOPE: list[str] = ["USO", "XLE", "XOM", "CVX", "CL=F", "BZ=F"]
 
+# ---------------------------------------------------------------------------
+# Phase 1 edge score formula — static heuristic weights
+#
+# Two signals are available in Phase 1:
+#   1. volatility_gap  — IV premium over realized vol for the instrument
+#   2. sector_dispersion — price spread across XOM, CVX, USO, XLE
+#
+# Normalization:
+#   vol_gap_norm  = clip(gap / _VOL_GAP_FULL_WEIGHT, 0.0, 1.0)
+#                   A 20% IV premium (gap = 0.20) maps to 1.0; larger gaps cap at 1.0.
+#   disp_norm     = sector_dispersion (already in [0.0, 1.0] from compute_sector_dispersion)
+#
+# Weighted sum:
+#   edge_score = vol_gap_norm x _VOL_GAP_WEIGHT + disp_norm x _DISPERSION_WEIGHT
+#
+# If a signal is None (not computed), it contributes 0.0 — not an error.
+#
+# Phase 1 heuristic — weights to be tuned in Phase 3 via ML.
+# ---------------------------------------------------------------------------
+_VOL_GAP_FULL_WEIGHT: float = 0.20  # gap value that maps to full (1.0) contribution
+_VOL_GAP_WEIGHT: float = 0.70  # volatility gap share of total score
+_DISPERSION_WEIGHT: float = 0.30  # sector dispersion share of total score
+
 
 def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
     """
@@ -41,15 +64,24 @@ def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
 
     Returns:
         Float in [0.0, 1.0]. Higher = stronger signal confluence.
-
-    Raises:
-        NotImplementedError: Until implemented.
+        Returns 0.0 if the instrument has no volatility_gap record in the FeatureSet.
     """
-    raise NotImplementedError(
-        "compute_edge_score not yet implemented. "
-        "TODO: Heuristic scoring combining volatility_gap, supply_shock_probability, "
-        "narrative_velocity. Edge score = weighted sum of normalized signal values."
+    # --- Volatility gap contribution ---
+    vol_gap_record = next(
+        (vg for vg in feature_set.volatility_gaps if vg.instrument == instrument),
+        None,
     )
+    if vol_gap_record is None:
+        return 0.0
+
+    vol_gap_norm = min(max(vol_gap_record.gap / _VOL_GAP_FULL_WEIGHT, 0.0), 1.0)
+    vol_gap_contribution = vol_gap_norm * _VOL_GAP_WEIGHT
+
+    # --- Sector dispersion contribution ---
+    disp_norm = feature_set.sector_dispersion if feature_set.sector_dispersion is not None else 0.0
+    disp_contribution = disp_norm * _DISPERSION_WEIGHT
+
+    return vol_gap_contribution + disp_contribution
 
 
 def evaluate_strategies(feature_set: FeatureSet) -> list[StrategyCandidate]:

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -11,9 +11,85 @@ from datetime import UTC, datetime
 
 import pytest
 
-from src.agents.feature_generation.models import FeatureSet
+from src.agents.feature_generation.models import FeatureSet, VolatilityGap
 from src.agents.strategy_evaluation.models import StrategyCandidate
-from src.agents.strategy_evaluation.strategy_evaluation_agent import evaluate_strategies
+from src.agents.strategy_evaluation.strategy_evaluation_agent import (
+    compute_edge_score,
+    evaluate_strategies,
+)
+
+
+def _make_vg(instrument: str, gap: float) -> VolatilityGap:
+    return VolatilityGap(
+        instrument=instrument,
+        realized_vol=0.20,
+        implied_vol=0.20 + gap,
+        gap=gap,
+        computed_at=datetime.now(tz=UTC),
+    )
+
+
+def _make_feature_set(
+    gaps: list[VolatilityGap],
+    sector_dispersion: float | None = None,
+) -> FeatureSet:
+    return FeatureSet(
+        snapshot_time=datetime.now(tz=UTC),
+        volatility_gaps=gaps,
+        sector_dispersion=sector_dispersion,
+    )
+
+
+class TestComputeEdgeScore:
+    """Tests for compute_edge_score()."""
+
+    def test_high_gap_high_dispersion(self) -> None:
+        """Full vol gap + full dispersion → 1.0."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=1.0)
+        score = compute_edge_score("USO", fs)
+        assert abs(score - 1.0) < 1e-9
+
+    def test_full_gap_no_dispersion(self) -> None:
+        """Full vol gap, dispersion None → 0.70."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=None)
+        score = compute_edge_score("USO", fs)
+        assert abs(score - 0.70) < 1e-9
+
+    def test_low_gap(self) -> None:
+        """Half vol gap, half dispersion → 0.35 + 0.15 = 0.50."""
+        fs = _make_feature_set([_make_vg("XLE", 0.10)], sector_dispersion=0.50)
+        score = compute_edge_score("XLE", fs)
+        assert abs(score - 0.50) < 1e-9
+
+    def test_gap_capped_at_one(self) -> None:
+        """Vol gap larger than 0.20 caps at 1.0 contribution, so score ≤ 1.0."""
+        fs = _make_feature_set([_make_vg("XOM", 0.50)], sector_dispersion=1.0)
+        score = compute_edge_score("XOM", fs)
+        assert abs(score - 1.0) < 1e-9
+
+    def test_no_instrument_returns_zero(self) -> None:
+        """Instrument not in feature_set.volatility_gaps → 0.0."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=1.0)
+        score = compute_edge_score("XOM", fs)
+        assert score == 0.0
+
+    def test_negative_gap_returns_zero(self) -> None:
+        """Negative vol gap (IV below realized) clipped to 0 → 0.0 vol contribution."""
+        fs = _make_feature_set([_make_vg("CVX", -0.05)], sector_dispersion=None)
+        score = compute_edge_score("CVX", fs)
+        assert score == 0.0
+
+    def test_zero_dispersion(self) -> None:
+        """Full gap, zero dispersion → 0.70."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.0)
+        score = compute_edge_score("USO", fs)
+        assert abs(score - 0.70) < 1e-9
+
+    def test_score_bounded(self) -> None:
+        """Edge score must always be in [0.0, 1.0]."""
+        fs = _make_feature_set([_make_vg("USO", 1.0)], sector_dispersion=1.0)
+        score = compute_edge_score("USO", fs)
+        assert 0.0 <= score <= 1.0
 
 
 class TestEvaluateStrategies:


### PR DESCRIPTION
## Summary
- Implements `compute_edge_score(instrument, feature_set) -> float` in `strategy_evaluation_agent.py`
- Phase 1 formula: `clip(gap / 0.20, 0, 1) x 0.70` + `sector_dispersion x 0.30`
- Missing signals contribute 0.0; no DB access (pure function)
- Formula and weights documented with block comment: "Phase 1 heuristic — weights to be tuned in Phase 3 via ML"
- 8 unit tests: high gap + high dispersion, full gap no dispersion, low gap, gap capped, no instrument record, negative gap, zero dispersion, bounds check

## Test plan
- [ ] All 8 `TestComputeEdgeScore` tests pass
- [ ] 3 `TestEvaluateStrategies` xfail tests remain xfail (not yet implemented)
- [ ] `local_check.sh` exits 0 (ruff, black, mypy, import scan, pytest all pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)