### PR TITLE
feat(event-detection): implement fetch_eia_data — EIA weekly inventory feed (#101)

### DIFF
--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
+> Advisory system only. No automated trade execution occurs at any point in the pipeline.
 
 ---
 
@@ -18,333 +18,347 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
-### What the pipeline does
+### Pipeline Architecture
+
+The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
     subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping & Logistics\nMarineTraffic / VesselFinder]
-        A8[Narrative & Sentiment\nReddit / Stocktwits]
+        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
+        A2([ETF & Equity Prices\nyfinance])
+        A3([Options Chains\nYahoo / Polygon.io])
+        A4([Supply / Inventory\nEIA API])
+        A5([News & Geo Events\nGDELT / NewsAPI])
+        A6([Insider Activity\nSEC EDGAR / Quiver])
+        A7([Shipping\nMarineTraffic])
+        A8([Sentiment\nReddit / Stocktwits])
     end
 
-    subgraph Pipeline
+    subgraph Pipeline["Four-Agent Pipeline"]
         direction TB
-        B1["① Data Ingestion Agent\nFetch & Normalize"]
-        B2["② Event Detection Agent\nSupply & Geo Signals"]
-        B3["③ Feature Generation Agent\nDerived Signal Computation"]
-        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+        B["🟦 Data Ingestion Agent\nFetch & Normalize\n→ Market State Object"]
+        C["🟨 Event Detection Agent\nSupply & Geo Signals\n→ Scored Events"]
+        D["🟩 Feature Generation Agent\nDerived Signal Computation\n→ Features Store"]
+        E["🟥 Strategy Evaluation Agent\nOpportunity Ranking\n→ Ranked Candidates"]
+        B --> C --> D --> E
     end
 
     subgraph Output
-        C1[Ranked Candidates\nJSON / Dashboard]
+        F([JSON Candidates\nedge_score · signals\nexpiration · structure])
     end
 
-    Inputs --> B1
-    B1 -->|Unified Market State| B2
-    B2 -->|Scored Events| B3
-    B3 -->|Derived Features| B4
-    B4 --> C1
+    Inputs --> B
+    E --> Output
 ```
 
-### In-scope instruments
+### In-Scope Instruments
 
 | Category | Instruments |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-scope option structures (MVP)
+### In-Scope Option Structures (MVP)
 
-| Structure | Enum value |
+| Structure | Enum Value |
 |---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
 
-> **Advisory only.** Automated trade execution is explicitly out of scope. All output is for informational and analytical purposes.
+> **Out of scope (MVP):** exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10+ |
+| OS | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| Deployment target | Local machine, single VM, or container |
+| Disk | 5 GB (6–12 months of historical data) |
+| Network | Outbound HTTPS to external APIs |
 
-### Required Python packages
+### Python Dependencies
 
-Install dependencies from the project root:
+Install all dependencies from the project root:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Key dependencies include:
+Key packages the pipeline relies on include:
 
-```text
-yfinance
-requests
-pandas
-numpy
-python-dotenv
-schedule
-```
+| Package | Purpose |
+|---|---|
+| `yfinance` | ETF, equity, and options chain data |
+| `requests` | HTTP calls to EIA, Alpha Vantage, GDELT, NewsAPI |
+| `pandas` / `numpy` | Data normalization and feature computation |
+| `pydantic` | Market state object and output schema validation |
+| `schedule` or `apscheduler` | Cadence-based refresh scheduling |
 
-### External API accounts
+### API Accounts
 
-Obtain free-tier credentials for each data source before configuring the pipeline.
+You must obtain API keys (all free or freemium) before running the pipeline:
 
-| Service | URL | Cost | Used for |
-|---|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co | Free | WTI / Brent spot and futures |
-| EIA API | https://www.eia.gov/opendata | Free | Inventory and refinery utilization |
-| NewsAPI | https://newsapi.org | Free tier | News and geopolitical events |
-| GDELT | https://www.gdeltproject.org | Free | Geopolitical event stream |
-| Polygon.io | https://polygon.io | Free/Limited | Options chains |
-| SEC EDGAR | https://www.sec.gov/developer | Free | Insider filing data |
-| Quiver Quant | https://www.quiverquant.com | Free/Limited | Parsed insider trades |
-| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flow data |
-
-> **Tip:** `yfinance` (Yahoo Finance) requires no API key and is used as the primary fallback for equity, ETF, and options chain data.
+| Service | Registration URL | Tier Needed |
+|---|---|---|
+| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free |
+| MetalpriceAPI | https://metalpriceapi.com | Free |
+| Polygon.io | https://polygon.io | Free / Limited |
+| EIA API | https://www.eia.gov/opendata/ | Free |
+| NewsAPI | https://newsapi.org | Free |
+| GDELT | No key required (public dataset) | — |
+| SEC EDGAR | No key required (public dataset) | — |
+| Quiver Quant | https://www.quiverquant.com | Free / Limited |
+| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Free tier |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a virtual environment
+### 2. Create a Virtual Environment
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows
+# .venv\Scripts\activate.bat     # Windows CMD
+# .venv\Scripts\Activate.ps1     # Windows PowerShell
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Create the environment file
+### 4. Configure Environment Variables
 
-Copy the provided template and populate it with your credentials:
+Copy the example environment file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and fill in each value:
+Open `.env` in your editor and set each value. The full set of supported environment variables is listed below.
 
-```dotenv
-# .env — Energy Options Opportunity Agent
-
-# ── Data Ingestion ────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-EIA_API_KEY=your_eia_key
-POLYGON_API_KEY=your_polygon_key
-
-# ── Event Detection ───────────────────────────────────────────
-NEWS_API_KEY=your_newsapi_key
-
-# ── Alternative / Contextual Signals ─────────────────────────
-QUIVER_QUANT_API_KEY=your_quiver_quant_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-
-# ── Output ────────────────────────────────────────────────────
-OUTPUT_DIR=./output
-OUTPUT_FORMAT=json
-
-# ── Scheduling ────────────────────────────────────────────────
-MARKET_DATA_INTERVAL_MINUTES=5
-SLOW_FEED_INTERVAL_HOURS=24
-
-# ── Data Retention ───────────────────────────────────────────
-RETENTION_DAYS=365
-```
-
-### Environment variable reference
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for WTI and Brent crude prices |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery data |
-| `POLYGON_API_KEY` | No | — | API key for options chain data (falls back to yfinance) |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical and energy news |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for parsed SEC insider trade data |
-| `MARINE_TRAFFIC_API_KEY` | No | — | API key for tanker flow and shipping data |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Yes | — | API key for MetalpriceAPI (Brent/WTI spot) |
+| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery utilization |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy news |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
+| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flow data |
 | `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `OUTPUT_FORMAT` | No | `json` | Output format; currently `json` is supported |
-| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for market data (prices, options) |
-| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Polling cadence for slow feeds (EIA, EDGAR) |
-| `RETENTION_DAYS` | No | `365` | Number of days of historical data to retain on disk |
+| `DATA_STORE_DIR` | No | `./data` | Root directory for raw and derived historical data |
+| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Refresh cadence in minutes for market price feeds |
+| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Refresh cadence in hours for EIA and EDGAR feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_PHASE` | No | `1` | Active MVP phase (`1`–`4`); gates which agents are enabled |
+| `MIN_EDGE_SCORE` | No | `0.20` | Minimum edge score threshold for emitting a candidate |
+| `MAX_CANDIDATES` | No | `10` | Maximum number of ranked candidates per pipeline run |
 
-> **Optional keys:** If `POLYGON_API_KEY`, `QUIVER_QUANT_API_KEY`, or `MARINE_TRAFFIC_API_KEY` are absent, the pipeline will fall back to available free sources or skip those signals gracefully. The pipeline will not fail due to a missing optional key.
+> **Tip:** Variables marked **No** under *Required* are optional. The pipeline degrades gracefully when optional data sources are unavailable — it will log a warning and continue rather than halting.
 
-### 5. Verify the setup
+#### Example `.env`
 
-Run the built-in configuration check before starting the pipeline:
+```dotenv
+# --- Required API Keys ---
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+METALPRICE_API_KEY=YOUR_MP_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWS_API_KEY_HERE
+
+# --- Optional API Keys ---
+POLYGON_API_KEY=
+QUIVER_QUANT_API_KEY=
+MARINETRAFFIC_API_KEY=
+
+# --- Pipeline Behaviour ---
+PIPELINE_PHASE=1
+MIN_EDGE_SCORE=0.20
+MAX_CANDIDATES=10
+MARKET_DATA_INTERVAL_MIN=5
+SLOW_FEED_INTERVAL_HOURS=24
+
+# --- Storage ---
+OUTPUT_DIR=./output
+DATA_STORE_DIR=./data
+RETENTION_DAYS=365
+
+# --- Observability ---
+LOG_LEVEL=INFO
+```
+
+### 5. Initialise the Data Store
+
+Run the one-time initialisation script to create the required directory structure and seed the historical data store:
 
 ```bash
-python -m agent check-config
+python -m agent.cli init
 ```
 
 Expected output:
 
 ```
-[OK] Alpha Vantage         reachable
-[OK] EIA API               reachable
-[OK] NewsAPI               reachable
-[OK] yfinance              available (no key required)
-[WARN] Polygon.io          key not set — falling back to yfinance for options
-[WARN] MarineTraffic       key not set — shipping signals disabled
-[OK] Output directory      ./output exists
-Configuration check complete. 2 warning(s), 0 error(s).
+[INFO] Creating data store at ./data ...
+[INFO] Creating output directory at ./output ...
+[INFO] Initialisation complete. Run `python -m agent.cli run` to start the pipeline.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution sequence
+### Pipeline Data Flow (Sequence)
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant CLI as CLI / Scheduler
-    participant DI as ① Data Ingestion Agent
-    participant ED as ② Event Detection Agent
-    participant FG as ③ Feature Generation Agent
-    participant SE as ④ Strategy Evaluation Agent
-    participant FS as Filesystem / Output
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant FS as File System (JSON Output)
 
-    CLI->>DI: trigger run
-    DI->>DI: fetch crude prices, ETF/equity, options chains
-    DI->>DI: normalize → unified market state object
-    DI->>ED: market state
-    ED->>ED: scan news, GDELT, shipping feeds
-    ED->>ED: score events (confidence + intensity)
-    ED->>FG: market state + scored events
-    FG->>FG: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock probability
-    FG->>SE: derived features store
-    SE->>SE: evaluate eligible option structures\nagainst computed signals
-    SE->>SE: generate edge scores, attach signal references
-    SE->>FS: write ranked candidates (JSON)
-    FS-->>CLI: run complete — candidates available in ./output
+    CLI->>DIA: trigger run()
+    DIA->>DIA: fetch crude, ETF, equity prices
+    DIA->>DIA: fetch options chains
+    DIA->>DIA: normalize → MarketStateObject
+    DIA-->>EDA: MarketStateObject
+
+    EDA->>EDA: scan GDELT / NewsAPI
+    EDA->>EDA: score supply disruptions, outages, chokepoints
+    EDA-->>FGA: MarketStateObject + ScoredEvents
+
+    FGA->>FGA: compute volatility gaps (realized vs. implied)
+    FGA->>FGA: compute curve steepness, dispersion, insider scores
+    FGA->>FGA: compute narrative velocity, supply shock probability
+    FGA-->>SEA: FeaturesStore
+
+    SEA->>SEA: evaluate eligible option structures
+    SEA->>SEA: compute edge scores
+    SEA->>SEA: rank candidates, attach signal references
+    SEA-->>FS: write ranked_candidates_<timestamp>.json
 ```
 
-### Run once (manual)
+### Single Run (One-Shot)
 
-Execute a single end-to-end pipeline run:
+Execute the full pipeline once and write output to `OUTPUT_DIR`:
 
 ```bash
-python -m agent run
+python -m agent.cli run
 ```
 
-This triggers all four agents in sequence and writes the output to `OUTPUT_DIR`.
-
-### Run on a schedule (continuous mode)
-
-Start the pipeline in continuous mode. Market data is polled at the cadence set by `MARKET_DATA_INTERVAL_MINUTES`; slow feeds (EIA, EDGAR) refresh at `SLOW_FEED_INTERVAL_HOURS`:
+To override the active phase without editing `.env`:
 
 ```bash
-python -m agent run --continuous
+python -m agent.cli run --phase 2
 ```
 
-### Run a specific agent only
-
-Each agent can be executed independently, which is useful during development or when debugging a single stage:
+To lower the minimum edge score for a broader candidate set:
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent run --agent ingestion
-
-# Run only the Event Detection Agent
-python -m agent run --agent events
-
-# Run only the Feature Generation Agent
-python -m agent run --agent features
-
-# Run only the Strategy Evaluation Agent
-python -m agent run --agent strategy
+python -m agent.cli run --min-edge-score 0.10
 ```
 
-> **Dependency note:** Running `features` or `strategy` in isolation requires a valid market state object and event scores to already exist in the derived features store from a prior run of the upstream agents.
+### Continuous Mode (Scheduled)
 
-### Run with Docker
+Run the pipeline on a recurring cadence driven by `MARKET_DATA_INTERVAL_MIN`:
 
-A `Dockerfile` and `docker-compose.yml` are provided for containerized deployment on a single VM:
+```bash
+python -m agent.cli run --continuous
+```
+
+The scheduler will:
+- Refresh market price feeds every `MARKET_DATA_INTERVAL_MIN` minutes.
+- Refresh slow feeds (EIA, EDGAR) every `SLOW_FEED_INTERVAL_HOURS` hours.
+- Append a new output file per cycle to `OUTPUT_DIR`.
+
+Stop the process with `Ctrl+C`.
+
+### Running Individual Agents
+
+Each agent can be run in isolation for development or debugging:
+
+```bash
+# Data Ingestion only
+python -m agent.cli run --agent ingestion
+
+# Event Detection only (requires a prior ingestion snapshot)
+python -m agent.cli run --agent event-detection
+
+# Feature Generation only
+python -m agent.cli run --agent feature-generation
+
+# Strategy Evaluation only
+python -m agent.cli run --agent strategy-evaluation
+```
+
+### Running in Docker
+
+A minimal container target is provided for cloud or server deployment:
 
 ```bash
 # Build the image
-docker build -t energy-options-agent .
+docker build -t energy-options-agent:latest .
 
-# Run once
-docker run --env-file .env -v $(pwd)/output:/app/output energy-options-agent
-
-# Run continuously via docker-compose
-docker-compose up -d
+# Run with your local .env file
+docker run --env-file .env \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  energy-options-agent:latest
 ```
-
-### CLI reference
-
-| Command | Description |
-|---|---|
-| `python -m agent check-config` | Validate configuration and API connectivity |
-| `python -m agent run` | Execute one full pipeline run |
-| `python -m agent run --continuous` | Run pipeline on a repeating schedule |
-| `python -m agent run --agent <name>` | Run a single agent (`ingestion`, `events`, `features`, `strategy`) |
-| `python -m agent status` | Show last run timestamp and candidate count |
-| `python -m agent clean --older-than <days>` | Purge output files older than `<days>` days |
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output File Location
 
-After each run, one or more JSON files are written to `OUTPUT_DIR` (default: `./output`):
+Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
-./output/
-└── candidates_2026-03-15T14:32:00Z.json
+output/
+└── ranked_candidates_2026-03-15T14:05:00Z.json
 ```
 
-### Output schema
+### Output Schema
 
-Each file contains an array of strategy candidate objects:
+Each file contains an array of candidate objects. The fields are:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
 | `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
 | `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current state |
+| `signals` | `object` | Map of contributing signals and their qualitative levels |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output
+### Example Output
 
 ```json
 [
@@ -358,65 +372,59 @@ Each file contains an array of strategy candidate objects:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:05:00Z"
   },
   {
-    "instrument": "XOM",
+    "instrument": "XLE",
     "structure": "call_spread",
     "expiration": 45,
     "edge_score": 0.31,
     "signals": {
-      "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "insider_conviction_score": "moderate"
+      "volatility_gap": "positive",
+      "sector_dispersion": "widening"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:05:00Z"
   }
 ]
 ```
 
-### Reading the edge score
+### Reading the Edge Score
 
-The `edge_score` is a composite float between `0.0` and `1.0` reflecting the degree of signal confluence across all active layers.
-
-| Edge score range | Interpretation |
+| Edge Score Range | Interpretation |
 |---|---|
-| `0.70 – 1.00` | Strong confluence — multiple independent signals agree |
-| `0.40 – 0.69` | Moderate confluence — worth monitoring; verify signals manually |
-| `0.00 – 0.39` | Weak confluence — low signal agreement; treat with caution |
+| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
+| `0.40 – 0.69` | Moderate confluence — worthy of further review |
+| `0.20 – 0.39` | Weak signal — monitor rather than act |
+| `< 0.20` | Below threshold — suppressed by default (`MIN_EDGE_SCORE`) |
 
-> **Important:** The edge score is a heuristic ranking tool, not a probability of profit. It indicates the relative strength of signal alignment, not a forecast of price direction or options premium outcome.
+> **Important:** The edge score is an advisory signal, not a trade recommendation. The system does not execute trades and does not account for individual risk tolerance, position sizing, or transaction costs.
 
-### Reading the signals map
+### Signal Reference
 
-The `signals` object provides the explainability layer for each candidate. Each key is a derived feature; each value describes its current state.
+The `signals` map reports the state of each contributing derived feature at the time of evaluation:
 
-| Signal key | Description |
+| Signal Key | What It Measures |
 |---|---|
-| `volatility_gap` | Relationship between realized and implied volatility (`positive` = IV underprices realized vol) |
-| `futures_curve_steepness` | Degree of contango or backwardation in the crude futures curve |
-| `sector_dispersion` | Cross-instrument divergence within energy equities and ETFs |
-| `insider_conviction_score` | Aggregated signal from recent SEC EDGAR insider filings |
-| `narrative_velocity` | Rate of headline acceleration from news and social feeds |
-| `supply_shock_probability` | Derived probability of a near-term supply disruption event |
-| `tanker_disruption_index` | Signal derived from shipping and logistics flow anomalies |
+| `volatility_gap` | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Contango or backwardation steepness |
+| `sector_dispersion` | Cross-instrument spread within the energy sector |
+| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
+| `narrative_velocity` | Headline acceleration from GDELT / NewsAPI / Reddit |
+| `supply_shock_probability` | Probability of near-term supply disruption |
+| `tanker_disruption_index` | Shipping flow anomaly from MarineTraffic |
 
-### Consuming the output in thinkorswim
+### Using the Output with thinkorswim
 
-The JSON output is compatible with any thinkorswim thinkScript import tool or third-party JSON-to-watchlist utility. Export the `instrument` and `structure` fields to build a prioritized watchlist sorted descending by `edge_score`.
+The JSON output is compatible with any thinkorswim thinkScript study or third-party dashboard that can consume a JSON file. Load `ranked_candidates_<timestamp>.json` from your `OUTPUT_DIR` into your visualization layer. Candidates are pre-sorted by `edge_score` descending.
 
 ---
 
 ## Troubleshooting
 
-### General diagnostic steps
+### Common Issues
 
-1. Run `python -m agent check-config` to confirm all reachable APIs and environment variables.
-2. Check the log file at `./logs/agent.log` for timestamped error messages.
-3. Confirm your virtual environment is activated and dependencies are installed.
-
-### Common issues
-
-| Symptom | Likely cause | Resolution |
+| Symptom | Likely Cause | Resolution |
 |---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` file not loaded or key missing | Confirm `.env` exists in the project root and the variable is set; ensure `python-
+| `KeyError: ALPHA_VANTAGE_API_KEY` | Environment variable not set | Verify `.env` is populated and loaded; re-run `source .venv/bin/activate` |
+| `WARNING: options chain unavailable for XOM` | Polygon.io

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> Advisory only. The system surfaces ranked options candidates; it does **not** execute trades.
+> Advisory only. The system surfaces ranked options opportunities; it does **not** place trades automatically.
 
 ---
 
@@ -18,45 +18,36 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and surfaces ranked options trading candidates. It is designed for a single developer running on local hardware or a low-cost cloud VM.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil-market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
 
 The pipeline is composed of four loosely coupled agents that execute in sequence:
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["1 · Data Ingestion Agent"]
-        A1[Crude Prices\nWTI · Brent]
-        A2[ETF / Equity\nUSO · XLE · XOM · CVX]
-        A3[Options Chains\nIV · Strike · Volume]
-    end
+    A([Raw Feeds]) --> B[Data Ingestion Agent\nFetch & Normalize]
+    B -->|Market State Object| C[Event Detection Agent\nSupply & Geo Signals]
+    C -->|Scored Events| D[Feature Generation Agent\nDerived Signal Computation]
+    D -->|Feature Store| E[Strategy Evaluation Agent\nOpportunity Ranking]
+    E --> F([JSON Output\nRanked Candidates])
 
-    subgraph Events["2 · Event Detection Agent"]
-        B1[News & Geo\nGDELT · NewsAPI]
-        B2[Supply / Inventory\nEIA API]
-        B3[Shipping\nMarineTraffic]
-        B4[Confidence &\nIntensity Scores]
-    end
-
-    subgraph Features["3 · Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs Implied]
-        C2[Futures Curve\nSteepness]
-        C3[Supply Shock\nProbability]
-        C4[Narrative Velocity\nInsider Conviction]
-    end
-
-    subgraph Strategy["4 · Strategy Evaluation Agent"]
-        D1[Eligible Structures\nStraddle · Spreads]
-        D2[Edge Score\n0.0 – 1.0]
-        D3[Ranked Candidates\nJSON Output]
-    end
-
-    Ingestion -->|market state object| Events
-    Events    -->|scored events| Features
-    Features  -->|derived signals| Strategy
-    Strategy  -->|candidates.json| Output[(Output\nJSON / Dashboard)]
+    style A fill:#f5f5f5,stroke:#999
+    style F fill:#f5f5f5,stroke:#999
+    style B fill:#dbeafe,stroke:#3b82f6
+    style C fill:#fef9c3,stroke:#ca8a04
+    style D fill:#dcfce7,stroke:#16a34a
+    style E fill:#fce7f3,stroke:#db2777
 ```
 
-### In-scope instruments
+| Agent | Role | Key Output |
+|---|---|---|
+| **Data Ingestion Agent** | Fetch & normalize prices, ETF/equity data, and options chains | Unified market state object |
+| **Event Detection Agent** | Monitor news and geopolitical feeds; score supply disruptions | Confidence- and intensity-scored event list |
+| **Feature Generation Agent** | Compute volatility gaps, curve steepness, narrative velocity, etc. | Derived features store |
+| **Strategy Evaluation Agent** | Evaluate eligible structures; rank by edge score | JSON array of ranked strategy candidates |
+
+Data flows **unidirectionally** through the agents. Each agent can be deployed and updated independently without disrupting the rest of the pipeline.
+
+### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
@@ -64,73 +55,71 @@ flowchart LR
 | ETFs | USO, XLE |
 | Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-scope option structures (MVP)
+### In-Scope Option Structures (MVP)
 
-| Structure | Enum value |
-|---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
-
-> **Out of scope (Phase 4 / future):** exotic or multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
+- Long straddles
+- Call / put spreads
+- Calendar spreads
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| Operating system | Linux, macOS, or Windows (WSL recommended) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 5 GB free (6–12 months of historical data) |
-| Network | Outbound HTTPS to API endpoints |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to data provider endpoints |
 
-### Required tools
+### Required Tools
 
 ```bash
 # Verify Python version
-python --version          # must be >= 3.10
+python --version   # must be >= 3.10
 
 # Verify pip
 pip --version
 
-# Verify git
-git --version
+# (Recommended) Verify that venv is available
+python -m venv --help
 ```
 
-### API accounts
+### API Keys & Accounts
 
-The following free or freemium accounts are required. Register before proceeding.
+You must obtain credentials for the following services before running the pipeline. All tiers listed are **free or low-cost**.
 
-| Service | Used by | Tier needed | Sign-up URL |
+| Service | Used By | Sign-Up URL | Notes |
 |---|---|---|---|
-| Alpha Vantage | Data Ingestion (crude prices) | Free | https://www.alphavantage.co |
-| Yahoo Finance / yfinance | Data Ingestion (ETF, equity, options) | Free (no key needed) | — |
-| Polygon.io | Data Ingestion (options chains, fallback) | Free / Limited | https://polygon.io |
-| EIA API | Event Detection (supply / inventory) | Free | https://www.eia.gov/opendata |
-| GDELT | Event Detection (news / geo) | Free (no key needed) | — |
-| NewsAPI | Event Detection (news headlines) | Free | https://newsapi.org |
-| SEC EDGAR | Feature Generation (insider activity) | Free (no key needed) | — |
-| Quiver Quant | Feature Generation (insider conviction) | Free / Limited | https://www.quiverquant.com |
-| MarineTraffic | Feature Generation (shipping / tanker flows) | Free tier | https://www.marinetraffic.com |
-| Reddit API | Feature Generation (narrative sentiment) | Free | https://www.reddit.com/wiki/api |
+| Alpha Vantage | Crude prices (WTI, Brent) | <https://www.alphavantage.co/support/#api-key> | Free tier; rate-limited |
+| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required | Public API |
+| Polygon.io | Options data (fallback) | <https://polygon.io/> | Free tier available |
+| EIA API | Supply & inventory data | <https://www.eia.gov/opendata/> | Free; weekly cadence |
+| NewsAPI | News & geopolitical events | <https://newsapi.org/register> | Free developer tier |
+| GDELT | Geopolitical events | No key required | Public dataset |
+| SEC EDGAR | Insider activity | No key required | Public API |
+| Quiver Quant | Insider conviction scores | <https://www.quiverquant.com/> | Free/limited tier |
+| Reddit API | Narrative / sentiment | <https://www.reddit.com/prefs/apps> | Free; OAuth2 app required |
+| Stocktwits | Narrative / sentiment | <https://api.stocktwits.com/> | Free public stream |
+| MarineTraffic | Shipping / tanker flows | <https://www.marinetraffic.com/> | Free tier available |
+
+> **Tip:** For the MVP (Phase 1), only **Alpha Vantage**, **yfinance**, and optionally **Polygon.io** are strictly required. Additional keys unlock Phase 2 and Phase 3 signals.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
 python -m venv .venv
@@ -142,202 +131,187 @@ source .venv/bin/activate
 .venv\Scripts\Activate.ps1
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 4. Configure Environment Variables
 
-Copy the provided template and populate your credentials:
+Copy the provided template and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value marked `REQUIRED`.
+Open `.env` in your editor and fill in the values described in the table below.
 
-#### Complete environment variable reference
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
-| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | ✅ | — | API key for EIA supply / inventory data |
-| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI headline feed |
-| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider data (Phase 3) |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
-| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit app client ID for sentiment feed (Phase 3) |
-| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit app client secret (Phase 3) |
-| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | Reddit API user-agent string (Phase 3) |
-| `DATA_DIR` | ⬜ | `./data` | Root directory for raw and derived data storage |
-| `OUTPUT_DIR` | ⬜ | `./output` | Directory where `candidates.json` is written |
-| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
-| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Days of historical data to retain on disk |
-| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`3`); gates which agents are enabled |
-| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score for a candidate to appear in output |
-| `TZ` | ⬜ | `UTC` | Timezone for all timestamps; strongly recommended to leave as `UTC` |
+| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for Alpha Vantage crude price feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options data fallback |
+| `EIA_API_KEY` | ✅ Phase 2 | — | API key for EIA supply & inventory feed |
+| `NEWS_API_KEY` | ✅ Phase 2 | — | API key for NewsAPI geopolitical/news feed |
+| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
+| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit OAuth2 application client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit OAuth2 application client secret |
+| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `MARINETRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic shipping feed |
+| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Polling interval for market data feeds (minutes cadence) |
+| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `PHASE` | No | `1` | Active pipeline phase (`1`–`3`); controls which agents and signals are enabled |
 
-> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` already excludes it.
-
-#### Example `.env` (Phase 1)
+Example `.env` for a Phase 1 run:
 
 ```dotenv
-# --- Required ---
+# === Phase 1 — Core Market Signals ===
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=your_polygon_key_here
-EIA_API_KEY=your_eia_key_here
-NEWS_API_KEY=your_newsapi_key_here
+POLYGON_API_KEY=                        # optional fallback
+EIA_API_KEY=                            # required for Phase 2+
+NEWS_API_KEY=                           # required for Phase 2+
 
-# --- Optional overrides ---
-DATA_DIR=./data
+PHASE=1
+DATA_REFRESH_INTERVAL_MINUTES=5
+HISTORY_RETENTION_DAYS=365
 OUTPUT_DIR=./output
 LOG_LEVEL=INFO
-PIPELINE_PHASE=1
-EDGE_SCORE_THRESHOLD=0.30
-TZ=UTC
 ```
 
-### 5. Initialise the data store
+> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` excludes it by default.
 
-Creates the directory structure and seeds the SQLite database used for historical storage:
+### 5. Initialise the Database
+
+The pipeline stores historical raw and derived data locally (sized for 6–12 months of history):
 
 ```bash
-python -m agent init
+python manage.py init-db
 ```
 
 Expected output:
 
 ```
-[INFO] Data directory created at ./data
-[INFO] Output directory created at ./output
-[INFO] Historical database initialised (retention: 365 days)
-[INFO] Initialisation complete.
+[INFO] Initialising database at ./data/market_state.db ...
+[INFO] Schema applied. Historical data retention set to 365 days.
+[INFO] Done.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline phases
-
-Set `PIPELINE_PHASE` in `.env` to control which agents are active:
-
-| Phase | Name | Active agents / signals |
-|---|---|---|
-| `1` | Core Market Signals & Options | Data Ingestion, Feature Generation (IV / volatility gap, curve steepness), Strategy Evaluation |
-| `2` | Supply & Event Augmentation | Adds Event Detection (EIA inventory, GDELT/NewsAPI), supply disruption indices |
-| `3` | Alternative / Contextual Signals | Adds insider conviction (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic) |
-
-### Single run (one-shot)
-
-Executes the full pipeline once and writes `candidates.json` to `OUTPUT_DIR`:
-
-```bash
-python -m agent run
-```
-
-### Continuous mode (polling)
-
-Runs the pipeline on the cadence defined by `MARKET_DATA_INTERVAL_MINUTES`:
-
-```bash
-python -m agent run --continuous
-```
-
-Stop with <kbd>Ctrl</kbd>+<kbd>C</kbd>. The pipeline handles partial or missing data gracefully and will not crash on a failed upstream fetch.
-
-### Run a specific agent only
-
-Each agent can be invoked independently for testing or incremental development:
-
-```bash
-# Data Ingestion only
-python -m agent run --agent ingestion
-
-# Event Detection only
-python -m agent run --agent events
-
-# Feature Generation only
-python -m agent run --agent features
-
-# Strategy Evaluation only (reads from cached feature store)
-python -m agent run --agent strategy
-```
-
-### Override output path
-
-```bash
-python -m agent run --output /tmp/my_candidates.json
-```
-
-### Dry run (no disk writes)
-
-Runs the full pipeline and prints output to stdout without writing files:
-
-```bash
-python -m agent run --dry-run
-```
-
-### Pipeline execution flow (sequence)
+### Pipeline Execution Flow
 
 ```mermaid
 sequenceDiagram
-    participant CLI as CLI / Scheduler
+    participant CLI as User / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS  as Feature Store (disk)
-    participant OUT as Output (candidates.json)
+    participant FS as File System (JSON Output)
 
-    CLI->>DIA: trigger run
-    DIA->>DIA: fetch crude, ETF, equity, options chain
-    DIA->>FS: write normalised market state
-    DIA->>EDA: market state ready
-
-    EDA->>EDA: scan news, geo, EIA, shipping
-    EDA->>EDA: assign confidence & intensity scores
-    EDA->>FS: write scored events
-
-    FGA->>FS: read market state + events
-    FGA->>FGA: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock prob.
-    FGA->>FS: write derived features
-
-    SEA->>FS: read derived features
-    SEA->>SEA: evaluate eligible structures
-    SEA->>SEA: compute edge scores & rank candidates
-    SEA->>OUT: write candidates.json
-    SEA->>CLI: run complete
+    CLI->>DIA: python run_pipeline.py --phase 1
+    DIA->>DIA: Fetch crude, ETF/equity prices & options chains
+    DIA->>EDA: market_state object
+    EDA->>EDA: Score news / geo events (confidence + intensity)
+    EDA->>FGA: scored_events + market_state
+    FGA->>FGA: Compute volatility gaps, curve steepness, etc.
+    FGA->>SEA: derived_features store
+    SEA->>SEA: Evaluate structures; rank by edge_score
+    SEA->>FS: Write ranked_candidates_<timestamp>.json
+    FS-->>CLI: Pipeline complete ✓
 ```
+
+### Single Run
+
+Execute one full pass of the pipeline:
+
+```bash
+python run_pipeline.py
+```
+
+To override the active phase without editing `.env`:
+
+```bash
+python run_pipeline.py --phase 2
+```
+
+To specify a custom output directory for this run:
+
+```bash
+python run_pipeline.py --output-dir /tmp/pipeline-out
+```
+
+### Continuous (Polling) Mode
+
+Run the pipeline on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence:
+
+```bash
+python run_pipeline.py --continuous
+```
+
+Press `Ctrl+C` to stop. The pipeline will finish the current cycle before exiting cleanly.
+
+### Running Individual Agents
+
+Each agent can be executed independently for development or debugging:
+
+```bash
+# Data Ingestion only
+python -m agents.data_ingestion
+
+# Event Detection only (requires a saved market state)
+python -m agents.event_detection --state ./output/market_state_latest.json
+
+# Feature Generation only
+python -m agents.feature_generation --state ./output/market_state_latest.json
+
+# Strategy Evaluation only
+python -m agents.strategy_evaluation --features ./output/features_latest.json
+```
+
+### Phase-by-Phase Feature Availability
+
+| Phase | Name | Signals Enabled | Additional Keys Needed |
+|---|---|---|---|
+| 1 | Core Market Signals & Options | Crude prices, ETF/equity prices, IV surface, long straddles, call/put spreads | `ALPHA_VANTAGE_API_KEY` |
+| 2 | Supply & Event Augmentation | + EIA inventory, refinery utilisation, GDELT/NewsAPI event detection, supply disruption indices | `EIA_API_KEY`, `NEWS_API_KEY` |
+| 3 | Alternative / Contextual Signals | + Insider trades, narrative velocity (Reddit/Stocktwits), shipping data, cross-sector correlation | `REDDIT_CLIENT_ID/SECRET`, optionally `QUIVER_QUANT_API_KEY`, `MARINETRAFFIC_API_KEY` |
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output File Location
+
+After each pipeline run, a timestamped JSON file is written to `OUTPUT_DIR`:
 
 ```
-./output/candidates.json
+./output/ranked_candidates_2026-03-15T14:32:00Z.json
 ```
 
-The file contains a JSON array. Each element is one ranked strategy candidate.
+A symlink `ranked_candidates_latest.json` always points to the most recent file.
 
-### Output schema
+### Output Schema
+
+Each element in the output array represents one ranked strategy candidate:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher means stronger signal confluence |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; **higher = stronger signal confluence** |
 | `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example output
+### Example Output
 
 ```json
 [
@@ -354,69 +328,61 @@ The file contains a JSON array. Each element is one ranked strategy candidate.
     "generated_at": "2026-03-15T14:32:00Z"
   },
   {
-    "instrument": "XLE",
+    "instrument": "XOM",
     "structure": "call_spread",
-    "expiration": 21,
-    "edge_score": 0.38,
+    "expiration": 45,
+    "edge_score": 0.31,
     "signals": {
       "volatility_gap": "positive",
-      "futures_curve_steepness": "elevated",
-      "supply_shock_probability": "moderate"
+      "supply_shock_probability": "elevated",
+      "sector_dispersion": "high"
     },
     "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading edge scores
+### Reading the Edge Score
 
-| Edge score range | Interpretation | Suggested action |
+| Edge Score Range | Interpretation | Suggested Action |
 |---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High-priority candidate — review carefully |
-| `0.50 – 0.69` | Moderate confluence | Warrants further analysis |
-| `0.30 – 0.49` | Weak / marginal signal | Low confidence — treat as informational |
-| `< 0.30` | Below threshold | Filtered out by default (`EDGE_SCORE_THRESHOLD`) |
+| 0.70 – 1.00 | Strong signal confluence | High-priority candidate; review signals carefully |
+| 0.40 – 0.69 | Moderate confluence | Candidate worth monitoring; validate with additional research |
+| 0.10 – 0.39 | Weak confluence | Low-conviction signal; treat as background noise unless a specific thesis supports it |
+| 0.00 – 0.09 | Negligible | Discard |
 
-> The edge score is a heuristic composite; it is not a probability of profit. Always perform your own due diligence before placing a trade.
+> **Important:** The edge score is a heuristic composite, not a probability of profit. Always perform independent due diligence before placing any trade. The system is **advisory only**.
 
-### Signal reference
+### Signal Reference
 
-| Signal key | Description | Qualitative values |
+| Signal Key | Description | Source Agent |
 |---|---|---|
-| `volatility_gap` | Realised volatility vs. implied volatility differential | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | Slope of the oil futures term structure | `elevated`, `flat`, `inverted` |
-| `sector_dispersion` | Cross-sector correlation divergence | `high`, `moderate`, `low` |
-| `insider_conviction_score` | Aggregated insider trade activity (EDGAR/Quiver) | `high`, `moderate`, `low` |
-| `narrative_velocity` | Rate of change of energy-related headline / social volume | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | Modelled probability of near-term supply disruption | `high`, `moderate`, `low` |
-| `tanker_disruption_index` | Shipping / chokepoint anomaly score | `high`, `moderate`, `low` |
+| `volatility_gap` | Realised vs. implied volatility divergence | Feature Generation |
+| `futures_curve_steepness` | Contango / backwardation gradient | Feature Generation |
+| `sector_dispersion` | Spread between energy sub-sector moves | Feature Generation |
+| `insider_conviction_score` | Aggregated insider trading signal | Feature Generation |
+| `narrative_velocity` | Acceleration of energy-related headlines | Feature Generation |
+| `supply_shock_probability` | Modelled probability of a supply disruption | Feature Generation |
+| `tanker_disruption_index` | Shipping-flow anomaly score | Event Detection |
+| `refinery_outage_score` | Refinery utilisation deviation | Event Detection |
+| `geopolitical_intensity` | Geo-event confidence × intensity product | Event Detection |
 
-### Visualising output in thinkorswim
+### Visualisation
 
-The JSON output is designed to be consumed by any JSON-capable dashboard. For thinkorswim, import `candidates.json` via the platform's scripting interface or paste individual candidates into a watchlist notes field.
+The JSON output is compatible with **thinkorswim** or any JSON-capable dashboard. To load the latest candidates directly:
+
+```bash
+cat ./output/ranked_candidates_latest.json | python -m json.tool
+```
 
 ---
 
 ## Troubleshooting
 
-### General diagnostic commands
+### Common Issues
 
-```bash
-# Check environment variable loading
-python -m agent config check
-
-# Validate API connectivity for all configured sources
-python -m agent config test-connections
-
-# Print the current feature store snapshot
-python -m agent debug features
-
-# Print the last N log lines
-python -m agent logs --tail 50
-```
-
-### Common issues
-
-| Symptom | Likely cause | Resolution |
+| Symptom | Likely Cause | Resolution |
 |---|---|---|
-| `candidates.json` is empty | All candidates below `EDGE_SCORE_THRESHOLD` | Lower `EDGE_SCORE_THRESHOLD` in `.env` or check
+| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` not loaded or variable missing | Confirm `.env` exists in project root and contains the key; verify `python-dotenv` is installed |
+| `RateLimitError` from Alpha Vantage | Free-tier rate limit exceeded | Increase `DATA_REFRESH_INTERVAL_MINUTES`; consider caching raw responses |
+| Empty `ranked_candidates_*.json` | No candidates exceeded the minimum threshold | Check `LOG_LEVEL=DEBUG` output; verify market data was fetched

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> Advisory system only. No automated trade execution occurs at any point in the pipeline.
+> **Version 1.0 • March 2026**
+> Advisory only. The system surfaces ranked options candidates; it does **not** execute trades.
 
 ---
 
@@ -18,347 +18,326 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and surfaces ranked options trading candidates. It is designed for a single developer running on local hardware or a low-cost cloud VM.
 
-### Pipeline Architecture
-
-The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**.
+The pipeline is composed of four loosely coupled agents that execute in sequence:
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
-        A2([ETF & Equity Prices\nyfinance])
-        A3([Options Chains\nYahoo / Polygon.io])
-        A4([Supply / Inventory\nEIA API])
-        A5([News & Geo Events\nGDELT / NewsAPI])
-        A6([Insider Activity\nSEC EDGAR / Quiver])
-        A7([Shipping\nMarineTraffic])
-        A8([Sentiment\nReddit / Stocktwits])
+    subgraph Ingestion["1 · Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nIV · Strike · Volume]
     end
 
-    subgraph Pipeline["Four-Agent Pipeline"]
-        direction TB
-        B["🟦 Data Ingestion Agent\nFetch & Normalize\n→ Market State Object"]
-        C["🟨 Event Detection Agent\nSupply & Geo Signals\n→ Scored Events"]
-        D["🟩 Feature Generation Agent\nDerived Signal Computation\n→ Features Store"]
-        E["🟥 Strategy Evaluation Agent\nOpportunity Ranking\n→ Ranked Candidates"]
-        B --> C --> D --> E
+    subgraph Events["2 · Event Detection Agent"]
+        B1[News & Geo\nGDELT · NewsAPI]
+        B2[Supply / Inventory\nEIA API]
+        B3[Shipping\nMarineTraffic]
+        B4[Confidence &\nIntensity Scores]
     end
 
-    subgraph Output
-        F([JSON Candidates\nedge_score · signals\nexpiration · structure])
+    subgraph Features["3 · Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs Implied]
+        C2[Futures Curve\nSteepness]
+        C3[Supply Shock\nProbability]
+        C4[Narrative Velocity\nInsider Conviction]
     end
 
-    Inputs --> B
-    E --> Output
+    subgraph Strategy["4 · Strategy Evaluation Agent"]
+        D1[Eligible Structures\nStraddle · Spreads]
+        D2[Edge Score\n0.0 – 1.0]
+        D3[Ranked Candidates\nJSON Output]
+    end
+
+    Ingestion -->|market state object| Events
+    Events    -->|scored events| Features
+    Features  -->|derived signals| Strategy
+    Strategy  -->|candidates.json| Output[(Output\nJSON / Dashboard)]
 ```
 
-### In-Scope Instruments
+### In-scope instruments
 
 | Category | Instruments |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-Scope Option Structures (MVP)
+### In-scope option structures (MVP)
 
-| Structure | Enum Value |
+| Structure | Enum value |
 |---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
+| Long straddle | `long_straddle` |
+| Call spread | `call_spread` |
+| Put spread | `put_spread` |
+| Calendar spread | `calendar_spread` |
 
-> **Out of scope (MVP):** exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
+> **Out of scope (Phase 4 / future):** exotic or multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| OS | Linux, macOS, or Windows (WSL recommended) |
+| Python | 3.10 or later |
+| Operating system | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 5 GB (6–12 months of historical data) |
-| Network | Outbound HTTPS to external APIs |
+| Disk | 5 GB free (6–12 months of historical data) |
+| Network | Outbound HTTPS to API endpoints |
 
-### Python Dependencies
-
-Install all dependencies from the project root:
+### Required tools
 
 ```bash
-pip install -r requirements.txt
+# Verify Python version
+python --version          # must be >= 3.10
+
+# Verify pip
+pip --version
+
+# Verify git
+git --version
 ```
 
-Key packages the pipeline relies on include:
+### API accounts
 
-| Package | Purpose |
-|---|---|
-| `yfinance` | ETF, equity, and options chain data |
-| `requests` | HTTP calls to EIA, Alpha Vantage, GDELT, NewsAPI |
-| `pandas` / `numpy` | Data normalization and feature computation |
-| `pydantic` | Market state object and output schema validation |
-| `schedule` or `apscheduler` | Cadence-based refresh scheduling |
+The following free or freemium accounts are required. Register before proceeding.
 
-### API Accounts
-
-You must obtain API keys (all free or freemium) before running the pipeline:
-
-| Service | Registration URL | Tier Needed |
-|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free |
-| MetalpriceAPI | https://metalpriceapi.com | Free |
-| Polygon.io | https://polygon.io | Free / Limited |
-| EIA API | https://www.eia.gov/opendata/ | Free |
-| NewsAPI | https://newsapi.org | Free |
-| GDELT | No key required (public dataset) | — |
-| SEC EDGAR | No key required (public dataset) | — |
-| Quiver Quant | https://www.quiverquant.com | Free / Limited |
-| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Free tier |
+| Service | Used by | Tier needed | Sign-up URL |
+|---|---|---|---|
+| Alpha Vantage | Data Ingestion (crude prices) | Free | https://www.alphavantage.co |
+| Yahoo Finance / yfinance | Data Ingestion (ETF, equity, options) | Free (no key needed) | — |
+| Polygon.io | Data Ingestion (options chains, fallback) | Free / Limited | https://polygon.io |
+| EIA API | Event Detection (supply / inventory) | Free | https://www.eia.gov/opendata |
+| GDELT | Event Detection (news / geo) | Free (no key needed) | — |
+| NewsAPI | Event Detection (news headlines) | Free | https://newsapi.org |
+| SEC EDGAR | Feature Generation (insider activity) | Free (no key needed) | — |
+| Quiver Quant | Feature Generation (insider conviction) | Free / Limited | https://www.quiverquant.com |
+| MarineTraffic | Feature Generation (shipping / tanker flows) | Free tier | https://www.marinetraffic.com |
+| Reddit API | Feature Generation (narrative sentiment) | Free | https://www.reddit.com/wiki/api |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate.bat     # Windows CMD
-# .venv\Scripts\Activate.ps1     # Windows PowerShell
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the example environment file and populate it with your credentials:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set each value. The full set of supported environment variables is listed below.
+Open `.env` in your editor and fill in every value marked `REQUIRED`.
 
-#### Environment Variable Reference
+#### Complete environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Yes | — | API key for MetalpriceAPI (Brent/WTI spot) |
-| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery utilization |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy news |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
-| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flow data |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `DATA_STORE_DIR` | No | `./data` | Root directory for raw and derived historical data |
-| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
-| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Refresh cadence in minutes for market price feeds |
-| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Refresh cadence in hours for EIA and EDGAR feeds |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_PHASE` | No | `1` | Active MVP phase (`1`–`4`); gates which agents are enabled |
-| `MIN_EDGE_SCORE` | No | `0.20` | Minimum edge score threshold for emitting a candidate |
-| `MAX_CANDIDATES` | No | `10` | Maximum number of ranked candidates per pipeline run |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
+| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | ✅ | — | API key for EIA supply / inventory data |
+| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI headline feed |
+| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider data (Phase 3) |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
+| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit app client ID for sentiment feed (Phase 3) |
+| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit app client secret (Phase 3) |
+| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | Reddit API user-agent string (Phase 3) |
+| `DATA_DIR` | ⬜ | `./data` | Root directory for raw and derived data storage |
+| `OUTPUT_DIR` | ⬜ | `./output` | Directory where `candidates.json` is written |
+| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
+| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Days of historical data to retain on disk |
+| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`3`); gates which agents are enabled |
+| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score for a candidate to appear in output |
+| `TZ` | ⬜ | `UTC` | Timezone for all timestamps; strongly recommended to leave as `UTC` |
 
-> **Tip:** Variables marked **No** under *Required* are optional. The pipeline degrades gracefully when optional data sources are unavailable — it will log a warning and continue rather than halting.
+> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` already excludes it.
 
-#### Example `.env`
+#### Example `.env` (Phase 1)
 
 ```dotenv
-# --- Required API Keys ---
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-METALPRICE_API_KEY=YOUR_MP_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWS_API_KEY_HERE
+# --- Required ---
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
+POLYGON_API_KEY=your_polygon_key_here
+EIA_API_KEY=your_eia_key_here
+NEWS_API_KEY=your_newsapi_key_here
 
-# --- Optional API Keys ---
-POLYGON_API_KEY=
-QUIVER_QUANT_API_KEY=
-MARINETRAFFIC_API_KEY=
-
-# --- Pipeline Behaviour ---
-PIPELINE_PHASE=1
-MIN_EDGE_SCORE=0.20
-MAX_CANDIDATES=10
-MARKET_DATA_INTERVAL_MIN=5
-SLOW_FEED_INTERVAL_HOURS=24
-
-# --- Storage ---
+# --- Optional overrides ---
+DATA_DIR=./data
 OUTPUT_DIR=./output
-DATA_STORE_DIR=./data
-RETENTION_DAYS=365
-
-# --- Observability ---
 LOG_LEVEL=INFO
+PIPELINE_PHASE=1
+EDGE_SCORE_THRESHOLD=0.30
+TZ=UTC
 ```
 
-### 5. Initialise the Data Store
+### 5. Initialise the data store
 
-Run the one-time initialisation script to create the required directory structure and seed the historical data store:
+Creates the directory structure and seeds the SQLite database used for historical storage:
 
 ```bash
-python -m agent.cli init
+python -m agent init
 ```
 
 Expected output:
 
 ```
-[INFO] Creating data store at ./data ...
-[INFO] Creating output directory at ./output ...
-[INFO] Initialisation complete. Run `python -m agent.cli run` to start the pipeline.
+[INFO] Data directory created at ./data
+[INFO] Output directory created at ./output
+[INFO] Historical database initialised (retention: 365 days)
+[INFO] Initialisation complete.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Data Flow (Sequence)
+### Pipeline phases
+
+Set `PIPELINE_PHASE` in `.env` to control which agents are active:
+
+| Phase | Name | Active agents / signals |
+|---|---|---|
+| `1` | Core Market Signals & Options | Data Ingestion, Feature Generation (IV / volatility gap, curve steepness), Strategy Evaluation |
+| `2` | Supply & Event Augmentation | Adds Event Detection (EIA inventory, GDELT/NewsAPI), supply disruption indices |
+| `3` | Alternative / Contextual Signals | Adds insider conviction (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic) |
+
+### Single run (one-shot)
+
+Executes the full pipeline once and writes `candidates.json` to `OUTPUT_DIR`:
+
+```bash
+python -m agent run
+```
+
+### Continuous mode (polling)
+
+Runs the pipeline on the cadence defined by `MARKET_DATA_INTERVAL_MINUTES`:
+
+```bash
+python -m agent run --continuous
+```
+
+Stop with <kbd>Ctrl</kbd>+<kbd>C</kbd>. The pipeline handles partial or missing data gracefully and will not crash on a failed upstream fetch.
+
+### Run a specific agent only
+
+Each agent can be invoked independently for testing or incremental development:
+
+```bash
+# Data Ingestion only
+python -m agent run --agent ingestion
+
+# Event Detection only
+python -m agent run --agent events
+
+# Feature Generation only
+python -m agent run --agent features
+
+# Strategy Evaluation only (reads from cached feature store)
+python -m agent run --agent strategy
+```
+
+### Override output path
+
+```bash
+python -m agent run --output /tmp/my_candidates.json
+```
+
+### Dry run (no disk writes)
+
+Runs the full pipeline and prints output to stdout without writing files:
+
+```bash
+python -m agent run --dry-run
+```
+
+### Pipeline execution flow (sequence)
 
 ```mermaid
 sequenceDiagram
-    autonumber
     participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (JSON Output)
+    participant FS  as Feature Store (disk)
+    participant OUT as Output (candidates.json)
 
-    CLI->>DIA: trigger run()
-    DIA->>DIA: fetch crude, ETF, equity prices
-    DIA->>DIA: fetch options chains
-    DIA->>DIA: normalize → MarketStateObject
-    DIA-->>EDA: MarketStateObject
+    CLI->>DIA: trigger run
+    DIA->>DIA: fetch crude, ETF, equity, options chain
+    DIA->>FS: write normalised market state
+    DIA->>EDA: market state ready
 
-    EDA->>EDA: scan GDELT / NewsAPI
-    EDA->>EDA: score supply disruptions, outages, chokepoints
-    EDA-->>FGA: MarketStateObject + ScoredEvents
+    EDA->>EDA: scan news, geo, EIA, shipping
+    EDA->>EDA: assign confidence & intensity scores
+    EDA->>FS: write scored events
 
-    FGA->>FGA: compute volatility gaps (realized vs. implied)
-    FGA->>FGA: compute curve steepness, dispersion, insider scores
-    FGA->>FGA: compute narrative velocity, supply shock probability
-    FGA-->>SEA: FeaturesStore
+    FGA->>FS: read market state + events
+    FGA->>FGA: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock prob.
+    FGA->>FS: write derived features
 
-    SEA->>SEA: evaluate eligible option structures
-    SEA->>SEA: compute edge scores
-    SEA->>SEA: rank candidates, attach signal references
-    SEA-->>FS: write ranked_candidates_<timestamp>.json
-```
-
-### Single Run (One-Shot)
-
-Execute the full pipeline once and write output to `OUTPUT_DIR`:
-
-```bash
-python -m agent.cli run
-```
-
-To override the active phase without editing `.env`:
-
-```bash
-python -m agent.cli run --phase 2
-```
-
-To lower the minimum edge score for a broader candidate set:
-
-```bash
-python -m agent.cli run --min-edge-score 0.10
-```
-
-### Continuous Mode (Scheduled)
-
-Run the pipeline on a recurring cadence driven by `MARKET_DATA_INTERVAL_MIN`:
-
-```bash
-python -m agent.cli run --continuous
-```
-
-The scheduler will:
-- Refresh market price feeds every `MARKET_DATA_INTERVAL_MIN` minutes.
-- Refresh slow feeds (EIA, EDGAR) every `SLOW_FEED_INTERVAL_HOURS` hours.
-- Append a new output file per cycle to `OUTPUT_DIR`.
-
-Stop the process with `Ctrl+C`.
-
-### Running Individual Agents
-
-Each agent can be run in isolation for development or debugging:
-
-```bash
-# Data Ingestion only
-python -m agent.cli run --agent ingestion
-
-# Event Detection only (requires a prior ingestion snapshot)
-python -m agent.cli run --agent event-detection
-
-# Feature Generation only
-python -m agent.cli run --agent feature-generation
-
-# Strategy Evaluation only
-python -m agent.cli run --agent strategy-evaluation
-```
-
-### Running in Docker
-
-A minimal container target is provided for cloud or server deployment:
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run with your local .env file
-docker run --env-file .env \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/output:/app/output \
-  energy-options-agent:latest
+    SEA->>FS: read derived features
+    SEA->>SEA: evaluate eligible structures
+    SEA->>SEA: compute edge scores & rank candidates
+    SEA->>OUT: write candidates.json
+    SEA->>CLI: run complete
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
-
-Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
+### Output file location
 
 ```
-output/
-└── ranked_candidates_2026-03-15T14:05:00Z.json
+./output/candidates.json
 ```
 
-### Output Schema
+The file contains a JSON array. Each element is one ranked strategy candidate.
 
-Each file contains an array of candidate objects. The fields are:
+### Output schema
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative levels |
+| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher means stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output
+### Example output
 
 ```json
 [
@@ -372,59 +351,72 @@ Each file contains an array of candidate objects. The fields are:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:05:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
+    "expiration": 21,
+    "edge_score": 0.38,
     "signals": {
-      "supply_shock_probability": "elevated",
       "volatility_gap": "positive",
-      "sector_dispersion": "widening"
+      "futures_curve_steepness": "elevated",
+      "supply_shock_probability": "moderate"
     },
-    "generated_at": "2026-03-15T14:05:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading the Edge Score
+### Reading edge scores
 
-| Edge Score Range | Interpretation |
-|---|---|
-| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
-| `0.40 – 0.69` | Moderate confluence — worthy of further review |
-| `0.20 – 0.39` | Weak signal — monitor rather than act |
-| `< 0.20` | Below threshold — suppressed by default (`MIN_EDGE_SCORE`) |
+| Edge score range | Interpretation | Suggested action |
+|---|---|---|
+| `0.70 – 1.00` | Strong signal confluence | High-priority candidate — review carefully |
+| `0.50 – 0.69` | Moderate confluence | Warrants further analysis |
+| `0.30 – 0.49` | Weak / marginal signal | Low confidence — treat as informational |
+| `< 0.30` | Below threshold | Filtered out by default (`EDGE_SCORE_THRESHOLD`) |
 
-> **Important:** The edge score is an advisory signal, not a trade recommendation. The system does not execute trades and does not account for individual risk tolerance, position sizing, or transaction costs.
+> The edge score is a heuristic composite; it is not a probability of profit. Always perform your own due diligence before placing a trade.
 
-### Signal Reference
+### Signal reference
 
-The `signals` map reports the state of each contributing derived feature at the time of evaluation:
+| Signal key | Description | Qualitative values |
+|---|---|---|
+| `volatility_gap` | Realised volatility vs. implied volatility differential | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | Slope of the oil futures term structure | `elevated`, `flat`, `inverted` |
+| `sector_dispersion` | Cross-sector correlation divergence | `high`, `moderate`, `low` |
+| `insider_conviction_score` | Aggregated insider trade activity (EDGAR/Quiver) | `high`, `moderate`, `low` |
+| `narrative_velocity` | Rate of change of energy-related headline / social volume | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | Modelled probability of near-term supply disruption | `high`, `moderate`, `low` |
+| `tanker_disruption_index` | Shipping / chokepoint anomaly score | `high`, `moderate`, `low` |
 
-| Signal Key | What It Measures |
-|---|---|
-| `volatility_gap` | Realized vs. implied volatility divergence |
-| `futures_curve_steepness` | Contango or backwardation steepness |
-| `sector_dispersion` | Cross-instrument spread within the energy sector |
-| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
-| `narrative_velocity` | Headline acceleration from GDELT / NewsAPI / Reddit |
-| `supply_shock_probability` | Probability of near-term supply disruption |
-| `tanker_disruption_index` | Shipping flow anomaly from MarineTraffic |
+### Visualising output in thinkorswim
 
-### Using the Output with thinkorswim
-
-The JSON output is compatible with any thinkorswim thinkScript study or third-party dashboard that can consume a JSON file. Load `ranked_candidates_<timestamp>.json` from your `OUTPUT_DIR` into your visualization layer. Candidates are pre-sorted by `edge_score` descending.
+The JSON output is designed to be consumed by any JSON-capable dashboard. For thinkorswim, import `candidates.json` via the platform's scripting interface or paste individual candidates into a watchlist notes field.
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
+### General diagnostic commands
 
-| Symptom | Likely Cause | Resolution |
+```bash
+# Check environment variable loading
+python -m agent config check
+
+# Validate API connectivity for all configured sources
+python -m agent config test-connections
+
+# Print the current feature store snapshot
+python -m agent debug features
+
+# Print the last N log lines
+python -m agent logs --tail 50
+```
+
+### Common issues
+
+| Symptom | Likely cause | Resolution |
 |---|---|---|
-| `KeyError: ALPHA_VANTAGE_API_KEY` | Environment variable not set | Verify `.env` is populated and loaded; re-run `source .venv/bin/activate` |
-| `WARNING: options chain unavailable for XOM` | Polygon.io
+| `candidates.json` is empty | All candidates below `EDGE_SCORE_THRESHOLD` | Lower `EDGE_SCORE_THRESHOLD` in `.env` or check

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -26,6 +26,7 @@ import requests
 from src.agents.event_detection.models import (
     ClassifyLLMResponse,
     DetectedEvent,
+    EIAInventoryRecord,
     EventIntensity,
     EventType,
 )
@@ -45,6 +46,11 @@ _NEWSAPI_PAGE_SIZE: int = 20
 _GDELT_QUERY: str = "crude oil supply disruption OR OPEC OR refinery"
 _GDELT_MAX_RECORDS: int = 20
 _GDELT_TIMESPAN_MINUTES: int = 1440  # 24 hours
+
+# EIA API v2 endpoints and fetch parameters
+_EIA_CRUDE_STOCKS_PATH: str = "/v2/petroleum/sum/sndw/data/"
+_EIA_REFINERY_UTIL_PATH: str = "/v2/petroleum/pnp/wiup/data/"
+_EIA_FETCH_WEEKS: int = 4  # most recent 4 weeks per fetch
 
 # LLM model for event classification — Haiku for speed and cost efficiency
 _CLASSIFY_MODEL_ID: str = "claude-haiku-4-5-20251001"
@@ -190,6 +196,126 @@ def fetch_gdelt_events() -> list[dict[str, object]]:
 
     logger.info("fetch_gdelt_events: retrieved %d article(s) from GDELT", len(articles))
     return articles
+
+
+def _fetch_eia_series(
+    base_url: str,
+    api_key: str,
+    path: str,
+) -> dict[str, float | None]:
+    """
+    Fetch one EIA API v2 data series and return a period → value mapping.
+
+    Args:
+        base_url: EIA API base URL (e.g. https://api.eia.gov).
+        api_key: EIA API key.
+        path: Series path (e.g. /v2/petroleum/sum/sndw/data/).
+
+    Returns:
+        Dict mapping period string (YYYY-WW) to float value or None if
+        the EIA record has a null value for that period.
+
+    Raises:
+        requests.HTTPError: Propagates on non-2xx response.
+    """
+    params: dict[str, str | int] = {
+        "api_key": api_key,
+        "frequency": "weekly",
+        "data[0]": "value",
+        "sort[0][column]": "period",
+        "sort[0][direction]": "desc",
+        "length": _EIA_FETCH_WEEKS,
+    }
+    response = requests.get(
+        f"{base_url}{path}",
+        params=params,
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    data: dict[str, object] = response.json()
+
+    raw_inner: object = data.get("response", {})
+    inner: dict[str, object] = raw_inner if isinstance(raw_inner, dict) else {}
+    raw_records: object = inner.get("data", [])
+    records: list[dict[str, object]] = raw_records if isinstance(raw_records, list) else []
+
+    result: dict[str, float | None] = {}
+    for record in records:
+        period_raw = record.get("period", "")
+        period: str = period_raw if isinstance(period_raw, str) else ""
+        if not period:
+            continue
+        raw_value = record.get("value")
+        value: float | None = None
+        if raw_value is not None:
+            try:
+                value = float(raw_value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                logger.warning(
+                    "_fetch_eia_series: unparseable value %r for period=%r in %s",
+                    raw_value,
+                    period,
+                    path,
+                )
+        result[period] = value
+    return result
+
+
+@with_retry()
+def fetch_eia_data() -> list[EIAInventoryRecord]:
+    """
+    Fetch weekly EIA petroleum inventory data for the most recent 4 weeks.
+
+    Queries two EIA API v2 series:
+      - /v2/petroleum/sum/sndw/data/ : U.S. crude oil stocks (millions of barrels)
+      - /v2/petroleum/pnp/wiup/data/ : U.S. refinery utilization rate (percent)
+
+    Records from both series are merged by period and returned as a list of
+    EIAInventoryRecord objects sorted newest-first.
+
+    If EIA_API_KEY is not set, logs a WARNING and returns [] (degraded mode).
+    Override the base URL for testing via the EIA_BASE_URL env var.
+
+    Returns:
+        List of EIAInventoryRecord, one per reporting period, newest first.
+        Empty list if the API key is absent or both series return no data.
+
+    Raises:
+        requests.HTTPError: Propagates after all retry attempts if either
+            series endpoint returns a non-2xx status.
+    """
+    api_key = os.environ.get("EIA_API_KEY")
+    if not api_key:
+        logger.warning("EIA_API_KEY not set; skipping EIA fetch (degraded mode)")
+        return []
+
+    base_url = os.environ.get("EIA_BASE_URL", "https://api.eia.gov")
+    fetched_at = datetime.now(tz=UTC)
+
+    crude_by_period = _fetch_eia_series(base_url, api_key, _EIA_CRUDE_STOCKS_PATH)
+    refinery_by_period = _fetch_eia_series(base_url, api_key, _EIA_REFINERY_UTIL_PATH)
+
+    all_periods: set[str] = set(crude_by_period) | set(refinery_by_period)
+    records: list[EIAInventoryRecord] = []
+    for period in all_periods:
+        try:
+            record = EIAInventoryRecord(
+                period=period,
+                crude_stocks_mb=crude_by_period.get(period),
+                refinery_utilization_pct=refinery_by_period.get(period),
+                fetched_at=fetched_at,
+            )
+            records.append(record)
+        except Exception:
+            logger.warning(
+                "fetch_eia_data: skipping malformed record for period=%r",
+                period,
+                exc_info=True,
+            )
+
+    records.sort(key=lambda r: r.period, reverse=True)
+    logger.info("fetch_eia_data: retrieved %d EIA record(s)", len(records))
+    return records
 
 
 @with_retry()

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for fetch_eia_data() in the Event Detection Agent.
+
+All HTTP calls are mocked — no real EIA API key or network required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import fetch_eia_data
+from src.agents.event_detection.models import EIAInventoryRecord
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CRUDE_RESPONSE = {
+    "response": {
+        "data": [
+            {"period": "2024-10", "value": "423.5"},
+            {"period": "2024-09", "value": "418.2"},
+        ]
+    }
+}
+
+_REFINERY_RESPONSE = {
+    "response": {
+        "data": [
+            {"period": "2024-10", "value": "87.4"},
+            {"period": "2024-09", "value": "86.1"},
+        ]
+    }
+}
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = payload
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Missing API key — degraded mode
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataDegradedMode:
+    def test_missing_key_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EIA_API_KEY", raising=False)
+        result = fetch_eia_data()
+        assert result == []
+
+    def test_missing_key_logs_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.delenv("EIA_API_KEY", raising=False)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            fetch_eia_data()
+        assert any("EIA_API_KEY" in m for m in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataHappyPath:
+    def test_returns_list_of_eia_inventory_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert len(result) == 2
+        assert all(isinstance(r, EIAInventoryRecord) for r in result)
+
+    def test_records_sorted_newest_first(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert result[0].period == "2024-10"
+        assert result[1].period == "2024-09"
+
+    def test_crude_stocks_and_refinery_merged_by_period(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        latest = next(r for r in result if r.period == "2024-10")
+        assert latest.crude_stocks_mb == pytest.approx(423.5)
+        assert latest.refinery_utilization_pct == pytest.approx(87.4)
+
+    def test_fetched_at_is_utc_datetime(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        for record in result:
+            assert record.fetched_at.tzinfo is not None
+
+    def test_source_defaults_to_eia(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert all(r.source == "eia" for r in result)
+
+    def test_api_key_sent_in_params(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "my-secret-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            fetch_eia_data()
+
+        for c in mock_get.call_args_list:
+            params = c.kwargs.get("params", {})
+            assert params.get("api_key") == "my-secret-key"
+
+    def test_eia_base_url_env_var_used(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        monkeypatch.setenv("EIA_BASE_URL", "http://eia-mock.internal")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            fetch_eia_data()
+
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert all(u.startswith("http://eia-mock.internal") for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# Malformed / partial responses
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataMalformedResponse:
+    def test_empty_data_array_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        empty = {"response": {"data": []}}
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(empty),
+                _mock_response(empty),
+            ]
+            result = fetch_eia_data()
+
+        assert result == []
+
+    def test_null_value_in_series_yields_none_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        crude_with_null = {"response": {"data": [{"period": "2024-10", "value": None}]}}
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(crude_with_null),
+                _mock_response({"response": {"data": []}}),
+            ]
+            result = fetch_eia_data()
+
+        assert len(result) == 1
+        assert result[0].crude_stocks_mb is None
+
+    def test_missing_period_key_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        bad_crude = {"response": {"data": [{"value": "400.0"}]}}  # no period key
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(bad_crude),
+                _mock_response({"response": {"data": []}}),
+            ]
+            result = fetch_eia_data()
+
+        assert result == []
+
+    def test_http_error_propagates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import requests as req_mod
+
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        error_resp = MagicMock()
+        error_resp.raise_for_status.side_effect = req_mod.HTTPError("500")
+        with patch("requests.get", return_value=error_resp):
+            with pytest.raises(req_mod.HTTPError):
+                fetch_eia_data()

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -7,6 +7,7 @@ All HTTP calls are mocked — no real EIA API key or network required.
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -157,7 +158,7 @@ class TestFetchEIADataHappyPath:
             fetch_eia_data()
 
         urls = [c.args[0] for c in mock_get.call_args_list]
-        assert all(u.startswith("http://eia-mock.internal") for u in urls)
+        assert all(urlparse(u).netloc == "eia-mock.internal" for u in urls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -49,9 +49,7 @@ def _mock_response(payload: dict) -> MagicMock:
 
 
 class TestFetchEIADataDegradedMode:
-    def test_missing_key_returns_empty_list(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("EIA_API_KEY", raising=False)
         result = fetch_eia_data()
         assert result == []
@@ -73,9 +71,7 @@ class TestFetchEIADataDegradedMode:
 
 
 class TestFetchEIADataHappyPath:
-    def test_returns_list_of_eia_inventory_records(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_returns_list_of_eia_inventory_records(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -87,9 +83,7 @@ class TestFetchEIADataHappyPath:
         assert len(result) == 2
         assert all(isinstance(r, EIAInventoryRecord) for r in result)
 
-    def test_records_sorted_newest_first(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_records_sorted_newest_first(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -116,9 +110,7 @@ class TestFetchEIADataHappyPath:
         assert latest.crude_stocks_mb == pytest.approx(423.5)
         assert latest.refinery_utilization_pct == pytest.approx(87.4)
 
-    def test_fetched_at_is_utc_datetime(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fetched_at_is_utc_datetime(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -130,9 +122,7 @@ class TestFetchEIADataHappyPath:
         for record in result:
             assert record.fetched_at.tzinfo is not None
 
-    def test_source_defaults_to_eia(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_source_defaults_to_eia(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -143,9 +133,7 @@ class TestFetchEIADataHappyPath:
 
         assert all(r.source == "eia" for r in result)
 
-    def test_api_key_sent_in_params(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_api_key_sent_in_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "my-secret-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -158,9 +146,7 @@ class TestFetchEIADataHappyPath:
             params = c.kwargs.get("params", {})
             assert params.get("api_key") == "my-secret-key"
 
-    def test_eia_base_url_env_var_used(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_eia_base_url_env_var_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         monkeypatch.setenv("EIA_BASE_URL", "http://eia-mock.internal")
         with patch("requests.get") as mock_get:
@@ -180,9 +166,7 @@ class TestFetchEIADataHappyPath:
 
 
 class TestFetchEIADataMalformedResponse:
-    def test_empty_data_array_returns_empty_list(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_empty_data_array_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         empty = {"response": {"data": []}}
         with patch("requests.get") as mock_get:
@@ -194,9 +178,7 @@ class TestFetchEIADataMalformedResponse:
 
         assert result == []
 
-    def test_null_value_in_series_yields_none_field(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_null_value_in_series_yields_none_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         crude_with_null = {"response": {"data": [{"period": "2024-10", "value": None}]}}
         with patch("requests.get") as mock_get:
@@ -209,9 +191,7 @@ class TestFetchEIADataMalformedResponse:
         assert len(result) == 1
         assert result[0].crude_stocks_mb is None
 
-    def test_missing_period_key_skipped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_period_key_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         bad_crude = {"response": {"data": [{"value": "400.0"}]}}  # no period key
         with patch("requests.get") as mock_get:
@@ -223,9 +203,7 @@ class TestFetchEIADataMalformedResponse:
 
         assert result == []
 
-    def test_http_error_propagates(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import requests as req_mod
 
         monkeypatch.setenv("EIA_API_KEY", "test-key")


### PR DESCRIPTION
## Summary
- Implements `fetch_eia_data()` in the Event Detection Agent (issue #101)
- Fetches crude oil stocks and refinery utilization from EIA API v2, 4 weeks at a time
- Merges both series by period into `list[EIAInventoryRecord]`, sorted newest-first
- Degraded mode (returns `[]`, logs WARNING) when `EIA_API_KEY` is not set
- `EIA_BASE_URL` env var for test/CI override
- `write_eia_records()` already exists in `db.py` (merged in #114)

## Test plan
- [ ] 13 unit tests pass: happy path, degraded mode, null values, missing period key, HTTP error
- [ ] `pytest -m "not integration"` — 187 passed
- [ ] mypy strict — no issues
- [ ] ruff — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)