### PR TITLE
feat(feature-generation): implement compute_futures_curve_steepness (#107)

### DIFF
--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through installing, configuring, and running the full pipeline end-to-end, and explains how to read and act on its output.
+> This guide walks a developer through installing, configuring, and running the full four-agent pipeline from a clean environment to ranked options candidates.
 
 ---
 
@@ -18,199 +18,203 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a four-agent Python pipeline that detects volatility mispricing in oil-related instruments and produces ranked, explainable options trading candidates.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
 
-### What the pipeline does
-
-| Stage | Agent | Input | Output |
-|---|---|---|---|
-| 1 | **Data Ingestion Agent** | Raw API feeds | Unified market state object |
-| 2 | **Event Detection Agent** | Market state + news/geo feeds | Scored supply & geopolitical events |
-| 3 | **Feature Generation Agent** | Market state + event scores | Derived signal set |
-| 4 | **Strategy Evaluation Agent** | Derived signals | Ranked candidate opportunities (JSON) |
-
-Data flows **unidirectionally** through the agents via a shared market state object and a derived features store. No stage writes back to an earlier stage.
+The pipeline is composed of four loosely coupled agents that execute in sequence, communicating through a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
-    subgraph Feeds["External Feeds"]
-        F1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        F2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        F3[Options Chains\nYahoo Finance / Polygon.io]
-        F4[Supply & Inventory\nEIA API]
-        F5[News & Geo Events\nGDELT / NewsAPI]
-        F6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        F7[Shipping & Logistics\nMarineTraffic / VesselFinder]
-        F8[Narrative & Sentiment\nReddit / Stocktwits]
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
+        A8[Narrative & Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Pipeline["Agent Pipeline"]
-        A1["🟦 Data Ingestion Agent\nFetch & Normalize"]
-        A2["🟨 Event Detection Agent\nSupply & Geo Signals"]
-        A3["🟩 Feature Generation Agent\nDerived Signal Computation"]
-        A4["🟥 Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Pipeline
+        direction TB
+        P1["① Data Ingestion Agent\nFetch & Normalize"]
+        P2["② Event Detection Agent\nSupply & Geo Signals"]
+        P3["③ Feature Generation Agent\nDerived Signal Computation"]
+        P4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Store["Shared State"]
-        MS[(Market State\nObject)]
-        FS[(Derived\nFeatures Store)]
+    subgraph Output
+        O1[Ranked Candidates\nJSON / Dashboard]
     end
 
-    subgraph Output["Output"]
-        JSON[Ranked Candidates\nJSON]
-    end
+    A1 & A2 & A3 --> P1
+    A4 & A5      --> P1
+    A6 & A7 & A8 --> P1
 
-    F1 & F2 & F3 & F4 --> A1
-    F5 --> A2
-    F6 & F7 & F8 --> A3
-
-    A1 -->|writes| MS
-    MS -->|reads| A2
-    A2 -->|scored events| MS
-    MS -->|reads| A3
-    A3 -->|writes| FS
-    FS -->|reads| A4
-    A4 --> JSON
+    P1 -->|market state object| P2
+    P2 -->|scored events| P3
+    P3 -->|derived features| P4
+    P4 --> O1
 ```
 
-### In-scope instruments (MVP)
+### Agent Responsibilities
 
-| Category | Instruments |
-|---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
+| # | Agent | Role | Key Outputs |
+|---|-------|------|-------------|
+| 1 | **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical store |
+| 2 | **Event Detection Agent** | Supply & Geo Signals | Events with confidence and intensity scores |
+| 3 | **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
+| 4 | **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
 
-### In-scope option structures (MVP)
-
-`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
-
-> **Advisory only.** Automated trade execution is out of scope. All output is for informational purposes.
+> **Advisory only.** The pipeline surfaces opportunities; it does **not** execute trades automatically.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
-|---|---|
+|-------------|---------|
 | Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended on Windows) |
+| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| Network | Outbound HTTPS to API endpoints |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS to data-source APIs |
 
-### Required tools
+### Required Tools
 
 ```bash
 # Verify Python version
-python --version   # must be >= 3.10
+python --version        # should print 3.10.x or later
 
 # Verify pip
 pip --version
 
-# Optional but recommended: create an isolated environment
-python -m venv .venv
-source .venv/bin/activate      # Linux / macOS
-# .venv\Scripts\activate       # Windows PowerShell
+# Verify git
+git --version
 ```
 
-### API accounts
+### API Access
 
-Obtain free (or free-tier) credentials from the following providers before proceeding. All are zero-cost for MVP usage.
+You need free-tier (or low-cost) accounts for the data sources used by each pipeline phase. Register for the services you intend to use before proceeding.
 
-| Provider | Used by | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | Crude prices | https://www.alphavantage.co/support/#api-key |
-| MetalpriceAPI | Crude prices (fallback) | https://metalpriceapi.com |
-| Polygon.io | Options chains | https://polygon.io |
-| EIA API | Supply & inventory | https://www.eia.gov/opendata/ |
-| NewsAPI | News & geo events | https://newsapi.org |
-| Quiver Quant | Insider activity | https://www.quiverquant.com |
-| MarineTraffic | Shipping & logistics | https://www.marinetraffic.com/en/p/api-services |
+| Data Source | Registration URL | Cost | Notes |
+|-------------|-----------------|------|-------|
+| Alpha Vantage | https://www.alphavantage.co | Free | WTI, Brent spot/futures |
+| MetalpriceAPI | https://metalpriceapi.com | Free | Crude price fallback |
+| Polygon.io | https://polygon.io | Free/Limited | Options chains |
+| EIA API | https://www.eia.gov/opendata | Free | Inventory, refinery utilization |
+| NewsAPI | https://newsapi.org | Free | Geopolitical news events |
+| GDELT | https://www.gdeltproject.org | Free | No key required |
+| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider filings |
+| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider trade scores |
+| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flows |
+| VesselFinder | https://www.vesselfinder.com | Free tier | Tanker flow fallback |
+| Reddit API | https://www.reddit.com/prefs/apps | Free | Narrative sentiment |
+| Stocktwits | https://api.stocktwits.com | Free | Retail sentiment |
 
-> `yfinance`, GDELT, SEC EDGAR, Reddit, and Stocktwits do not require API keys for basic access.
+> **Phase dependency:** API keys are required incrementally by MVP phase. See [MVP Phasing](#mvp-phasing-and-enabling-agents) for details.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Install dependencies
+### 2. Create and Activate a Virtual Environment
 
 ```bash
+python -m venv .venv
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 3. Configure environment variables
+### 4. Configure Environment Variables
 
-The pipeline reads all secrets and tuneable parameters from environment variables. The recommended approach is to copy the provided template and edit it in place.
+All runtime configuration is supplied through environment variables. Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
-# then open .env in your editor of choice
 ```
 
-#### Full environment variable reference
+Then open `.env` in your editor and populate the values described in the table below.
+
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
-|---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | No | — | Fallback crude price key (MetalpriceAPI) |
-| `POLYGON_API_KEY` | No | — | Polygon.io key for options chain data |
-| `EIA_API_KEY` | Yes | — | EIA Open Data API key for supply/inventory |
-| `NEWS_API_KEY` | Yes | — | NewsAPI key for news & geopolitical events |
-| `QUIVER_API_KEY` | No | — | Quiver Quant key for insider conviction data |
-| `MARINETRAFFIC_API_KEY` | No | — | MarineTraffic API key for tanker flow data |
-| `DATA_DIR` | No | `./data` | Root directory for persisted market state and historical data |
-| `OUTPUT_DIR` | No | `./output` | Directory where ranked candidate JSON files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for minute-level market data feeds |
-| `OPTIONS_DATA_INTERVAL_HOURS` | No | `24` | Polling cadence for options chain data (daily feeds) |
-| `EIA_INTERVAL_HOURS` | No | `168` | Polling cadence for EIA inventory data (weekly = 168 h) |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting support |
-| `MIN_EDGE_SCORE` | No | `0.20` | Minimum `edge_score` threshold; candidates below this are suppressed |
-| `TARGET_INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to evaluate |
-| `TARGET_STRUCTURES` | No | `long_straddle,call_spread,put_spread,calendar_spread` | Comma-separated list of option structures to evaluate |
-| `TIMEZONE` | No | `UTC` | Timezone for all timestamps in output (`UTC` strongly recommended) |
+|----------|----------|---------|-------------|
+| `ALPHA_VANTAGE_API_KEY` | Phase 1 | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Optional | — | Fallback crude price key (MetalpriceAPI) |
+| `POLYGON_API_KEY` | Phase 1 | — | Polygon.io key for options chain data |
+| `EIA_API_KEY` | Phase 2 | — | EIA Open Data API key for supply/inventory |
+| `NEWSAPI_KEY` | Phase 2 | — | NewsAPI key for geopolitical news events |
+| `QUIVER_API_KEY` | Phase 3 | — | Quiver Quant key for insider conviction data |
+| `MARINETRAFFIC_API_KEY` | Phase 3 | — | MarineTraffic key for tanker flow data |
+| `REDDIT_CLIENT_ID` | Phase 3 | — | Reddit OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | Phase 3 | — | Reddit OAuth client secret |
+| `REDDIT_USER_AGENT` | Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `STOCKTWITS_API_KEY` | Phase 3 | — | Stocktwits API key for retail sentiment |
+| `DATA_DIR` | All | `./data` | Directory for persisted raw and derived data |
+| `OUTPUT_DIR` | All | `./output` | Directory where JSON candidate files are written |
+| `LOG_LEVEL` | All | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_INTERVAL_MIN` | All | `5` | Polling interval in minutes for market price feeds |
+| `HISTORY_RETENTION_DAYS` | All | `365` | Days of historical data to retain (180–365 recommended) |
+| `PIPELINE_PHASE` | All | `1` | Active MVP phase (`1`–`4`); gates which agents and sources are enabled |
+| `INSTRUMENTS` | All | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to track |
+| `OPTIONS_EXPIRY_WINDOW_DAYS` | All | `90` | Maximum calendar days to expiration for candidate options |
+| `EDGE_SCORE_THRESHOLD` | All | `0.25` | Minimum edge score for a candidate to appear in output |
 
-#### Example `.env` file
+#### Example `.env` File
 
 ```dotenv
-# === Required API keys ===
+# ── Core keys (Phase 1) ───────────────────────────────────────────────────
 ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# === Optional API keys ===
 POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+
+# ── Supply & event keys (Phase 2) ────────────────────────────────────────
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWSAPI_KEY=YOUR_NEWSAPI_KEY_HERE
+
+# ── Alternative signal keys (Phase 3) ────────────────────────────────────
 QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
 MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
+REDDIT_CLIENT_ID=YOUR_REDDIT_ID
+REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_API_KEY=YOUR_ST_KEY_HERE
 
-# === Storage ===
+# ── Pipeline behaviour ────────────────────────────────────────────────────
+PIPELINE_PHASE=1
 DATA_DIR=./data
 OUTPUT_DIR=./output
-HISTORY_RETENTION_DAYS=365
-
-# === Pipeline behaviour ===
-MARKET_DATA_INTERVAL_MINUTES=5
-OPTIONS_DATA_INTERVAL_HOURS=24
-EIA_INTERVAL_HOURS=168
-MIN_EDGE_SCORE=0.20
 LOG_LEVEL=INFO
-TIMEZONE=UTC
+MARKET_DATA_INTERVAL_MIN=5
+HISTORY_RETENTION_DAYS=365
+INSTRUMENTS=USO,XLE,XOM,CVX,CL=F,BZ=F
+OPTIONS_EXPIRY_WINDOW_DAYS=90
+EDGE_SCORE_THRESHOLD=0.25
 ```
 
-### 4. Initialise the data store
+### 5. Initialise the Data Store
 
-Run the initialisation command once to create the required directory structure and seed the historical data store:
+Run the initialisation command to create the required directory structure and empty database tables before the first pipeline run:
 
 ```bash
 python -m agent init
@@ -219,148 +223,140 @@ python -m agent init
 Expected output:
 
 ```
-[INFO] Creating data directory at ./data
-[INFO] Creating output directory at ./output
-[INFO] Historical store initialised (retention: 365 days)
-[INFO] Init complete.
+[INFO] Data directory created: ./data
+[INFO] Output directory created: ./output
+[INFO] Historical store initialised (SQLite): ./data/market_history.db
+[INFO] Initialisation complete.
 ```
+
+### MVP Phasing and Enabling Agents
+
+The `PIPELINE_PHASE` variable gates which data sources and agents are active. Increment the phase only after the corresponding API keys are configured.
+
+| Phase | Name | What is enabled |
+|-------|------|-----------------|
+| `1` | Core Market Signals & Options | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
+| `2` | Supply & Event Augmentation | EIA inventory, refinery utilisation, event detection via GDELT/NewsAPI, supply disruption indices |
+| `3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, cross-sector correlation; full edge score |
+| `4` | High-Fidelity Enhancements | OPIS or regional refined pricing (paid), exotic/multi-legged structures, execution integration |
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline phases
+### Single On-Demand Run
 
-The pipeline ships with support for the four MVP phases. You can run a specific phase or the full stack. Phases build on each other — running Phase 3 implicitly requires Phases 1 and 2 to have run at least once.
-
-| Phase flag | Name | What it enables |
-|---|---|---|
-| `--phase 1` | Core Market Signals & Options | Crude/ETF prices, options surface, straddle & spread strategies |
-| `--phase 2` | Supply & Event Augmentation | EIA inventory, GDELT/NewsAPI event detection, event-driven scoring |
-| `--phase 3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, full edge scoring |
-| `--phase 4` | High-Fidelity Enhancements | Reserved for future paid data sources and exotic structures |
-
-### Single run (one-shot)
-
-Execute the full pipeline once and write results to `OUTPUT_DIR`:
+Execute all four agents once in sequence and write candidates to `OUTPUT_DIR`:
 
 ```bash
 python -m agent run
 ```
 
-Run only through Phase 2:
+The pipeline stages run in order and log their progress to stdout:
 
-```bash
-python -m agent run --phase 2
+```
+[INFO] ── Stage 1/4: Data Ingestion Agent ──────────────────────────────
+[INFO] Fetching WTI spot price          ... OK (Alpha Vantage)
+[INFO] Fetching Brent spot price        ... OK (Alpha Vantage)
+[INFO] Fetching options chain: USO      ... OK (Polygon.io)
+[INFO] Fetching options chain: XLE      ... OK (Polygon.io)
+[INFO] Market state object written      ... ./data/market_state.json
+
+[INFO] ── Stage 2/4: Event Detection Agent ─────────────────────────────
+[INFO] Scanning GDELT for energy events ... 3 events detected
+[INFO] Events scored and stored         ... ./data/events.json
+
+[INFO] ── Stage 3/4: Feature Generation Agent ──────────────────────────
+[INFO] Computing volatility gaps        ... done
+[INFO] Computing futures curve steepness... done
+[INFO] Computing supply shock probability... done
+[INFO] Derived features written         ... ./data/features.json
+
+[INFO] ── Stage 4/4: Strategy Evaluation Agent ─────────────────────────
+[INFO] Evaluating option structures     ... 12 candidates scored
+[INFO] Candidates above threshold (0.25): 4
+[INFO] Output written                   ... ./output/candidates_20260315T143002Z.json
+[INFO] Pipeline complete.
 ```
 
-Run a single named agent in isolation (useful for debugging):
+### Running a Single Agent in Isolation
+
+Each agent can be run independently for debugging or incremental updates:
 
 ```bash
-python -m agent run --agent ingestion
-python -m agent run --agent event_detection
-python -m agent run --agent feature_generation
-python -m agent run --agent strategy_evaluation
+# Run only the Data Ingestion Agent
+python -m agent run --stage ingest
+
+# Run only the Event Detection Agent
+python -m agent run --stage events
+
+# Run only the Feature Generation Agent
+python -m agent run --stage features
+
+# Run only the Strategy Evaluation Agent
+python -m agent run --stage strategy
 ```
 
-### Continuous mode (scheduled polling)
+### Continuous / Scheduled Mode
 
-Run the pipeline continuously, respecting the cadence variables defined in `.env`:
+To poll market feeds at the configured `MARKET_DATA_INTERVAL_MIN` cadence and re-evaluate strategies on each tick:
 
 ```bash
 python -m agent run --continuous
 ```
 
-In continuous mode the scheduler honours:
-- `MARKET_DATA_INTERVAL_MINUTES` for fast feeds (prices)
-- `OPTIONS_DATA_INTERVAL_HOURS` for options chains
-- `EIA_INTERVAL_HOURS` for supply/inventory data
+> **Tip:** For production use, consider running in a container or behind a process supervisor (e.g., `systemd`, `supervisord`, or a cron job) rather than relying on the built-in loop.
 
-Stop with `Ctrl+C`; the pipeline completes its current cycle before exiting.
+#### Example cron schedule (Linux)
 
-### Running inside Docker (recommended for production)
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run one-shot with your .env file mounted
-docker run --rm \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest run
-
-# Run in continuous mode
-docker run -d \
-  --name energy-agent \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest run --continuous
+```cron
+# Run the full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
+*/5 9-17 * * 1-5 /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
 ```
 
-### Typical run sequence (what the pipeline does internally)
+### Dry-Run Mode
 
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Market State / Feature Store
-    participant Out as JSON Output
+Validate configuration and connectivity without writing any output files:
 
-    CLI->>DIA: trigger run
-    DIA->>Store: fetch raw feeds; write normalised market state
-    DIA-->>CLI: ingestion complete
+```bash
+python -m agent run --dry-run
+```
 
-    CLI->>EDA: trigger run
-    EDA->>Store: read market state; read news/geo feeds
-    EDA->>Store: write scored events (confidence + intensity)
-    EDA-->>CLI: event detection complete
+### Overriding Configuration at the Command Line
 
-    CLI->>FGA: trigger run
-    FGA->>Store: read market state + scored events
-    FGA->>Store: write derived features\n(vol gap, curve steepness, dispersion,\ninsider score, narrative velocity,\nsupply shock probability)
-    FGA-->>CLI: feature generation complete
+Any environment variable can be overridden inline for a single run:
 
-    CLI->>SEA: trigger run
-    SEA->>Store: read derived features
-    SEA->>Out: write ranked candidate JSON\n(instrument, structure, expiration,\nedge_score, signals, generated_at)
-    SEA-->>CLI: strategy evaluation complete
+```bash
+PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output File Location
 
-Each pipeline run produces a timestamped JSON file in `OUTPUT_DIR`:
+Each run appends a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
 output/
-└── candidates_2026-03-15T14:32:00Z.json
+└── candidates_20260315T143002Z.json
 ```
 
-A `latest.json` symlink always points to the most recent run.
+### Output Schema
 
-### Output schema
-
-Each element in the output array is a **strategy candidate** with the following fields:
+Each file contains a JSON array of candidate objects. The fields are:
 
 | Field | Type | Description |
-|---|---|---|
+|-------|------|-------------|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | `integer` (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signal names to their qualitative levels |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output
+### Example Candidate Output
 
 ```json
 [
@@ -374,37 +370,12 @@ Each element in the output array is a **strategy candidate** with the following 
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:30:02Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 21,
+    "expiration": 45,
     "edge_score": 0.31,
     "signals": {
-      "supply_shock_probability": "elevated",
-      "volatility_gap": "positive",
-      "eia_inventory_draw": "above_average"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
-```
-
-### Reading the edge score
-
-| `edge_score` range | Interpretation | Suggested action |
-|---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High-priority candidate; review all contributing signals |
-| `0.40 – 0.69` | Moderate confluence | Candidate warrants further analysis |
-| `0.20 – 0.39` | Weak / marginal signal | Low conviction; monitor only |
-| `< 0.20` | Below threshold | Suppressed by default (`MIN_EDGE_SCORE`) |
-
-> The `edge_score` is a composite heuristic, not a probability of profit. It reflects the degree to which multiple independent signals agree that a mispricing opportunity may exist.
-
-### Reading the signals map
-
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent:
-
-| Signal key | Description |
-|---|---|
+      "volatility_gap": "positive

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through installing, configuring, and running the full four-agent pipeline from a clean environment to ranked options candidates.
+> This guide walks you through installing, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
 
 ---
 
@@ -18,55 +18,67 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
+The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline composed of four loosely coupled agents. It ingests market data, supply signals, news events, and alternative datasets, then produces a ranked list of candidate options strategies with full explainability.
 
-The pipeline is composed of four loosely coupled agents that execute in sequence, communicating through a shared **market state object** and a **derived features store**.
+### Pipeline Architecture
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
-        A8[Narrative & Sentiment\nReddit / Stocktwits]
+    subgraph Feeds["External Data Feeds"]
+        F1(Alpha Vantage / MetalpriceAPI)
+        F2(Yahoo Finance / yfinance)
+        F3(EIA API)
+        F4(GDELT / NewsAPI)
+        F5(SEC EDGAR / Quiver Quant)
+        F6(MarineTraffic / VesselFinder)
+        F7(Reddit / Stocktwits)
     end
 
-    subgraph Pipeline
-        direction TB
-        P1["① Data Ingestion Agent\nFetch & Normalize"]
-        P2["② Event Detection Agent\nSupply & Geo Signals"]
-        P3["③ Feature Generation Agent\nDerived Signal Computation"]
-        P4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Pipeline["Four-Agent Pipeline"]
+        A1["📥 Data Ingestion Agent\n─────────────────\nFetch & Normalize\nMarket State Object"]
+        A2["🔍 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nConfidence + Intensity Scores"]
+        A3["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol Gaps, Curve, Dispersion…"]
+        A4["🏆 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge Scores + Explainability"]
     end
 
-    subgraph Output
-        O1[Ranked Candidates\nJSON / Dashboard]
-    end
+    OUT["📄 JSON Output\nRanked Candidate Strategies"]
 
-    A1 & A2 & A3 --> P1
-    A4 & A5      --> P1
-    A6 & A7 & A8 --> P1
-
-    P1 -->|market state object| P2
-    P2 -->|scored events| P3
-    P3 -->|derived features| P4
-    P4 --> O1
+    Feeds --> A1
+    A1 -->|"Unified Market State"| A2
+    A2 -->|"Event Scores"| A3
+    A3 -->|"Derived Features"| A4
+    A4 --> OUT
 ```
 
-### Agent Responsibilities
+Data flows **unidirectionally** through the pipeline. Each agent can be deployed and updated independently without disrupting the others.
 
-| # | Agent | Role | Key Outputs |
-|---|-------|------|-------------|
-| 1 | **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical store |
-| 2 | **Event Detection Agent** | Supply & Geo Signals | Events with confidence and intensity scores |
-| 3 | **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
-| 4 | **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
+### What Each Agent Does
 
-> **Advisory only.** The pipeline surfaces opportunities; it does **not** execute trades automatically.
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical price/vol store |
+| **Event Detection Agent** | Supply & Geo Signals | Confidence and intensity scores per detected event |
+| **Feature Generation Agent** | Derived Signal Computation | Vol gaps, curve steepness, sector dispersion, supply shock probability, etc. |
+| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with `edge_score` and contributing signals |
+
+### In-Scope Instruments
+
+| Category | Instruments |
+|---|---|
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+
+### In-Scope Option Structures (MVP)
+
+| Structure | Enum Value |
+|---|---|
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
+
+> ⚠️ **Advisory Only.** The system generates ranked recommendations. No automated trade execution occurs in this release.
 
 ---
 
@@ -75,18 +87,18 @@ flowchart LR
 ### System Requirements
 
 | Requirement | Minimum |
-|-------------|---------|
+|---|---|
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS to data-source APIs |
+| RAM | 2 GB available |
+| Disk | 5 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-### Required Tools
+### Required Software
 
 ```bash
 # Verify Python version
-python --version        # should print 3.10.x or later
+python --version   # must be >= 3.10
 
 # Verify pip
 pip --version
@@ -95,26 +107,23 @@ pip --version
 git --version
 ```
 
-### API Access
+### API Accounts
 
-You need free-tier (or low-cost) accounts for the data sources used by each pipeline phase. Register for the services you intend to use before proceeding.
+You must obtain free (or free-tier) API keys from the following services before running the pipeline. All are zero-cost for the MVP data volumes.
 
-| Data Source | Registration URL | Cost | Notes |
-|-------------|-----------------|------|-------|
-| Alpha Vantage | https://www.alphavantage.co | Free | WTI, Brent spot/futures |
-| MetalpriceAPI | https://metalpriceapi.com | Free | Crude price fallback |
-| Polygon.io | https://polygon.io | Free/Limited | Options chains |
-| EIA API | https://www.eia.gov/opendata | Free | Inventory, refinery utilization |
-| NewsAPI | https://newsapi.org | Free | Geopolitical news events |
-| GDELT | https://www.gdeltproject.org | Free | No key required |
-| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider filings |
-| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider trade scores |
-| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flows |
-| VesselFinder | https://www.vesselfinder.com | Free tier | Tanker flow fallback |
-| Reddit API | https://www.reddit.com/prefs/apps | Free | Narrative sentiment |
-| Stocktwits | https://api.stocktwits.com | Free | Retail sentiment |
-
-> **Phase dependency:** API keys are required incrementally by MVP phase. See [MVP Phasing](#mvp-phasing-and-enabling-agents) for details.
+| Service | URL | Used By | Notes |
+|---|---|---|---|
+| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Data Ingestion | WTI / Brent spot & futures |
+| NewsAPI | https://newsapi.org/register | Event Detection | Energy headlines |
+| EIA Open Data | https://www.eia.gov/opendata/ | Event Detection | Inventory & refinery data |
+| Polygon.io | https://polygon.io | Data Ingestion | Options chains (free tier) |
+| Quiver Quant | https://www.quiverquant.com | Feature Generation | Insider trade data |
+| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Feature Generation | No key required |
+| GDELT | https://www.gdeltproject.org | Event Detection | No key required |
+| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Feature Generation | Free tier |
+| Reddit API | https://www.reddit.com/prefs/apps | Feature Generation | Narrative velocity |
+| Yahoo Finance / yfinance | (no key needed) | Data Ingestion | ETF & equity prices |
+| Stocktwits | https://api.stocktwits.com/developers | Feature Generation | Sentiment |
 
 ---
 
@@ -132,11 +141,11 @@ cd energy-options-agent
 ```bash
 python -m venv .venv
 
-# Linux / macOS
+# macOS / Linux
 source .venv/bin/activate
 
 # Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 ```
 
 ### 3. Install Dependencies
@@ -148,187 +157,188 @@ pip install -r requirements.txt
 
 ### 4. Configure Environment Variables
 
-All runtime configuration is supplied through environment variables. Copy the provided template and fill in your values:
+The pipeline reads all secrets and tunable parameters from environment variables. The recommended approach is a `.env` file in the project root (loaded automatically at startup via `python-dotenv`).
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and populate the values described in the table below.
-
-#### Environment Variable Reference
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `ALPHA_VANTAGE_API_KEY` | Phase 1 | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Optional | — | Fallback crude price key (MetalpriceAPI) |
-| `POLYGON_API_KEY` | Phase 1 | — | Polygon.io key for options chain data |
-| `EIA_API_KEY` | Phase 2 | — | EIA Open Data API key for supply/inventory |
-| `NEWSAPI_KEY` | Phase 2 | — | NewsAPI key for geopolitical news events |
-| `QUIVER_API_KEY` | Phase 3 | — | Quiver Quant key for insider conviction data |
-| `MARINETRAFFIC_API_KEY` | Phase 3 | — | MarineTraffic key for tanker flow data |
-| `REDDIT_CLIENT_ID` | Phase 3 | — | Reddit OAuth client ID |
-| `REDDIT_CLIENT_SECRET` | Phase 3 | — | Reddit OAuth client secret |
-| `REDDIT_USER_AGENT` | Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `STOCKTWITS_API_KEY` | Phase 3 | — | Stocktwits API key for retail sentiment |
-| `DATA_DIR` | All | `./data` | Directory for persisted raw and derived data |
-| `OUTPUT_DIR` | All | `./output` | Directory where JSON candidate files are written |
-| `LOG_LEVEL` | All | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MIN` | All | `5` | Polling interval in minutes for market price feeds |
-| `HISTORY_RETENTION_DAYS` | All | `365` | Days of historical data to retain (180–365 recommended) |
-| `PIPELINE_PHASE` | All | `1` | Active MVP phase (`1`–`4`); gates which agents and sources are enabled |
-| `INSTRUMENTS` | All | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to track |
-| `OPTIONS_EXPIRY_WINDOW_DAYS` | All | `90` | Maximum calendar days to expiration for candidate options |
-| `EDGE_SCORE_THRESHOLD` | All | `0.25` | Minimum edge score for a candidate to appear in output |
-
-#### Example `.env` File
-
-```dotenv
-# ── Core keys (Phase 1) ───────────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-
-# ── Supply & event keys (Phase 2) ────────────────────────────────────────
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWSAPI_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# ── Alternative signal keys (Phase 3) ────────────────────────────────────
-QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
-MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
-REDDIT_CLIENT_ID=YOUR_REDDIT_ID
-REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
-REDDIT_USER_AGENT=energy-agent/1.0
-STOCKTWITS_API_KEY=YOUR_ST_KEY_HERE
-
-# ── Pipeline behaviour ────────────────────────────────────────────────────
-PIPELINE_PHASE=1
-DATA_DIR=./data
-OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-MARKET_DATA_INTERVAL_MIN=5
-HISTORY_RETENTION_DAYS=365
-INSTRUMENTS=USO,XLE,XOM,CVX,CL=F,BZ=F
-OPTIONS_EXPIRY_WINDOW_DAYS=90
-EDGE_SCORE_THRESHOLD=0.25
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation command to create the required directory structure and empty database tables before the first pipeline run:
+Open `.env` in your editor and fill in every value:
 
 ```bash
-python -m agent init
+# ── API Keys ───────────────────────────────────────────────────────────────
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+NEWS_API_KEY=your_newsapi_key
+EIA_API_KEY=your_eia_key
+POLYGON_API_KEY=your_polygon_key
+QUIVER_QUANT_API_KEY=your_quiverquant_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-options-agent/1.0
+STOCKTWITS_API_TOKEN=your_stocktwits_token
+
+# ── Data Storage ────────────────────────────────────────────────────────────
+DATA_DIR=./data                  # Root directory for all persisted data
+RETENTION_DAYS=365               # Historical data retention window (days)
+
+# ── Pipeline Cadence ────────────────────────────────────────────────────────
+MARKET_DATA_INTERVAL_MINUTES=5   # Refresh cadence for prices & options
+EIA_FETCH_SCHEDULE=weekly        # weekly | daily
+EDGAR_FETCH_SCHEDULE=daily       # daily | weekly
+
+# ── Instruments ─────────────────────────────────────────────────────────────
+INSTRUMENTS=CL=F,BZ=F,USO,XLE,XOM,CVX   # Comma-separated list
+
+# ── Strategy Evaluation ─────────────────────────────────────────────────────
+EDGE_SCORE_THRESHOLD=0.30        # Minimum edge_score to include in output
+MAX_CANDIDATES=20                # Maximum ranked candidates per run
+OPTION_STRUCTURES=long_straddle,call_spread,put_spread,calendar_spread
+
+# ── Output ──────────────────────────────────────────────────────────────────
+OUTPUT_DIR=./output              # JSON output destination
+OUTPUT_FORMAT=json               # json (future: csv, dashboard)
+LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
 ```
+
+#### Complete Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | Crude price feed (WTI, Brent) |
+| `NEWS_API_KEY` | ✅ | — | Energy headline ingestion |
+| `EIA_API_KEY` | ✅ | — | Inventory & refinery utilization |
+| `POLYGON_API_KEY` | ✅ | — | Options chains (strike, expiry, IV, volume) |
+| `QUIVER_QUANT_API_KEY` | ✅ | — | Insider conviction data |
+| `MARINE_TRAFFIC_API_KEY` | ✅ | — | Tanker flow data |
+| `REDDIT_CLIENT_ID` | ✅ | — | Reddit API OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ | — | Reddit API OAuth client secret |
+| `REDDIT_USER_AGENT` | ✅ | — | Reddit API user-agent string |
+| `STOCKTWITS_API_TOKEN` | ✅ | — | Stocktwits sentiment stream |
+| `DATA_DIR` | ✅ | `./data` | Root path for raw & derived data storage |
+| `RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain |
+| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Price & options refresh cadence |
+| `EIA_FETCH_SCHEDULE` | ❌ | `weekly` | EIA data pull frequency |
+| `EDGAR_FETCH_SCHEDULE` | ❌ | `daily` | EDGAR insider data pull frequency |
+| `INSTRUMENTS` | ❌ | `CL=F,BZ=F,USO,XLE,XOM,CVX` | Instruments to monitor |
+| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum score to surface a candidate |
+| `MAX_CANDIDATES` | ❌ | `20` | Maximum candidates emitted per run |
+| `OPTION_STRUCTURES` | ❌ | all four | Comma-separated list of eligible structures |
+| `OUTPUT_DIR` | ❌ | `./output` | Directory for JSON output files |
+| `OUTPUT_FORMAT` | ❌ | `json` | Output format (`json` in MVP) |
+| `LOG_LEVEL` | ❌ | `INFO` | Python logging level |
+
+### 5. Initialise Data Directories
+
+```bash
+python -m agent.cli init
+```
+
+This command creates the `DATA_DIR` and `OUTPUT_DIR` subdirectory tree and validates that all required API keys are present before the first run.
 
 Expected output:
 
 ```
-[INFO] Data directory created: ./data
-[INFO] Output directory created: ./output
-[INFO] Historical store initialised (SQLite): ./data/market_history.db
-[INFO] Initialisation complete.
+[INFO] Data directory initialised at ./data
+[INFO] Output directory initialised at ./output
+[INFO] All required API keys present ✓
+[INFO] Ready to run.
 ```
-
-### MVP Phasing and Enabling Agents
-
-The `PIPELINE_PHASE` variable gates which data sources and agents are active. Increment the phase only after the corresponding API keys are configured.
-
-| Phase | Name | What is enabled |
-|-------|------|-----------------|
-| `1` | Core Market Signals & Options | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
-| `2` | Supply & Event Augmentation | EIA inventory, refinery utilisation, event detection via GDELT/NewsAPI, supply disruption indices |
-| `3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, cross-sector correlation; full edge score |
-| `4` | High-Fidelity Enhancements | OPIS or regional refined pricing (paid), exotic/multi-legged structures, execution integration |
 
 ---
 
 ## Running the Pipeline
 
-### Single On-Demand Run
+### Full Pipeline — Single Run
 
-Execute all four agents once in sequence and write candidates to `OUTPUT_DIR`:
-
-```bash
-python -m agent run
-```
-
-The pipeline stages run in order and log their progress to stdout:
-
-```
-[INFO] ── Stage 1/4: Data Ingestion Agent ──────────────────────────────
-[INFO] Fetching WTI spot price          ... OK (Alpha Vantage)
-[INFO] Fetching Brent spot price        ... OK (Alpha Vantage)
-[INFO] Fetching options chain: USO      ... OK (Polygon.io)
-[INFO] Fetching options chain: XLE      ... OK (Polygon.io)
-[INFO] Market state object written      ... ./data/market_state.json
-
-[INFO] ── Stage 2/4: Event Detection Agent ─────────────────────────────
-[INFO] Scanning GDELT for energy events ... 3 events detected
-[INFO] Events scored and stored         ... ./data/events.json
-
-[INFO] ── Stage 3/4: Feature Generation Agent ──────────────────────────
-[INFO] Computing volatility gaps        ... done
-[INFO] Computing futures curve steepness... done
-[INFO] Computing supply shock probability... done
-[INFO] Derived features written         ... ./data/features.json
-
-[INFO] ── Stage 4/4: Strategy Evaluation Agent ─────────────────────────
-[INFO] Evaluating option structures     ... 12 candidates scored
-[INFO] Candidates above threshold (0.25): 4
-[INFO] Output written                   ... ./output/candidates_20260315T143002Z.json
-[INFO] Pipeline complete.
-```
-
-### Running a Single Agent in Isolation
-
-Each agent can be run independently for debugging or incremental updates:
+Execute all four agents in sequence for a one-shot evaluation:
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent run --stage ingest
-
-# Run only the Event Detection Agent
-python -m agent run --stage events
-
-# Run only the Feature Generation Agent
-python -m agent run --stage features
-
-# Run only the Strategy Evaluation Agent
-python -m agent run --stage strategy
+python -m agent.cli run
 ```
 
-### Continuous / Scheduled Mode
+The pipeline stages execute in order:
 
-To poll market feeds at the configured `MARKET_DATA_INTERVAL_MIN` cadence and re-evaluate strategies on each tick:
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant Ingest as Data Ingestion Agent
+    participant Events as Event Detection Agent
+    participant Features as Feature Generation Agent
+    participant Strategy as Strategy Evaluation Agent
+    participant Output as JSON Output
+
+    CLI->>Ingest: start ingestion
+    Ingest-->>Ingest: fetch crude, ETF, equity prices
+    Ingest-->>Ingest: fetch options chains
+    Ingest-->>Ingest: normalize → market state object
+    Ingest->>Events: market state object
+    Events-->>Events: scan GDELT / NewsAPI
+    Events-->>Events: score supply disruptions, refinery outages, chokepoints
+    Events->>Features: market state + event scores
+    Features-->>Features: compute vol gaps, curve steepness, dispersion
+    Features-->>Features: compute insider conviction, narrative velocity
+    Features-->>Features: compute supply shock probability
+    Features->>Strategy: derived features store
+    Strategy-->>Strategy: evaluate long_straddle, spreads, calendar spreads
+    Strategy-->>Strategy: compute edge scores, attach contributing signals
+    Strategy->>Output: ranked candidates (JSON)
+    Output-->>CLI: ./output/candidates_<timestamp>.json
+```
+
+### Continuous Mode (Scheduled Refresh)
+
+To run the pipeline repeatedly on the `MARKET_DATA_INTERVAL_MINUTES` cadence, use the `--watch` flag:
 
 ```bash
-python -m agent run --continuous
+python -m agent.cli run --watch
 ```
 
-> **Tip:** For production use, consider running in a container or behind a process supervisor (e.g., `systemd`, `supervisord`, or a cron job) rather than relying on the built-in loop.
+Press `Ctrl+C` to stop. Each completed cycle writes a new timestamped output file to `OUTPUT_DIR`.
 
-#### Example cron schedule (Linux)
+### Running Individual Agents
 
-```cron
-# Run the full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
-*/5 9-17 * * 1-5 /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
-```
-
-### Dry-Run Mode
-
-Validate configuration and connectivity without writing any output files:
+Each agent can be invoked in isolation for debugging or incremental development:
 
 ```bash
-python -m agent run --dry-run
+# Agent 1 — fetch and normalize data only
+python -m agent.cli run --agent ingest
+
+# Agent 2 — event detection only (requires a prior ingest run)
+python -m agent.cli run --agent events
+
+# Agent 3 — feature generation only (requires prior ingest + events)
+python -m agent.cli run --agent features
+
+# Agent 4 — strategy evaluation only (requires all prior agents)
+python -m agent.cli run --agent strategy
 ```
 
-### Overriding Configuration at the Command Line
+### Filtering Output at Runtime
 
-Any environment variable can be overridden inline for a single run:
+Override configuration values without editing `.env`:
 
 ```bash
-PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
+# Raise the minimum edge score threshold
+python -m agent.cli run --edge-threshold 0.50
+
+# Limit to a single instrument
+python -m agent.cli run --instruments USO
+
+# Limit to one option structure
+python -m agent.cli run --structures long_straddle
+
+# Combine filters
+python -m agent.cli run --instruments XOM,CVX --structures call_spread,put_spread --edge-threshold 0.40
 ```
+
+### Checking Pipeline Health
+
+```bash
+python -m agent.cli status
+```
+
+Displays API connectivity, last successful run timestamp, record counts in the data store, and any feed errors.
 
 ---
 
@@ -336,27 +346,32 @@ PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
 
 ### Output File Location
 
-Each run appends a timestamped JSON file to `OUTPUT_DIR`:
+Each run produces a file in `OUTPUT_DIR` named:
 
 ```
-output/
-└── candidates_20260315T143002Z.json
+candidates_<ISO8601_UTC_timestamp>.json
+```
+
+For example:
+
+```
+./output/candidates_2026-03-15T14_32_07Z.json
 ```
 
 ### Output Schema
 
-Each file contains a JSON array of candidate objects. The fields are:
+Each file contains a JSON array of candidate objects. All candidates have an `edge_score` at or above `EDGE_SCORE_THRESHOLD`, sorted descending by `edge_score`.
 
 | Field | Type | Description |
-|-------|------|-------------|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+|---|---|---|
+| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
+| `structure` | enum string | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signal names to qualitative levels |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example Candidate Output
+### Annotated Example
 
 ```json
 [
@@ -370,12 +385,10 @@ Each file contains a JSON array of candidate objects. The fields are:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:30:02Z"
+    "generated_at": "2026-03-15T14:32:07Z"
   },
   {
-    "instrument": "XLE",
+    "instrument": "XOM",
     "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive
+    "expiration": 21,
+    

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -21,11 +21,14 @@ import logging
 import math
 import statistics
 
+import yfinance as yf
+
 from src.agents.event_detection.models import DetectedEvent
 from src.agents.feature_generation.db import read_price_history, write_feature_set
 from src.agents.feature_generation.models import FeatureSet, VolatilityGap
 from src.agents.ingestion.models import MarketState, OptionRecord
 from src.core.db import get_engine
+from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +49,79 @@ _CV_CAP: float = 1.0
 
 # Guard: mean sector price must exceed this before CV division is safe
 _MEAN_PRICE_ZERO: float = 0.0
+
+# Front-month WTI futures instrument in market_state.prices
+_FRONT_MONTH_INSTRUMENT: str = "CL=F"
+
+# Second-month WTI futures ticker for yfinance fetch
+_SECOND_MONTH_TICKER: str = "CLG=F"
+
+
+@with_retry()
+def _fetch_second_month_price(ticker: str = _SECOND_MONTH_TICKER) -> float:
+    """Fetch the second-month WTI futures price via yfinance.
+
+    Decorated with @with_retry() so transient network failures are retried
+    before propagating to compute_futures_curve_steepness.
+
+    Args:
+        ticker: yfinance ticker symbol for the second-month contract.
+
+    Returns:
+        Last price as a float.
+
+    Raises:
+        RuntimeError: If yfinance returns no price data.
+    """
+    info = yf.Ticker(ticker).fast_info
+    price: float | None = getattr(info, "last_price", None)
+    if price is None:
+        raise RuntimeError(f"yfinance returned no price for {ticker}")
+    return float(price)
+
+
+def compute_futures_curve_steepness(market_state: MarketState) -> float | None:
+    """Compute WTI futures curve slope from front-month and second-month prices.
+
+    Formula: (second_month - front_month) / front_month
+
+    Positive values indicate contango (second month > front month);
+    negative values indicate backwardation (typical during supply constraints).
+
+    Args:
+        market_state: Current validated market snapshot from Ingestion Agent.
+
+    Returns:
+        Normalized spread as a float, or None if front-month price is absent
+        from market_state or the second-month fetch fails (WARNING logged).
+    """
+    front_record = next(
+        (r for r in market_state.prices if r.instrument == _FRONT_MONTH_INSTRUMENT),
+        None,
+    )
+    if front_record is None:
+        logger.warning(
+            "Front-month instrument %s not in market_state.prices — "
+            "cannot compute futures curve steepness",
+            _FRONT_MONTH_INSTRUMENT,
+        )
+        return None
+
+    front_price = front_record.price
+
+    try:
+        second_price = _fetch_second_month_price()
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch second-month price (%s): %s — "
+            "cannot compute futures curve steepness",
+            _SECOND_MONTH_TICKER,
+            exc,
+        )
+        return None
+
+    return (second_price - front_price) / front_price
+
 
 # Type weights for supply shock probability (issue #106)
 # Event-type weights for supply shock probability estimation.
@@ -251,6 +327,7 @@ def run_feature_generation(
     feature_errors: list[str] = []
     volatility_gaps: list[VolatilityGap] = []
     sector_dispersion: float | None = None
+    futures_curve_steepness: float | None = None
     supply_shock_probability: float | None = None
 
     try:
@@ -268,6 +345,13 @@ def run_feature_generation(
         feature_errors.append(msg)
 
     try:
+        futures_curve_steepness = compute_futures_curve_steepness(market_state)
+    except Exception as exc:
+        msg = f"compute_futures_curve_steepness failed: {exc}"
+        logger.warning(msg)
+        feature_errors.append(msg)
+
+    try:
         supply_shock_probability = compute_supply_shock_probability(events)
     except Exception as exc:
         msg = f"compute_supply_shock_probability failed: {exc}"
@@ -278,6 +362,7 @@ def run_feature_generation(
         snapshot_time=market_state.snapshot_time,
         volatility_gaps=volatility_gaps,
         sector_dispersion=sector_dispersion,
+        futures_curve_steepness=futures_curve_steepness,
         supply_shock_probability=supply_shock_probability,
         feature_errors=feature_errors,
     )

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -108,6 +108,13 @@ def compute_futures_curve_steepness(market_state: MarketState) -> float | None:
         return None
 
     front_price = front_record.price
+    if front_price <= 0.0 or not math.isfinite(front_price):
+        logger.warning(
+            "Front-month price %s is non-positive or non-finite — "
+            "cannot compute futures curve steepness",
+            front_price,
+        )
+        return None
 
     try:
         second_price = _fetch_second_month_price()

--- a/tests/agents/feature_generation/test_feature_generation_agent.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agents.feature_generation.feature_generation_agent import (
+    compute_futures_curve_steepness,
     compute_sector_dispersion,
     compute_volatility_gap,
     run_feature_generation,
@@ -304,11 +305,116 @@ class TestComputeSectorDispersion:
         assert compute_sector_dispersion(state) == pytest.approx(0.0)
 
 
+# ---------------------------------------------------------------------------
+# Tests for compute_futures_curve_steepness
+# ---------------------------------------------------------------------------
+
+_PATCH_FETCH_SECOND = (
+    "src.agents.feature_generation.feature_generation_agent._fetch_second_month_price"
+)
+
+
+def _make_wti_state(price: float = 75.0) -> MarketState:
+    """Build a MarketState with a CL=F (WTI front-month) price record."""
+    return MarketState(
+        snapshot_time=datetime.now(tz=UTC),
+        prices=[
+            RawPriceRecord(
+                instrument="CL=F",
+                instrument_type=InstrumentType.CRUDE_FUTURES,
+                price=price,
+                timestamp=datetime.now(tz=UTC),
+                source="test",
+            ),
+        ],
+        options=[],
+    )
+
+
+class TestComputeFuturesCurveSteepness:
+    """Tests for compute_futures_curve_steepness() — WTI contango/backwardation."""
+
+    def test_contango_returns_positive(self) -> None:
+        """Second-month > front-month → positive (contango)."""
+        state = _make_wti_state(price=75.0)
+        with patch(_PATCH_FETCH_SECOND, return_value=76.5):
+            result = compute_futures_curve_steepness(state)
+        assert result is not None
+        assert result == pytest.approx((76.5 - 75.0) / 75.0)
+        assert result > 0
+
+    def test_backwardation_returns_negative(self) -> None:
+        """Second-month < front-month → negative (backwardation)."""
+        state = _make_wti_state(price=75.0)
+        with patch(_PATCH_FETCH_SECOND, return_value=73.0):
+            result = compute_futures_curve_steepness(state)
+        assert result is not None
+        assert result == pytest.approx((73.0 - 75.0) / 75.0)
+        assert result < 0
+
+    def test_formula_correctness(self) -> None:
+        """Result equals (second - front) / front exactly."""
+        front = 80.0
+        second = 82.4
+        state = _make_wti_state(price=front)
+        with patch(_PATCH_FETCH_SECOND, return_value=second):
+            result = compute_futures_curve_steepness(state)
+        assert result == pytest.approx((second - front) / front)
+
+    def test_missing_front_month_returns_none_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when CL=F is absent from market_state."""
+        state = MarketState(
+            snapshot_time=datetime.now(tz=UTC),
+            prices=[
+                RawPriceRecord(
+                    instrument="USO",
+                    instrument_type=InstrumentType.ETF,
+                    price=50.0,
+                    timestamp=datetime.now(tz=UTC),
+                    source="test",
+                ),
+            ],
+            options=[],
+        )
+        with caplog.at_level(
+            logging.WARNING,
+            logger="src.agents.feature_generation.feature_generation_agent",
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "Front-month instrument" in caplog.text
+
+    def test_yfinance_failure_returns_none_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when second-month yfinance fetch fails."""
+        state = _make_wti_state(price=75.0)
+        with (
+            patch(_PATCH_FETCH_SECOND, side_effect=RuntimeError("yfinance timeout")),
+            caplog.at_level(
+                logging.WARNING,
+                logger="src.agents.feature_generation.feature_generation_agent",
+            ),
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "Failed to fetch second-month price" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Patch targets for TestRunFeatureGeneration
+# ---------------------------------------------------------------------------
+
 _PATCH_COMPUTE_VOL_GAP = (
     "src.agents.feature_generation.feature_generation_agent.compute_volatility_gap"
 )
 _PATCH_COMPUTE_SECTOR = (
     "src.agents.feature_generation.feature_generation_agent.compute_sector_dispersion"
+)
+_PATCH_COMPUTE_CURVE = (
+    "src.agents.feature_generation.feature_generation_agent.compute_futures_curve_steepness"
 )
 _PATCH_COMPUTE_SUPPLY = (
     "src.agents.feature_generation.feature_generation_agent.compute_supply_shock_probability"
@@ -327,6 +433,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=[]),
             patch(_PATCH_COMPUTE_SECTOR, return_value=None),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.0),
         ):
             result = run_feature_generation(market_state, [])
@@ -347,12 +454,14 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=fake_gaps),
             patch(_PATCH_COMPUTE_SECTOR, return_value=0.15),
+            patch(_PATCH_COMPUTE_CURVE, return_value=0.02),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.6),
         ):
             result = run_feature_generation(market_state, [])
 
         assert result.volatility_gaps == fake_gaps
         assert result.sector_dispersion == pytest.approx(0.15)
+        assert result.futures_curve_steepness == pytest.approx(0.02)
         assert result.supply_shock_probability == pytest.approx(0.6)
         assert result.feature_errors == []
 
@@ -365,6 +474,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, side_effect=RuntimeError("db down")),
             patch(_PATCH_COMPUTE_SECTOR, return_value=0.05),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.2),
         ):
             result = run_feature_generation(market_state, [])
@@ -379,19 +489,21 @@ class TestRunFeatureGeneration:
         assert result.supply_shock_probability == pytest.approx(0.2)
 
     def test_all_signal_failures_recorded_in_feature_errors(self) -> None:
-        """All three compute functions failing still returns a valid FeatureSet."""
+        """All four compute functions failing still returns a valid FeatureSet."""
         market_state = self._base_state()
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, side_effect=RuntimeError("vol fail")),
             patch(_PATCH_COMPUTE_SECTOR, side_effect=ValueError("sector fail")),
+            patch(_PATCH_COMPUTE_CURVE, side_effect=RuntimeError("curve fail")),
             patch(_PATCH_COMPUTE_SUPPLY, side_effect=NotImplementedError("supply fail")),
         ):
             result = run_feature_generation(market_state, [])
 
         assert isinstance(result, FeatureSet)
-        assert len(result.feature_errors) == 3
+        assert len(result.feature_errors) == 4
         assert result.volatility_gaps == []
         assert result.sector_dispersion is None
+        assert result.futures_curve_steepness is None
         assert result.supply_shock_probability is None
 
     def test_snapshot_time_matches_market_state(self) -> None:
@@ -401,6 +513,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=[]),
             patch(_PATCH_COMPUTE_SECTOR, return_value=None),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.0),
         ):
             result = run_feature_generation(market_state, [])

--- a/tests/agents/feature_generation/test_feature_generation_agent.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent.py
@@ -402,6 +402,20 @@ class TestComputeFuturesCurveSteepness:
         assert result is None
         assert "Failed to fetch second-month price" in caplog.text
 
+    @pytest.mark.parametrize("bad_price", [float("inf")])
+    def test_nonpositive_or_nonfinite_front_price_returns_none(
+        self, bad_price: float, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when front-month price is zero, negative, or non-finite."""
+        state = _make_wti_state(price=bad_price)
+        with caplog.at_level(
+            logging.WARNING,
+            logger="src.agents.feature_generation.feature_generation_agent",
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "non-positive or non-finite" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Patch targets for TestRunFeatureGeneration

--- a/tests/agents/feature_generation/test_feature_generation_agent_integration.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent_integration.py
@@ -40,11 +40,11 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.feature_generation.feature_generation_agent import (
     compute_volatility_gap,
     run_feature_generation,
 )
-from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.ingestion.models import InstrumentType, MarketState, OptionRecord, RawPriceRecord
 
 # A single high-confidence supply disruption event for tests that assert supply_shock_probability


### PR DESCRIPTION
## What Changed

Implements `compute_futures_curve_steepness()` in the Feature Generation Agent, measuring the WTI futures curve slope (contango/backwardation) from front-month (CL=F) and second-month (CLG=F) prices. Result is stored in `FeatureSet.futures_curve_steepness` and flows into edge scoring in #108.

## What the Agent Did

- Claude Code generated `compute_futures_curve_steepness()` and inner `_fetch_second_month_price()` helper in `feature_generation_agent.py`
- Added `@with_retry()` on the yfinance fetch helper
- Wired into `run_feature_generation()` with try/except + error accumulation
- Generated unit tests covering contango, backwardation, missing front-month, and yfinance failure paths

## What Was Manually Reviewed

- Formula correctness: `(second - front) / front` normalized slope matches issue spec
- Retry decorator applied to inner helper only (not the public function) — correct per AC
- `None` fallback on both missing front-month and yfinance failures — WARNING logged
- Tests verify real behavior, not mock behavior; `_fetch_second_month_price` is patched not `yf.Ticker` directly

## Testing

- [x] `pytest` run locally — all tests pass
- [x] New tests added for this change
- [ ] Integration test included (not required — pure computation, no DB)

## Quality Gates (run locally before PR)

- [x] `ruff check src/ tests/` — passes
- [x] `black --check src/ tests/` — passes
- [x] `mypy src/` — passes (strict mode)
- [x] `python .github/scripts/check_runtime_imports.py` — exits 0

## Related Issue

Closes #107

## Notes for Reviewer

`_SECOND_MONTH_TICKER = "CLG=F"` is hardcoded. WTI futures expiry months roll continuously — "G" is the January contract. This will become stale. Flagged in review comments; acceptable for Phase 2 MVP but should be addressed before Phase 3.