### PR TITLE
feat(event-detection): implement run_event_detection — orchestrate fetch, classify, persist (#105)

### DIFF
--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -23,6 +23,7 @@ import os
 from pydantic import ValidationError
 import requests
 
+from src.agents.event_detection.db import write_detected_events, write_eia_records
 from src.agents.event_detection.models import (
     ClassifyLLMResponse,
     DetectedEvent,
@@ -30,6 +31,7 @@ from src.agents.event_detection.models import (
     EventIntensity,
     EventType,
 )
+from src.core.db import get_engine
 from src.core.llm_wrapper import LLMWrapper
 from src.core.retry import with_retry
 
@@ -440,18 +442,94 @@ def classify_event(article: dict[str, object]) -> DetectedEvent | None:
     return event
 
 
+_MS_PER_SECOND: int = 1000
+
+
 def run_event_detection() -> list[DetectedEvent]:
     """
     Execute one full event detection cycle.
 
-    Returns:
-        List of DetectedEvent objects detected in this cycle.
+    Fetches articles from NewsAPI and GDELT, classifies each with the LLM,
+    persists detected events and EIA inventory records to PostgreSQL, and
+    emits a structured JSON cycle-complete log.
 
-    Raises:
-        NotImplementedError: Until implemented in issue #105.
+    Each source and DB write runs in an independent try/except — one failure
+    never aborts the others. The function never raises.
+
+    Returns:
+        List of DetectedEvent objects classified in this cycle. EIA records
+        are persisted to eia_inventory and not included in the return value.
     """
-    raise NotImplementedError(
-        "run_event_detection not yet implemented. "
-        "TODO: Orchestrate fetch_news_events, fetch_gdelt_events, classify_event, "
-        "write_detected_events. See issue #105."
+    start_time = datetime.now(tz=UTC)
+    errors: list[str] = []
+    news_articles: list[dict[str, object]] = []
+    gdelt_articles: list[dict[str, object]] = []
+
+    # --- Fetch feeds ---
+    try:
+        news_articles = fetch_news_events()
+    except Exception as exc:
+        logger.exception("fetch_news_events failed")
+        errors.append(f"fetch_news_events: {exc}")
+
+    try:
+        gdelt_articles = fetch_gdelt_events()
+    except Exception as exc:
+        logger.exception("fetch_gdelt_events failed")
+        errors.append(f"fetch_gdelt_events: {exc}")
+
+    # --- Classify articles ---
+    all_articles = news_articles + gdelt_articles
+    events: list[DetectedEvent] = []
+    for article in all_articles:
+        result = classify_event(article)
+        if result is not None:
+            events.append(result)
+
+    # --- Persist to PostgreSQL ---
+    events_written = 0
+    _engine = None
+    try:
+        _engine = get_engine()
+    except Exception as exc:
+        logger.exception("run_event_detection: failed to acquire DB engine")
+        errors.append(f"get_engine: {exc}")
+
+    if _engine is not None and events:
+        try:
+            events_written = write_detected_events(events, _engine)
+        except Exception as exc:
+            logger.exception("write_detected_events failed; events not persisted")
+            errors.append(f"write_detected_events: {exc}")
+
+    # --- Fetch and persist EIA inventory ---
+    try:
+        eia_records = fetch_eia_data()
+        if _engine is not None and eia_records:
+            try:
+                write_eia_records(eia_records, _engine)
+            except Exception as exc:
+                logger.exception("write_eia_records failed; EIA records not persisted")
+                errors.append(f"write_eia_records: {exc}")
+    except Exception as exc:
+        logger.exception("fetch_eia_data failed")
+        errors.append(f"fetch_eia_data: {exc}")
+
+    # --- Structured cycle log ---
+    end_time = datetime.now(tz=UTC)
+    duration_ms = int((end_time - start_time).total_seconds() * _MS_PER_SECOND)
+    logger.info(
+        json.dumps(
+            {
+                "event": "event_detection_cycle_complete",
+                "news_articles": len(news_articles),
+                "gdelt_articles": len(gdelt_articles),
+                "events_classified": len(events),
+                "events_written": events_written,
+                "error_count": len(errors),
+                "duration_ms": duration_ms,
+            }
+        )
     )
+
+    return events

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -527,6 +527,7 @@ def run_event_detection() -> list[DetectedEvent]:
                 "events_classified": len(events),
                 "events_written": events_written,
                 "error_count": len(errors),
+                "errors": errors,
                 "duration_ms": duration_ms,
             }
         )

--- a/tests/agents/event_detection/test_event_detection_agent.py
+++ b/tests/agents/event_detection/test_event_detection_agent.py
@@ -1,32 +1,8 @@
 """
 Unit tests for the Event Detection Agent.
 
-Coverage goal (expand per GitHub Issue):
-  - run_event_detection: returns list of DetectedEvent
-  - classify_event: correct EventType and intensity for known headlines
-  - fetch_news_events: retry behavior on API failure
+run_event_detection() tests live in test_run_event_detection.py (issue #105).
+classify_event() tests live in test_classify_event.py (issue #104).
+fetch_news_events() / fetch_gdelt_events() tests live in test_fetch_news_gdelt.py (#102/#103).
+fetch_eia_data() tests live in test_fetch_eia.py (issue #101).
 """
-
-import pytest
-
-from src.agents.event_detection.event_detection_agent import run_event_detection
-from src.agents.event_detection.models import DetectedEvent
-
-
-class TestRunEventDetection:
-    """Tests for run_event_detection() orchestration function."""
-
-    @pytest.mark.xfail(reason="Not yet implemented", strict=True)
-    def test_run_event_detection_returns_list(self) -> None:
-        """run_event_detection() must return a list of DetectedEvent instances."""
-        result = run_event_detection()
-        assert isinstance(result, list)
-        for item in result:
-            assert isinstance(item, DetectedEvent)
-
-    @pytest.mark.xfail(reason="Not yet implemented", strict=True)
-    def test_detected_event_confidence_in_range(self) -> None:
-        """All DetectedEvent confidence_score values must be in [0.0, 1.0]."""
-        result = run_event_detection()
-        for event in result:
-            assert 0.0 <= event.confidence_score <= 1.0

--- a/tests/agents/event_detection/test_run_event_detection.py
+++ b/tests/agents/event_detection/test_run_event_detection.py
@@ -261,3 +261,4 @@ class TestRunEventDetectionDBFailure:
         assert "duration_ms" in payload
         assert "events_classified" in payload
         assert "error_count" in payload
+        assert "errors" in payload

--- a/tests/agents/event_detection/test_run_event_detection.py
+++ b/tests/agents/event_detection/test_run_event_detection.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for run_event_detection() orchestration.
+
+All external calls (fetch_*, classify_event, get_engine, write_*) are mocked.
+No real API keys, network, or database required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import run_event_detection
+from src.agents.event_detection.models import (
+    DetectedEvent,
+    EventIntensity,
+    EventType,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_MODULE = "src.agents.event_detection.event_detection_agent"
+
+
+def _make_event(event_id: str = "abc123") -> DetectedEvent:
+    return DetectedEvent(
+        event_id=event_id,
+        event_type=EventType.SUPPLY_DISRUPTION,
+        description="Test event",
+        source="newsapi",
+        confidence_score=0.9,
+        intensity=EventIntensity.HIGH,
+        detected_at=datetime.now(tz=UTC),
+        affected_instruments=["CL=F"],
+    )
+
+
+def _patch_all(
+    news_return=None,
+    gdelt_return=None,
+    classify_return=None,
+    eia_return=None,
+    engine_return=None,
+    write_events_return=1,
+    news_raises=None,
+    gdelt_raises=None,
+    eia_raises=None,
+    engine_raises=None,
+    write_events_raises=None,
+):
+    """Return a context manager stack patching all external dependencies."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def _ctx():
+        news_mock = MagicMock(
+            return_value=news_return or [],
+            side_effect=news_raises,
+        )
+        gdelt_mock = MagicMock(
+            return_value=gdelt_return or [],
+            side_effect=gdelt_raises,
+        )
+        classify_mock = MagicMock(return_value=classify_return)
+        eia_mock = MagicMock(
+            return_value=eia_return or [],
+            side_effect=eia_raises,
+        )
+        engine_mock = MagicMock() if engine_return is None else engine_return
+        if engine_raises:
+            engine_mock_fn = MagicMock(side_effect=engine_raises)
+        else:
+            engine_mock_fn = MagicMock(return_value=engine_mock)
+
+        write_events_mock = MagicMock(
+            return_value=write_events_return,
+            side_effect=write_events_raises,
+        )
+        write_eia_mock = MagicMock()
+
+        with (
+            patch(f"{_MODULE}.fetch_news_events", news_mock),
+            patch(f"{_MODULE}.fetch_gdelt_events", gdelt_mock),
+            patch(f"{_MODULE}.classify_event", classify_mock),
+            patch(f"{_MODULE}.fetch_eia_data", eia_mock),
+            patch(f"{_MODULE}.get_engine", engine_mock_fn),
+            patch(f"{_MODULE}.write_detected_events", write_events_mock),
+            patch(f"{_MODULE}.write_eia_records", write_eia_mock),
+        ):
+            yield {
+                "news": news_mock,
+                "gdelt": gdelt_mock,
+                "classify": classify_mock,
+                "eia": eia_mock,
+                "engine": engine_mock_fn,
+                "write_events": write_events_mock,
+                "write_eia": write_eia_mock,
+            }
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# All-sources-success
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionSuccess:
+    def test_returns_classified_events(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            gdelt_return=[article],
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 2
+        assert all(isinstance(e, DetectedEvent) for e in result)
+
+    def test_none_from_classify_skipped(self) -> None:
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article, article],
+            classify_return=None,
+        ):
+            result = run_event_detection()
+
+        assert result == []
+
+    def test_write_detected_events_called_with_events(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+        ) as mocks:
+            run_event_detection()
+
+        mocks["write_events"].assert_called_once()
+        written_events = mocks["write_events"].call_args.args[0]
+        assert written_events == [event]
+
+    def test_eia_fetched_and_written(self) -> None:
+        from src.agents.event_detection.models import EIAInventoryRecord
+
+        eia_rec = EIAInventoryRecord(
+            period="2024-10",
+            crude_stocks_mb=420.0,
+            fetched_at=datetime.now(tz=UTC),
+        )
+        with _patch_all(eia_return=[eia_rec]) as mocks:
+            run_event_detection()
+
+        mocks["write_eia"].assert_called_once()
+
+    def test_returns_list_not_raises(self) -> None:
+        with _patch_all():
+            result = run_event_detection()
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Partial source failure
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionPartialFailure:
+    def test_news_failure_does_not_abort_gdelt(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_raises=RuntimeError("news down"),
+            gdelt_return=[article],
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+    def test_gdelt_failure_does_not_abort_news(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            gdelt_raises=RuntimeError("gdelt down"),
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+    def test_eia_failure_cycle_continues(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            eia_raises=RuntimeError("eia down"),
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# DB failure
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionDBFailure:
+    def test_db_engine_failure_events_still_returned(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            engine_raises=RuntimeError("db down"),
+        ):
+            result = run_event_detection()
+
+        assert result == [event]
+
+    def test_write_failure_events_still_returned(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            write_events_raises=RuntimeError("write failed"),
+        ):
+            result = run_event_detection()
+
+        assert result == [event]
+
+    def test_no_write_called_when_no_events(self) -> None:
+        with _patch_all(classify_return=None) as mocks:
+            run_event_detection()
+
+        mocks["write_events"].assert_not_called()
+
+    def test_structured_log_emitted(self, caplog: pytest.LogCaptureFixture) -> None:
+        import json
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            with _patch_all():
+                run_event_detection()
+
+        log_line = next(
+            (m for m in caplog.messages if "event_detection_cycle_complete" in m),
+            None,
+        )
+        assert log_line is not None
+        payload = json.loads(log_line)
+        assert "duration_ms" in payload
+        assert "events_classified" in payload
+        assert "error_count" in payload


### PR DESCRIPTION
## Summary
- Implements `run_event_detection()`, replacing the `NotImplementedError` stub (issue #105)
- Mirrors `run_ingestion()` pattern: each source fetch and DB write in independent `try/except`; never raises
- Fetches from NewsAPI, GDELT, and EIA; classifies articles via `classify_event()`; persists via `write_detected_events()` and `write_eia_records()`
- Emits structured JSON cycle-complete log: `event_detection_cycle_complete` with article/event/error/duration fields
- Replaces xfail placeholder tests now covered by `test_run_event_detection.py`

## Test plan
- [ ] 12 unit tests: all-sources-success, partial source failure, DB failure, structured log
- [ ] `pytest -m "not integration"` — 199 passed
- [ ] mypy strict — no issues
- [ ] ruff — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)