### PR TITLE
feature(event-detection): fetch_news_events + fetch_gdelt_events (#102, #103)

### DIFF
--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> Advisory only. The system surfaces ranked options opportunities; it does **not** place trades automatically.
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
 
 ---
 
@@ -18,48 +18,70 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil-market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
+The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline that identifies options trading opportunities driven by oil market instability. It consumes market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies with full signal explainability.
 
-The pipeline is composed of four loosely coupled agents that execute in sequence:
+### Pipeline Architecture
+
+The system is composed of four loosely coupled agents. Data flows **unidirectionally** through the pipeline:
 
 ```mermaid
 flowchart LR
-    A([Raw Feeds]) --> B[Data Ingestion Agent\nFetch & Normalize]
-    B -->|Market State Object| C[Event Detection Agent\nSupply & Geo Signals]
-    C -->|Scored Events| D[Feature Generation Agent\nDerived Signal Computation]
-    D -->|Feature Store| E[Strategy Evaluation Agent\nOpportunity Ranking]
-    E --> F([JSON Output\nRanked Candidates])
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
+        A8[Sentiment\nReddit / Stocktwits]
+    end
 
-    style A fill:#f5f5f5,stroke:#999
-    style F fill:#f5f5f5,stroke:#999
-    style B fill:#dbeafe,stroke:#3b82f6
-    style C fill:#fef9c3,stroke:#ca8a04
-    style D fill:#dcfce7,stroke:#16a34a
-    style E fill:#fce7f3,stroke:#db2777
+    subgraph Pipeline
+        B1["① Data Ingestion Agent\nFetch & Normalize"]
+        B2["② Event Detection Agent\nSupply & Geo Signals"]
+        B3["③ Feature Generation Agent\nDerived Signal Computation"]
+        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+    end
+
+    subgraph Output
+        C1[Ranked Candidates\nJSON / Dashboard]
+    end
+
+    A1 & A2 & A3 & A4 --> B1
+    A5 --> B2
+    A6 & A7 & A8 --> B3
+
+    B1 -->|Unified Market State| B2
+    B2 -->|Scored Events| B3
+    B3 -->|Derived Features| B4
+    B4 --> C1
 ```
 
-| Agent | Role | Key Output |
-|---|---|---|
-| **Data Ingestion Agent** | Fetch & normalize prices, ETF/equity data, and options chains | Unified market state object |
-| **Event Detection Agent** | Monitor news and geopolitical feeds; score supply disruptions | Confidence- and intensity-scored event list |
-| **Feature Generation Agent** | Compute volatility gaps, curve steepness, narrative velocity, etc. | Derived features store |
-| **Strategy Evaluation Agent** | Evaluate eligible structures; rank by edge score | JSON array of ranked strategy candidates |
+### Agents at a Glance
 
-Data flows **unidirectionally** through the agents. Each agent can be deployed and updated independently without disrupting the rest of the pipeline.
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion** | Fetch & Normalize | Unified market state object; historical store |
+| **Event Detection** | Supply & Geo Signals | Events with confidence and intensity scores |
+| **Feature Generation** | Derived Signal Computation | Volatility gaps, curve steepness, narrative velocity, etc. |
+| **Strategy Evaluation** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
 
 ### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
 ### In-Scope Option Structures (MVP)
 
 - Long straddles
 - Call / put spreads
 - Calendar spreads
+
+> **Advisory only.** Automated trade execution is explicitly out of scope for the MVP. All output is intended for human review.
 
 ---
 
@@ -70,43 +92,35 @@ Data flows **unidirectionally** through the agents. Each agent can be deployed a
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Operating System | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to data provider endpoints |
+| Disk | 5 GB (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-### Required Tools
+### Required Knowledge
 
-```bash
-# Verify Python version
-python --version   # must be >= 3.10
+- Comfortable running Python scripts and CLI commands
+- Familiarity with virtual environments (`venv` or `conda`)
+- Basic understanding of options terminology (implied volatility, strikes, expiration)
 
-# Verify pip
-pip --version
+### API Accounts
 
-# (Recommended) Verify that venv is available
-python -m venv --help
-```
+You must obtain API keys or free-tier access for the following services before running the pipeline. All sources are free or low-cost.
 
-### API Keys & Accounts
-
-You must obtain credentials for the following services before running the pipeline. All tiers listed are **free or low-cost**.
-
-| Service | Used By | Sign-Up URL | Notes |
+| Data Layer | Source | Sign-up URL | Cost |
 |---|---|---|---|
-| Alpha Vantage | Crude prices (WTI, Brent) | <https://www.alphavantage.co/support/#api-key> | Free tier; rate-limited |
-| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required | Public API |
-| Polygon.io | Options data (fallback) | <https://polygon.io/> | Free tier available |
-| EIA API | Supply & inventory data | <https://www.eia.gov/opendata/> | Free; weekly cadence |
-| NewsAPI | News & geopolitical events | <https://newsapi.org/register> | Free developer tier |
-| GDELT | Geopolitical events | No key required | Public dataset |
-| SEC EDGAR | Insider activity | No key required | Public API |
-| Quiver Quant | Insider conviction scores | <https://www.quiverquant.com/> | Free/limited tier |
-| Reddit API | Narrative / sentiment | <https://www.reddit.com/prefs/apps> | Free; OAuth2 app required |
-| Stocktwits | Narrative / sentiment | <https://api.stocktwits.com/> | Free public stream |
-| MarineTraffic | Shipping / tanker flows | <https://www.marinetraffic.com/> | Free tier available |
-
-> **Tip:** For the MVP (Phase 1), only **Alpha Vantage**, **yfinance**, and optionally **Polygon.io** are strictly required. Additional keys unlock Phase 2 and Phase 3 signals.
+| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free |
+| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free |
+| ETF / Equity | yfinance (Yahoo Finance) | No key required | Free |
+| Options Chains | Polygon.io | https://polygon.io | Free / Limited |
+| Supply & Inventory | EIA API | https://www.eia.gov/opendata | Free |
+| News & Geo Events | NewsAPI | https://newsapi.org | Free |
+| News & Geo Events (alt) | GDELT | https://www.gdeltproject.org | Free |
+| Insider Activity | SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free |
+| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free / Limited |
+| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
+| Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free |
+| Sentiment (alt) | Stocktwits | https://api.stocktwits.com/developers | Free |
 
 ---
 
@@ -122,13 +136,9 @@ cd energy-options-agent
 ### 2. Create and Activate a Virtual Environment
 
 ```bash
-python -m venv .venv
-
-# Linux / macOS
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+python3 -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows (PowerShell)
 ```
 
 ### 3. Install Dependencies
@@ -140,65 +150,82 @@ pip install -r requirements.txt
 
 ### 4. Configure Environment Variables
 
-Copy the provided template and populate it with your credentials:
+All runtime configuration is provided through environment variables. Copy the example file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in the values described in the table below.
+Then open `.env` in your editor and fill in the values described in the table below.
 
 #### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for Alpha Vantage crude price feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options data fallback |
-| `EIA_API_KEY` | ✅ Phase 2 | — | API key for EIA supply & inventory feed |
-| `NEWS_API_KEY` | ✅ Phase 2 | — | API key for NewsAPI geopolitical/news feed |
-| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
-| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit OAuth2 application client ID |
-| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit OAuth2 application client secret |
-| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `MARINETRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic shipping feed |
-| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Polling interval for market data feeds (minutes cadence) |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `PHASE` | No | `1` | Active pipeline phase (`1`–`3`); controls which agents and signals are enabled |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | No | — | API key for MetalpriceAPI (fallback crude feed) |
+| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA supply and inventory data |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/news events |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
+| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic shipping data |
+| `REDDIT_CLIENT_ID` | No | — | Reddit PRAW application client ID |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit PRAW application client secret |
+| `REDDIT_USER_AGENT` | No | `energy-agent/1.0` | Reddit PRAW user agent string |
+| `STOCKTWITS_API_KEY` | No | — | Stocktwits API key for sentiment feed |
+| `DATA_DIR` | No | `./data` | Root directory for raw and derived data storage |
+| `OUTPUT_DIR` | No | `./output` | Directory where ranked JSON candidates are written |
+| `HISTORY_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_SECONDS` | No | `60` | Polling cadence for minute-level market data feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_MODE` | No | `full` | Run mode: `full`, `ingest_only`, `features_only`, `evaluate_only` |
+| `MIN_EDGE_SCORE` | No | `0.30` | Minimum edge score threshold for a candidate to appear in output |
+| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
 
-Example `.env` for a Phase 1 run:
+> **Tip:** Variables marked **No** under *Required* activate optional data layers (shipping, insider, sentiment). The pipeline degrades gracefully when these keys are absent — see [Troubleshooting](#troubleshooting).
+
+#### Example `.env` File
 
 ```dotenv
-# === Phase 1 — Core Market Signals ===
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=                        # optional fallback
-EIA_API_KEY=                            # required for Phase 2+
-NEWS_API_KEY=                           # required for Phase 2+
+# Core credentials (required)
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
 
-PHASE=1
-DATA_REFRESH_INTERVAL_MINUTES=5
-HISTORY_RETENTION_DAYS=365
+# Optional enrichment layers
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+QUIVER_QUANT_API_KEY=YOUR_QUIVER_KEY_HERE
+MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
+REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
+REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
+REDDIT_USER_AGENT=energy-agent/1.0
+
+# Runtime settings
+DATA_DIR=./data
 OUTPUT_DIR=./output
+HISTORY_DAYS=365
+MARKET_DATA_INTERVAL_SECONDS=60
 LOG_LEVEL=INFO
+PIPELINE_MODE=full
+MIN_EDGE_SCORE=0.30
+MAX_CANDIDATES=20
 ```
 
-> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` excludes it by default.
+### 5. Initialise the Data Directory
 
-### 5. Initialise the Database
-
-The pipeline stores historical raw and derived data locally (sized for 6–12 months of history):
+Create the storage structure required for historical raw and derived data:
 
 ```bash
-python manage.py init-db
+python scripts/init_storage.py
 ```
 
 Expected output:
 
 ```
-[INFO] Initialising database at ./data/market_state.db ...
-[INFO] Schema applied. Historical data retention set to 365 days.
-[INFO] Done.
+[INFO] Created directory: ./data/raw
+[INFO] Created directory: ./data/derived
+[INFO] Created directory: ./output
+[INFO] Storage initialised successfully.
 ```
 
 ---
@@ -209,180 +236,159 @@ Expected output:
 
 ```mermaid
 sequenceDiagram
-    participant CLI as User / Scheduler
+    participant User
+    participant CLI as pipeline.py (CLI)
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (JSON Output)
+    participant FS as File System (output/)
 
-    CLI->>DIA: python run_pipeline.py --phase 1
-    DIA->>DIA: Fetch crude, ETF/equity prices & options chains
-    DIA->>EDA: market_state object
-    EDA->>EDA: Score news / geo events (confidence + intensity)
-    EDA->>FGA: scored_events + market_state
-    FGA->>FGA: Compute volatility gaps, curve steepness, etc.
-    FGA->>SEA: derived_features store
-    SEA->>SEA: Evaluate structures; rank by edge_score
-    SEA->>FS: Write ranked_candidates_<timestamp>.json
-    FS-->>CLI: Pipeline complete ✓
+    User->>CLI: python pipeline.py --mode full
+    CLI->>DIA: run()
+    DIA-->>CLI: market_state (unified object)
+    CLI->>EDA: run(market_state)
+    EDA-->>CLI: event_signals (scored events)
+    CLI->>FGA: run(market_state, event_signals)
+    FGA-->>CLI: derived_features (vol gaps, curve, etc.)
+    CLI->>SEA: run(market_state, event_signals, derived_features)
+    SEA-->>CLI: ranked_candidates[]
+    CLI->>FS: write candidates_<timestamp>.json
+    CLI-->>User: Summary printed to stdout
 ```
 
-### Single Run
+### Full Pipeline Run
 
-Execute one full pass of the pipeline:
+Run all four agents in sequence:
 
 ```bash
-python run_pipeline.py
+python pipeline.py --mode full
 ```
 
-To override the active phase without editing `.env`:
+### Partial / Single-Agent Runs
+
+Use `--mode` to run only a subset of the pipeline. This is useful for debugging or when feeding pre-computed intermediate data.
 
 ```bash
-python run_pipeline.py --phase 2
+# Re-ingest raw market data only
+python pipeline.py --mode ingest_only
+
+# Regenerate features from cached market state
+python pipeline.py --mode features_only
+
+# Re-evaluate strategies using the latest cached features
+python pipeline.py --mode evaluate_only
 ```
 
-To specify a custom output directory for this run:
+### Scheduled Continuous Execution
+
+For production use, drive the pipeline on a regular cadence using `cron` (Linux/macOS) or Task Scheduler (Windows):
 
 ```bash
-python run_pipeline.py --output-dir /tmp/pipeline-out
+# Example: run the full pipeline every 5 minutes during market hours
+crontab -e
 ```
 
-### Continuous (Polling) Mode
+```cron
+*/5 9-17 * * 1-5 /path/to/.venv/bin/python /path/to/pipeline.py --mode full >> /var/log/energy-agent.log 2>&1
+```
 
-Run the pipeline on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence:
+> **Note:** Market data refreshes on a minutes-level cadence. Slower feeds (EIA inventory, EDGAR insider filings) update daily or weekly; the pipeline applies the appropriate polling frequency per source automatically.
+
+### Verbose / Debug Mode
 
 ```bash
-python run_pipeline.py --continuous
+python pipeline.py --mode full --log-level DEBUG
 ```
 
-Press `Ctrl+C` to stop. The pipeline will finish the current cycle before exiting cleanly.
+Or set `LOG_LEVEL=DEBUG` in your `.env` file for persistent debug output.
 
-### Running Individual Agents
+### Running Inside Docker
 
-Each agent can be executed independently for development or debugging:
+A `Dockerfile` and `docker-compose.yml` are provided for containerised deployment on a single VM or local machine:
 
 ```bash
-# Data Ingestion only
-python -m agents.data_ingestion
+# Build the image
+docker build -t energy-options-agent:latest .
 
-# Event Detection only (requires a saved market state)
-python -m agents.event_detection --state ./output/market_state_latest.json
-
-# Feature Generation only
-python -m agents.feature_generation --state ./output/market_state_latest.json
-
-# Strategy Evaluation only
-python -m agents.strategy_evaluation --features ./output/features_latest.json
+# Run with your .env file mounted
+docker run --env-file .env \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  energy-options-agent:latest
 ```
-
-### Phase-by-Phase Feature Availability
-
-| Phase | Name | Signals Enabled | Additional Keys Needed |
-|---|---|---|---|
-| 1 | Core Market Signals & Options | Crude prices, ETF/equity prices, IV surface, long straddles, call/put spreads | `ALPHA_VANTAGE_API_KEY` |
-| 2 | Supply & Event Augmentation | + EIA inventory, refinery utilisation, GDELT/NewsAPI event detection, supply disruption indices | `EIA_API_KEY`, `NEWS_API_KEY` |
-| 3 | Alternative / Contextual Signals | + Insider trades, narrative velocity (Reddit/Stocktwits), shipping data, cross-sector correlation | `REDDIT_CLIENT_ID/SECRET`, optionally `QUIVER_QUANT_API_KEY`, `MARINETRAFFIC_API_KEY` |
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output Location
 
-After each pipeline run, a timestamped JSON file is written to `OUTPUT_DIR`:
+After each run, candidates are written to the directory specified by `OUTPUT_DIR` (default: `./output`):
 
 ```
-./output/ranked_candidates_2026-03-15T14:32:00Z.json
+output/
+└── candidates_2026-03-15T14:32:00Z.json
 ```
 
-A symlink `ranked_candidates_latest.json` always points to the most recent file.
+A `candidates_latest.json` symlink is also updated to always point to the most recent file.
 
 ### Output Schema
 
-Each element in the output array represents one ranked strategy candidate:
+Each ranked candidate is a JSON object with the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output
+### Example Candidate
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
+{
+  "instrument": "USO",
+  "structure": "long_straddle",
+  "expiration": 30,
+  "edge_score": 0.47,
+  "signals": {
+    "tanker_disruption_index": "high",
+    "volatility_gap": "positive",
+    "narrative_velocity": "rising"
   },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive",
-      "supply_shock_probability": "elevated",
-      "sector_dispersion": "high"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
+  "generated_at": "2026-03-15T14:32:00Z"
+}
 ```
 
 ### Reading the Edge Score
 
-| Edge Score Range | Interpretation | Suggested Action |
+The `edge_score` is the primary ranking signal. It is a composite of all contributing derived features, normalised to `[0.0, 1.0]`.
+
+| Edge Score Range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
+| `0.50 – 0.69` | Moderate signal confluence — worth monitoring |
+| `0.30 – 0.49` | Weak confluence — lower conviction, proceed with caution |
+| `< 0.30` | Below threshold — filtered out by default (`MIN_EDGE_SCORE`) |
+
+> Candidates are ordered by `edge_score` descending. Review the `signals` object for every candidate to understand **why** the score was assigned before acting on any recommendation.
+
+### Contributing Signals Reference
+
+The `signals` object may contain any of the following keys, depending on which data layers are active:
+
+| Signal Key | Source Layer | Possible Values |
 |---|---|---|
-| 0.70 – 1.00 | Strong signal confluence | High-priority candidate; review signals carefully |
-| 0.40 – 0.69 | Moderate confluence | Candidate worth monitoring; validate with additional research |
-| 0.10 – 0.39 | Weak confluence | Low-conviction signal; treat as background noise unless a specific thesis supports it |
-| 0.00 – 0.09 | Negligible | Discard |
+| `volatility_gap` | Feature Generation | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | Feature Generation | `contango`, `backwardation`, `flat` |
+| `sector_dispersion` | Feature Generation | `high`, `moderate`, `low` |
+| `insider_conviction_score` | Alternative Signals | `high`, `moderate`, `low` |
+| `narrative_velocity` | Alternative Signals | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | Event Detection | `high`, `moderate`, `low` |
+| `tanker_disruption_index` | Event Detection | `high`, `moderate`, `low` |
+| `eia_inventory_surprise` | Event Detection | `bullish`, `bearish`, `neutral` |
 
-> **Important:** The edge score is a heuristic composite, not a probability of profit. Always perform independent due diligence before placing any trade. The system is **advisory only**.
-
-### Signal Reference
-
-| Signal Key | Description | Source Agent |
-|---|---|---|
-| `volatility_gap` | Realised vs. implied volatility divergence | Feature Generation |
-| `futures_curve_steepness` | Contango / backwardation gradient | Feature Generation |
-| `sector_dispersion` | Spread between energy sub-sector moves | Feature Generation |
-| `insider_conviction_score` | Aggregated insider trading signal | Feature Generation |
-| `narrative_velocity` | Acceleration of energy-related headlines | Feature Generation |
-| `supply_shock_probability` | Modelled probability of a supply disruption | Feature Generation |
-| `tanker_disruption_index` | Shipping-flow anomaly score | Event Detection |
-| `refinery_outage_score` | Refinery utilisation deviation | Event Detection |
-| `geopolitical_intensity` | Geo-event confidence × intensity product | Event Detection |
-
-### Visualisation
-
-The JSON output is compatible with **thinkorswim** or any JSON-capable dashboard. To load the latest candidates directly:
-
-```bash
-cat ./output/ranked_candidates_latest.json | python -m json.tool
-```
-
----
-
-## Troubleshooting
-
-### Common Issues
-
-| Symptom | Likely Cause | Resolution |
-|---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` not loaded or variable missing | Confirm `.env` exists in project root and contains the key; verify `python-dotenv` is installed |
-| `RateLimitError` from Alpha Vantage | Free-tier rate limit exceeded | Increase `DATA_REFRESH_INTERVAL_MINUTES`; consider caching raw responses |
-| Empty `ranked_candidates_*.json` | No candidates exceeded the minimum threshold | Check `LOG_LEVEL=DEBUG` output; verify market data was fetched
+###

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -182,6 +182,11 @@ def fetch_gdelt_events() -> list[dict[str, object]]:
             dt = datetime.strptime(seendate, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
             normalized_seendate: str = dt.isoformat()
         except (ValueError, TypeError):
+            logger.warning(
+                "fetch_gdelt_events: unparseable seendate %r for url=%r; using raw value",
+                seendate,
+                article.get("url", ""),
+            )
             normalized_seendate = seendate
         articles.append(
             {

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -1,0 +1,179 @@
+"""
+Unit tests for fetch_news_events() and fetch_gdelt_events().
+
+Both functions make HTTP requests to external APIs; all network calls
+are mocked via unittest.mock.patch so no API keys or connectivity are required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import (
+    fetch_gdelt_events,
+    fetch_news_events,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NEWSAPI_ARTICLE = {
+    "title": "OPEC cuts output by 1 million barrels per day",
+    "description": "OPEC+ members agreed to reduce production.",
+    "source": {"name": "Reuters"},
+    "publishedAt": "2026-03-15T18:00:00Z",
+    "url": "https://reuters.com/opec-cuts",
+}
+
+_GDELT_RAW_ARTICLE = {
+    "title": "Oil supply disruption in Middle East",
+    "url": "https://example.com/oil-disruption",
+    "seendate": "20260315T180000Z",
+    "domain": "example.com",
+}
+
+
+def _mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import requests
+
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# fetch_news_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNewsEvents:
+    def test_missing_api_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No NEWSAPI_KEY → degraded mode, returns [] without making HTTP call."""
+        monkeypatch.delenv("NEWSAPI_KEY", raising=False)
+        with patch("requests.get") as mock_get:
+            result = fetch_news_events()
+        assert result == []
+        mock_get.assert_not_called()
+
+    def test_happy_path_returns_articles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Valid API response returns the articles list."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"articles": [_NEWSAPI_ARTICLE, _NEWSAPI_ARTICLE]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_news_events()
+        assert len(result) == 2
+        assert result[0]["title"] == _NEWSAPI_ARTICLE["title"]
+
+    def test_empty_articles_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """API response with no articles key returns []."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"status": "ok"})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_news_events()
+        assert result == []
+
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HTTP 4xx/5xx raises after retries are exhausted."""
+        import requests as req
+
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({}, status_code=401)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(req.HTTPError):
+                fetch_news_events()
+
+    def test_request_includes_api_key_param(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The API key is passed as a query parameter named 'apiKey'."""
+        monkeypatch.setenv("NEWSAPI_KEY", "my-secret-key")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_news_events()
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["apiKey"] == "my-secret-key"
+
+    def test_request_covers_last_24_hours(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The 'from' parameter is set (24-hour window)."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_news_events()
+        _, kwargs = mock_get.call_args
+        assert "from" in kwargs["params"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_gdelt_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGdeltEvents:
+    def test_happy_path_returns_normalized_articles(self) -> None:
+        """GDELT articles are returned with normalized publishedAt key."""
+        mock_resp = _mock_response({"articles": [_GDELT_RAW_ARTICLE]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert len(result) == 1
+        article = result[0]
+        assert article["title"] == "Oil supply disruption in Middle East"
+        # seendate normalized to ISO 8601
+        assert "2026-03-15" in article["seendate"]
+        assert "publishedAt" in article  # unified key present
+
+    def test_empty_articles_returns_empty_list(self) -> None:
+        """GDELT response with no articles returns []."""
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert result == []
+
+    def test_missing_articles_key_returns_empty_list(self) -> None:
+        """GDELT response missing 'articles' key returns []."""
+        mock_resp = _mock_response({})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert result == []
+
+    def test_http_error_propagates(self) -> None:
+        """HTTP errors propagate after retries."""
+        import requests as req
+
+        mock_resp = _mock_response({}, status_code=503)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(req.HTTPError):
+                fetch_gdelt_events()
+
+    def test_uses_gdelt_base_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GDELT_BASE_URL env var is used for the request URL."""
+        monkeypatch.setenv("GDELT_BASE_URL", "http://custom-gdelt.example.com/api/v2")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_gdelt_events()
+        url = mock_get.call_args.args[0]
+        assert url.startswith("http://custom-gdelt.example.com/api/v2")
+
+    def test_falls_back_to_default_gdelt_url_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to api.gdeltproject.org when GDELT_BASE_URL is not set."""
+        monkeypatch.delenv("GDELT_BASE_URL", raising=False)
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_gdelt_events()
+        url = mock_get.call_args.args[0]
+        assert "gdeltproject.org" in url
+
+    def test_malformed_seendate_preserved_as_is(self) -> None:
+        """Articles with unparseable seendate are included with the raw value."""
+        bad_article = {**_GDELT_RAW_ARTICLE, "seendate": "not-a-date"}
+        mock_resp = _mock_response({"articles": [bad_article]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert len(result) == 1
+        assert result[0]["seendate"] == "not-a-date"

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -8,6 +8,7 @@ are mocked via unittest.mock.patch so no API keys or connectivity are required.
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -167,7 +168,7 @@ class TestFetchGdeltEvents:
         with patch("requests.get", return_value=mock_resp) as mock_get:
             fetch_gdelt_events()
         url = mock_get.call_args.args[0]
-        assert url.startswith("http://api.gdeltproject.org")
+        assert urlparse(url).netloc == "api.gdeltproject.org"
 
     def test_malformed_seendate_preserved_as_is(self) -> None:
         """Articles with unparseable seendate are included with the raw value."""

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -167,7 +167,7 @@ class TestFetchGdeltEvents:
         with patch("requests.get", return_value=mock_resp) as mock_get:
             fetch_gdelt_events()
         url = mock_get.call_args.args[0]
-        assert "gdeltproject.org" in url
+        assert url.startswith("http://api.gdeltproject.org")
 
     def test_malformed_seendate_preserved_as_is(self) -> None:
         """Articles with unparseable seendate are included with the raw value."""


### PR DESCRIPTION
## Summary
- `fetch_news_events()`: NewsAPI energy headlines; degraded mode if `NEWSAPI_KEY` absent; `@with_retry()`
- `fetch_gdelt_events()`: GDELT Doc API v2 (free); normalizes `seendate` to ISO 8601; `GDELT_BASE_URL` from env with fallback
- Both return `list[dict[str, object]]` for downstream `classify_event()` processing
- 13 unit tests; all passing; mypy strict clean

## Test plan
- [x] `pytest tests/agents/event_detection/` — 13 passed, 2 xfailed
- [x] `ruff check` + `black --check` + `mypy` — all clean

Closes #102, #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)