### PR TITLE
feat(strategy-eval): add Phase 2 supply shock and curve steepness to edge scoring (#108)

### DIFF
--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide walks you through installing, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
+> **Version 1.0 · March 2026**
+> This guide walks you through installing, configuring, and running the full four-agent pipeline from a clean environment to a ranked list of options trading opportunities.
 
 ---
 
@@ -18,48 +18,44 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline composed of four loosely coupled agents. It ingests market data, supply signals, news events, and alternative datasets, then produces a ranked list of candidate options strategies with full explainability.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**. It is advisory only — no trades are placed automatically.
 
 ### Pipeline Architecture
 
+The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**. Data flows in one direction only.
+
 ```mermaid
 flowchart LR
-    subgraph Feeds["External Data Feeds"]
-        F1(Alpha Vantage / MetalpriceAPI)
-        F2(Yahoo Finance / yfinance)
-        F3(EIA API)
-        F4(GDELT / NewsAPI)
-        F5(SEC EDGAR / Quiver Quant)
-        F6(MarineTraffic / VesselFinder)
-        F7(Reddit / Stocktwits)
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[EIA Supply Data]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nEDGAR / Quiver Quant]
+        A7[Shipping Data\nMarineTraffic / VesselFinder]
+        A8[Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Pipeline["Four-Agent Pipeline"]
-        A1["📥 Data Ingestion Agent\n─────────────────\nFetch & Normalize\nMarket State Object"]
-        A2["🔍 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nConfidence + Intensity Scores"]
-        A3["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol Gaps, Curve, Dispersion…"]
-        A4["🏆 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge Scores + Explainability"]
+    subgraph Pipeline
+        B[Data Ingestion Agent\nFetch & Normalize]
+        C[Event Detection Agent\nSupply & Geo Signals]
+        D[Feature Generation Agent\nDerived Signal Computation]
+        E[Strategy Evaluation Agent\nOpportunity Ranking]
     end
 
-    OUT["📄 JSON Output\nRanked Candidate Strategies"]
+    subgraph Output
+        F[Ranked Candidates\nJSON / Dashboard]
+    end
 
-    Feeds --> A1
-    A1 -->|"Unified Market State"| A2
-    A2 -->|"Event Scores"| A3
-    A3 -->|"Derived Features"| A4
-    A4 --> OUT
+    A1 & A2 & A3 & A4 --> B
+    A5 --> C
+    A6 & A7 & A8 --> D
+    B --> C
+    C --> D
+    D --> E
+    E --> F
 ```
-
-Data flows **unidirectionally** through the pipeline. Each agent can be deployed and updated independently without disrupting the others.
-
-### What Each Agent Does
-
-| Agent | Role | Key Outputs |
-|---|---|---|
-| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical price/vol store |
-| **Event Detection Agent** | Supply & Geo Signals | Confidence and intensity scores per detected event |
-| **Feature Generation Agent** | Derived Signal Computation | Vol gaps, curve steepness, sector dispersion, supply shock probability, etc. |
-| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with `edge_score` and contributing signals |
 
 ### In-Scope Instruments
 
@@ -78,7 +74,7 @@ Data flows **unidirectionally** through the pipeline. Each agent can be deployed
 | Put Spread | `put_spread` |
 | Calendar Spread | `calendar_spread` |
 
-> ⚠️ **Advisory Only.** The system generates ranked recommendations. No automated trade execution occurs in this release.
+> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
@@ -88,42 +84,49 @@ Data flows **unidirectionally** through the pipeline. Each agent can be deployed
 
 | Requirement | Minimum |
 |---|---|
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| RAM | 2 GB available |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| RAM | 2 GB |
 | Disk | 5 GB free (for 6–12 months of historical data) |
 | Network | Outbound HTTPS access to all data source APIs |
 
-### Required Software
+### Required Accounts & API Keys
+
+Register for free-tier accounts at each provider before proceeding. All sources listed below have a free or free-limited tier sufficient for MVP operation.
+
+| Provider | Used By | Sign-up URL | Notes |
+|---|---|---|---|
+| Alpha Vantage or MetalpriceAPI | Data Ingestion | https://www.alphavantage.co / https://metalpriceapi.com | WTI & Brent spot/futures |
+| Polygon.io | Data Ingestion | https://polygon.io | Options chains; free tier is limited |
+| EIA Open Data | Data Ingestion | https://www.eia.gov/opendata | Inventory & refinery data |
+| NewsAPI | Event Detection | https://newsapi.org | Energy headlines |
+| GDELT | Event Detection | https://www.gdeltproject.org | Geopolitical events; no key required |
+| SEC EDGAR | Feature Generation | https://www.sec.gov/developer | Insider activity; no key required |
+| Quiver Quant | Feature Generation | https://www.quiverquant.com | Insider conviction; free tier available |
+| MarineTraffic or VesselFinder | Feature Generation | https://www.marinetraffic.com | Tanker flows; free tier |
+| Reddit (PRAW) | Feature Generation | https://www.reddit.com/prefs/apps | Narrative/sentiment velocity |
+
+### Python Dependencies
+
+Install dependencies into a virtual environment:
 
 ```bash
-# Verify Python version
-python --version   # must be >= 3.10
-
-# Verify pip
-pip --version
-
-# Verify git
-git --version
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install -r requirements.txt
 ```
 
-### API Accounts
+A minimal `requirements.txt` should include:
 
-You must obtain free (or free-tier) API keys from the following services before running the pipeline. All are zero-cost for the MVP data volumes.
-
-| Service | URL | Used By | Notes |
-|---|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Data Ingestion | WTI / Brent spot & futures |
-| NewsAPI | https://newsapi.org/register | Event Detection | Energy headlines |
-| EIA Open Data | https://www.eia.gov/opendata/ | Event Detection | Inventory & refinery data |
-| Polygon.io | https://polygon.io | Data Ingestion | Options chains (free tier) |
-| Quiver Quant | https://www.quiverquant.com | Feature Generation | Insider trade data |
-| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Feature Generation | No key required |
-| GDELT | https://www.gdeltproject.org | Event Detection | No key required |
-| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Feature Generation | Free tier |
-| Reddit API | https://www.reddit.com/prefs/apps | Feature Generation | Narrative velocity |
-| Yahoo Finance / yfinance | (no key needed) | Data Ingestion | ETF & equity prices |
-| Stocktwits | https://api.stocktwits.com/developers | Feature Generation | Sentiment |
+```text
+yfinance>=0.2
+requests>=2.31
+pandas>=2.0
+numpy>=1.26
+praw>=7.7
+python-dotenv>=1.0
+```
 
 ---
 
@@ -136,209 +139,213 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create the Environment File
 
-```bash
-python -m venv .venv
-
-# macOS / Linux
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.\.venv\Scripts\Activate.ps1
-```
-
-### 3. Install Dependencies
-
-```bash
-pip install --upgrade pip
-pip install -r requirements.txt
-```
-
-### 4. Configure Environment Variables
-
-The pipeline reads all secrets and tunable parameters from environment variables. The recommended approach is a `.env` file in the project root (loaded automatically at startup via `python-dotenv`).
+The pipeline reads all secrets and tuneable parameters from environment variables. Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value:
+Then open `.env` in your editor and populate each variable described in the table below.
 
-```bash
-# ── API Keys ───────────────────────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-NEWS_API_KEY=your_newsapi_key
-EIA_API_KEY=your_eia_key
-POLYGON_API_KEY=your_polygon_key
-QUIVER_QUANT_API_KEY=your_quiverquant_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=energy-options-agent/1.0
-STOCKTWITS_API_TOKEN=your_stocktwits_token
+### Environment Variables Reference
 
-# ── Data Storage ────────────────────────────────────────────────────────────
-DATA_DIR=./data                  # Root directory for all persisted data
-RETENTION_DAYS=365               # Historical data retention window (days)
+All variables are loaded at startup. Variables marked **Required** will cause the pipeline to exit immediately if absent. Variables marked **Optional** have defaults that are safe for MVP use.
 
-# ── Pipeline Cadence ────────────────────────────────────────────────────────
-MARKET_DATA_INTERVAL_MINUTES=5   # Refresh cadence for prices & options
-EIA_FETCH_SCHEDULE=weekly        # weekly | daily
-EDGAR_FETCH_SCHEDULE=daily       # daily | weekly
-
-# ── Instruments ─────────────────────────────────────────────────────────────
-INSTRUMENTS=CL=F,BZ=F,USO,XLE,XOM,CVX   # Comma-separated list
-
-# ── Strategy Evaluation ─────────────────────────────────────────────────────
-EDGE_SCORE_THRESHOLD=0.30        # Minimum edge_score to include in output
-MAX_CANDIDATES=20                # Maximum ranked candidates per run
-OPTION_STRUCTURES=long_straddle,call_spread,put_spread,calendar_spread
-
-# ── Output ──────────────────────────────────────────────────────────────────
-OUTPUT_DIR=./output              # JSON output destination
-OUTPUT_FORMAT=json               # json (future: csv, dashboard)
-LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
-```
-
-#### Complete Environment Variable Reference
+#### Data Ingestion Agent
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | Crude price feed (WTI, Brent) |
-| `NEWS_API_KEY` | ✅ | — | Energy headline ingestion |
-| `EIA_API_KEY` | ✅ | — | Inventory & refinery utilization |
-| `POLYGON_API_KEY` | ✅ | — | Options chains (strike, expiry, IV, volume) |
-| `QUIVER_QUANT_API_KEY` | ✅ | — | Insider conviction data |
-| `MARINE_TRAFFIC_API_KEY` | ✅ | — | Tanker flow data |
-| `REDDIT_CLIENT_ID` | ✅ | — | Reddit API OAuth client ID |
-| `REDDIT_CLIENT_SECRET` | ✅ | — | Reddit API OAuth client secret |
-| `REDDIT_USER_AGENT` | ✅ | — | Reddit API user-agent string |
-| `STOCKTWITS_API_TOKEN` | ✅ | — | Stocktwits sentiment stream |
-| `DATA_DIR` | ✅ | `./data` | Root path for raw & derived data storage |
-| `RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain |
-| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Price & options refresh cadence |
-| `EIA_FETCH_SCHEDULE` | ❌ | `weekly` | EIA data pull frequency |
-| `EDGAR_FETCH_SCHEDULE` | ❌ | `daily` | EDGAR insider data pull frequency |
-| `INSTRUMENTS` | ❌ | `CL=F,BZ=F,USO,XLE,XOM,CVX` | Instruments to monitor |
-| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum score to surface a candidate |
-| `MAX_CANDIDATES` | ❌ | `20` | Maximum candidates emitted per run |
-| `OPTION_STRUCTURES` | ❌ | all four | Comma-separated list of eligible structures |
-| `OUTPUT_DIR` | ❌ | `./output` | Directory for JSON output files |
-| `OUTPUT_FORMAT` | ❌ | `json` | Output format (`json` in MVP) |
-| `LOG_LEVEL` | ❌ | `INFO` | Python logging level |
+| `ALPHA_VANTAGE_API_KEY` | Required* | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Required* | — | API key for MetalpriceAPI crude feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chains |
+| `EIA_API_KEY` | Required | — | API key for EIA supply/inventory data |
+| `PRICE_REFRESH_INTERVAL_SEC` | Optional | `60` | Market price polling cadence in seconds |
+| `EIA_REFRESH_INTERVAL_SEC` | Optional | `86400` | EIA data polling cadence (default: daily) |
+| `HISTORICAL_RETENTION_DAYS` | Optional | `365` | Days of raw history to retain on disk |
 
-### 5. Initialise Data Directories
+> \* Provide at least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY`.
+
+#### Event Detection Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NEWS_API_KEY` | Required | — | API key for NewsAPI energy headlines |
+| `GDELT_ENABLED` | Optional | `true` | Enable GDELT geopolitical feed (no key needed) |
+| `EVENT_CONFIDENCE_THRESHOLD` | Optional | `0.5` | Minimum confidence score to surface an event |
+| `EVENT_INTENSITY_THRESHOLD` | Optional | `0.3` | Minimum intensity score to surface an event |
+
+#### Feature Generation Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `QUIVER_API_KEY` | Optional | — | API key for Quiver Quant insider conviction data |
+| `REDDIT_CLIENT_ID` | Optional | — | Reddit PRAW client ID for sentiment velocity |
+| `REDDIT_CLIENT_SECRET` | Optional | — | Reddit PRAW client secret |
+| `REDDIT_USER_AGENT` | Optional | `energy-agent/1.0` | Reddit PRAW user agent string |
+| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
+| `VESSEL_FINDER_API_KEY` | Optional | — | Alternative tanker data source key |
+
+#### Strategy Evaluation Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MIN_EDGE_SCORE` | Optional | `0.30` | Minimum edge score for a candidate to appear in output |
+| `MAX_CANDIDATES` | Optional | `20` | Maximum number of ranked candidates to emit per run |
+| `DEFAULT_EXPIRATION_DAYS` | Optional | `30` | Default target expiration when not overridden by signal |
+
+#### Output & Storage
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OUTPUT_DIR` | Optional | `./output` | Directory where JSON output files are written |
+| `DATA_STORE_DIR` | Optional | `./data` | Directory for historical raw and derived data |
+| `LOG_LEVEL` | Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+
+### 3. Verify Configuration
+
+Run the built-in config check before your first full run:
 
 ```bash
-python -m agent.cli init
+python -m agent.cli check-config
 ```
 
-This command creates the `DATA_DIR` and `OUTPUT_DIR` subdirectory tree and validates that all required API keys are present before the first run.
-
-Expected output:
+Expected output when all required variables are present:
 
 ```
-[INFO] Data directory initialised at ./data
-[INFO] Output directory initialised at ./output
-[INFO] All required API keys present ✓
-[INFO] Ready to run.
+[OK] Data Ingestion Agent     — all required keys present
+[OK] Event Detection Agent    — all required keys present
+[OK] Feature Generation Agent — optional keys: QUIVER_API_KEY missing (non-fatal)
+[OK] Strategy Evaluation Agent
+[OK] Output directories       — ./output, ./data created
+Configuration check passed.
 ```
+
+Missing optional keys produce `[WARN]` lines and are non-fatal. Missing required keys produce `[FAIL]` and abort the check.
+
+### 4. Initialize the Data Store
+
+Create the on-disk historical store and run an initial backfill:
+
+```bash
+python -m agent.cli init-store --backfill-days 30
+```
+
+This fetches up to 30 days of historical price, options, and inventory data. Use `--backfill-days 365` to build a full year of history for backtesting purposes (takes longer and consumes more API quota).
 
 ---
 
 ## Running the Pipeline
 
-### Full Pipeline — Single Run
+### Pipeline Execution Flow
 
-Execute all four agents in sequence for a one-shot evaluation:
+```mermaid
+sequenceDiagram
+    participant CLI as CLI / Scheduler
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant Store as Data Store
+    participant Out as JSON Output
+
+    CLI->>DIA: run(instruments, refresh_interval)
+    DIA->>Store: write market_state object
+    DIA-->>EDA: market_state ready signal
+
+    EDA->>Store: read market_state
+    EDA->>EDA: score events (confidence, intensity)
+    EDA->>Store: write event_scores
+    EDA-->>FGA: events ready signal
+
+    FGA->>Store: read market_state + event_scores
+    FGA->>FGA: compute derived signals
+    FGA->>Store: write features_store
+    FGA-->>SEA: features ready signal
+
+    SEA->>Store: read features_store
+    SEA->>SEA: evaluate & rank candidates
+    SEA->>Out: write ranked_candidates.json
+    SEA-->>CLI: pipeline complete
+```
+
+### Single Run (One-Shot)
+
+Execute the full four-agent pipeline once and write results to `./output`:
 
 ```bash
 python -m agent.cli run
 ```
 
-The pipeline stages execute in order:
-
-```mermaid
-sequenceDiagram
-    participant CLI
-    participant Ingest as Data Ingestion Agent
-    participant Events as Event Detection Agent
-    participant Features as Feature Generation Agent
-    participant Strategy as Strategy Evaluation Agent
-    participant Output as JSON Output
-
-    CLI->>Ingest: start ingestion
-    Ingest-->>Ingest: fetch crude, ETF, equity prices
-    Ingest-->>Ingest: fetch options chains
-    Ingest-->>Ingest: normalize → market state object
-    Ingest->>Events: market state object
-    Events-->>Events: scan GDELT / NewsAPI
-    Events-->>Events: score supply disruptions, refinery outages, chokepoints
-    Events->>Features: market state + event scores
-    Features-->>Features: compute vol gaps, curve steepness, dispersion
-    Features-->>Features: compute insider conviction, narrative velocity
-    Features-->>Features: compute supply shock probability
-    Features->>Strategy: derived features store
-    Strategy-->>Strategy: evaluate long_straddle, spreads, calendar spreads
-    Strategy-->>Strategy: compute edge scores, attach contributing signals
-    Strategy->>Output: ranked candidates (JSON)
-    Output-->>CLI: ./output/candidates_<timestamp>.json
-```
-
-### Continuous Mode (Scheduled Refresh)
-
-To run the pipeline repeatedly on the `MARKET_DATA_INTERVAL_MINUTES` cadence, use the `--watch` flag:
+To override the output directory for this run:
 
 ```bash
-python -m agent.cli run --watch
+python -m agent.cli run --output-dir /tmp/eo-results
 ```
 
-Press `Ctrl+C` to stop. Each completed cycle writes a new timestamped output file to `OUTPUT_DIR`.
+### Continuous Mode
+
+Run the pipeline on a repeating cadence driven by `PRICE_REFRESH_INTERVAL_SEC`:
+
+```bash
+python -m agent.cli run --continuous
+```
+
+Press `Ctrl+C` to stop gracefully. The pipeline will finish the current cycle before exiting.
 
 ### Running Individual Agents
 
-Each agent can be invoked in isolation for debugging or incremental development:
+Each agent can be executed in isolation for development or debugging:
 
 ```bash
-# Agent 1 — fetch and normalize data only
-python -m agent.cli run --agent ingest
+# Data Ingestion only
+python -m agent.cli run --agent ingestion
 
-# Agent 2 — event detection only (requires a prior ingest run)
-python -m agent.cli run --agent events
+# Event Detection only (reads existing market_state from store)
+python -m agent.cli run --agent event-detection
 
-# Agent 3 — feature generation only (requires prior ingest + events)
-python -m agent.cli run --agent features
+# Feature Generation only
+python -m agent.cli run --agent feature-generation
 
-# Agent 4 — strategy evaluation only (requires all prior agents)
-python -m agent.cli run --agent strategy
+# Strategy Evaluation only
+python -m agent.cli run --agent strategy-evaluation
 ```
 
-### Filtering Output at Runtime
+### Selecting MVP Phase
 
-Override configuration values without editing `.env`:
+The pipeline respects the phased rollout defined in the system design. Use `--phase` to limit which data sources and signals are active:
+
+| Flag | Phase | What Is Active |
+|---|---|---|
+| `--phase 1` | Core Market Signals | Crude benchmarks, USO/XLE prices, IV surface, long straddles & spreads |
+| `--phase 2` | Supply & Event Augmentation | Phase 1 + EIA data, GDELT/NewsAPI event detection, supply disruption index |
+| `--phase 3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider data, Reddit/Stocktwits sentiment, shipping data |
+| `--phase 4` | High-Fidelity Enhancements | Phase 3 + OPIS pricing, exotic structures (when implemented) |
 
 ```bash
-# Raise the minimum edge score threshold
-python -m agent.cli run --edge-threshold 0.50
-
-# Limit to a single instrument
-python -m agent.cli run --instruments USO
-
-# Limit to one option structure
-python -m agent.cli run --structures long_straddle
-
-# Combine filters
-python -m agent.cli run --instruments XOM,CVX --structures call_spread,put_spread --edge-threshold 0.40
+# Run Phase 2 pipeline
+python -m agent.cli run --phase 2
 ```
 
-### Checking Pipeline Health
+The default is `--phase 3` (all currently implemented signals).
+
+### Scheduled Execution (cron example)
+
+To run the pipeline every 5 minutes via cron:
 
 ```bash
-python -m agent.cli status
+crontab -e
 ```
 
-Displays API connectivity, last successful run timestamp, record counts in the data store, and any feed errors.
+Add the following line (adjust paths as needed):
+
+```cron
+*/5 * * * * /home/user/energy-options-agent/.venv/bin/python \
+    -m agent.cli run \
+    --output-dir /home/user/energy-options-agent/output \
+    >> /home/user/energy-options-agent/logs/pipeline.log 2>&1
+```
 
 ---
 
@@ -346,49 +353,69 @@ Displays API connectivity, last successful run timestamp, record counts in the d
 
 ### Output File Location
 
-Each run produces a file in `OUTPUT_DIR` named:
+Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
-candidates_<ISO8601_UTC_timestamp>.json
+output/
+└── ranked_candidates_20260315T142301Z.json
 ```
 
-For example:
-
-```
-./output/candidates_2026-03-15T14_32_07Z.json
-```
+A symlink `output/latest.json` always points to the most recent file.
 
 ### Output Schema
 
-Each file contains a JSON array of candidate objects. All candidates have an `edge_score` at or above `EDGE_SCORE_THRESHOLD`, sorted descending by `edge_score`.
+Each element in the output array is a **strategy candidate**:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
-| `structure` | enum string | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signal names to qualitative levels |
+| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum string | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | integer (days) | Target expiration in calendar days from evaluation date |
+| `edge_score` | float `[0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signals and their assessed levels |
 | `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Annotated Example
+### Example Output File
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
+{
+  "generated_at": "2026-03-15T14:23:01Z",
+  "phase": 3,
+  "candidate_count": 4,
+  "candidates": [
+    {
+      "instrument": "USO",
+      "structure": "long_straddle",
+      "expiration": 30,
+      "edge_score": 0.72,
+      "signals": {
+        "tanker_disruption_index": "high",
+        "volatility_gap": "positive",
+        "narrative_velocity": "rising",
+        "supply_shock_probability": "elevated"
+      },
+      "generated_at": "2026-03-15T14:23:01Z"
     },
-    "generated_at": "2026-03-15T14:32:07Z"
-  },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 21,
-    
+    {
+      "instrument": "XLE",
+      "structure": "call_spread",
+      "expiration": 21,
+      "edge_score": 0.51,
+      "signals": {
+        "volatility_gap": "positive",
+        "sector_dispersion": "high",
+        "insider_conviction": "bullish"
+      },
+      "generated_at": "2026-03-15T14:23:01Z"
+    },
+    {
+      "instrument": "CL=F",
+      "structure": "put_spread",
+      "expiration": 14,
+      "edge_score": 0.44,
+      "signals": {
+        "futures_curve_steepness": "contango_widening",
+        "eia_inventory_surprise": "bearish",
+        "narrative_velocity": "stable"
+      },
+      "generated_at": "2026

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full four-agent pipeline from a clean environment to a ranked list of options trading opportunities.
+> **Version 1.0 • March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline from a clean environment to ranked options candidates.
 
 ---
 
@@ -18,115 +18,82 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**. It is advisory only — no trades are placed automatically.
+The **Energy Options Opportunity Agent** is a four-agent Python pipeline that surfaces volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**.
 
 ### Pipeline Architecture
 
-The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**. Data flows in one direction only.
-
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[EIA Supply Data]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nEDGAR / Quiver Quant]
-        A7[Shipping Data\nMarineTraffic / VesselFinder]
-        A8[Sentiment\nReddit / Stocktwits]
+    subgraph Agents
+        A["🛢️ Data Ingestion Agent\nFetch & Normalize"]
+        B["📡 Event Detection Agent\nSupply & Geo Signals"]
+        C["⚙️ Feature Generation Agent\nDerived Signal Computation"]
+        D["🏆 Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Pipeline
-        B[Data Ingestion Agent\nFetch & Normalize]
-        C[Event Detection Agent\nSupply & Geo Signals]
-        D[Feature Generation Agent\nDerived Signal Computation]
-        E[Strategy Evaluation Agent\nOpportunity Ranking]
-    end
+    RAW["Raw Feeds\n(prices, options chains,\nnews, EIA, EDGAR,\nshipping, sentiment)"]
+    MS["Shared Market\nState Object"]
+    FS["Derived\nFeatures Store"]
+    OUT["Ranked Candidates\n(JSON output)"]
 
-    subgraph Output
-        F[Ranked Candidates\nJSON / Dashboard]
-    end
-
-    A1 & A2 & A3 & A4 --> B
-    A5 --> C
-    A6 & A7 & A8 --> D
-    B --> C
-    C --> D
-    D --> E
-    E --> F
+    RAW --> A
+    A -->|normalised| MS
+    MS --> B
+    B -->|event scores| MS
+    MS --> C
+    C -->|derived signals| FS
+    FS --> D
+    D --> OUT
 ```
 
-### In-Scope Instruments
+Data flows **unidirectionally**: raw feeds → normalised market state → event scores → derived features → ranked strategy candidates. Each agent is independently deployable, so you can update or replace any stage without disrupting the rest of the pipeline.
+
+### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
 ### In-Scope Option Structures (MVP)
 
-| Structure | Enum Value |
-|---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
+`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
 
-> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
+> **Advisory only.** The system produces recommendations; it does **not** execute trades automatically.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### Runtime Requirements
 
-| Requirement | Minimum |
-|---|---|
-| Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 5 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| Requirement | Minimum version | Notes |
+|---|---|---|
+| Python | 3.10+ | Tested on 3.11 |
+| pip | 23+ | or use `pipenv` / `poetry` |
+| Git | 2.x | for cloning the repo |
+| Docker *(optional)* | 24+ | for containerised deployment |
 
-### Required Accounts & API Keys
+### External API Accounts
 
-Register for free-tier accounts at each provider before proceeding. All sources listed below have a free or free-limited tier sufficient for MVP operation.
+Obtain free-tier credentials for each service before configuring the pipeline. All sources listed below have free or limited free tiers.
 
-| Provider | Used By | Sign-up URL | Notes |
-|---|---|---|---|
-| Alpha Vantage or MetalpriceAPI | Data Ingestion | https://www.alphavantage.co / https://metalpriceapi.com | WTI & Brent spot/futures |
-| Polygon.io | Data Ingestion | https://polygon.io | Options chains; free tier is limited |
-| EIA Open Data | Data Ingestion | https://www.eia.gov/opendata | Inventory & refinery data |
-| NewsAPI | Event Detection | https://newsapi.org | Energy headlines |
-| GDELT | Event Detection | https://www.gdeltproject.org | Geopolitical events; no key required |
-| SEC EDGAR | Feature Generation | https://www.sec.gov/developer | Insider activity; no key required |
-| Quiver Quant | Feature Generation | https://www.quiverquant.com | Insider conviction; free tier available |
-| MarineTraffic or VesselFinder | Feature Generation | https://www.marinetraffic.com | Tanker flows; free tier |
-| Reddit (PRAW) | Feature Generation | https://www.reddit.com/prefs/apps | Narrative/sentiment velocity |
+| Service | Used for | Sign-up URL |
+|---|---|---|
+| Alpha Vantage | WTI / Brent spot & futures prices | <https://www.alphavantage.co/support/#api-key> |
+| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required (public) |
+| Polygon.io *(optional)* | Higher-quality options data | <https://polygon.io> |
+| EIA API | Inventory & refinery utilisation | <https://www.eia.gov/opendata/register.php> |
+| GDELT | News & geopolitical events | No key required (public) |
+| NewsAPI | News headlines | <https://newsapi.org/register> |
+| SEC EDGAR | Insider trade filings | No key required (public) |
+| Quiver Quant *(optional)* | Parsed insider conviction data | <https://www.quiverquant.com> |
+| MarineTraffic / VesselFinder | Tanker flow data | Free tier; register at respective sites |
+| Reddit API | Retail sentiment | <https://www.reddit.com/prefs/apps> |
+| Stocktwits | Narrative velocity | <https://api.stocktwits.com/developers/apps/new> |
 
-### Python Dependencies
-
-Install dependencies into a virtual environment:
-
-```bash
-python -m venv .venv
-source .venv/bin/activate        # Windows: .venv\Scripts\activate
-pip install --upgrade pip
-pip install -r requirements.txt
-```
-
-A minimal `requirements.txt` should include:
-
-```text
-yfinance>=0.2
-requests>=2.31
-pandas>=2.0
-numpy>=1.26
-praw>=7.7
-python-dotenv>=1.0
-```
+> **Tip:** Phase 1 (core market signals) only requires **Alpha Vantage** and **yfinance**. You can run a partial pipeline without the remaining keys by setting later-phase features to disabled (see [Setup & Configuration](#setup--configuration)).
 
 ---
 
@@ -139,100 +106,96 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create the Environment File
+### 2. Create a Virtual Environment
 
-The pipeline reads all secrets and tuneable parameters from environment variables. Copy the provided template and fill in your values:
+```bash
+python -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows PowerShell
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 4. Configure Environment Variables
+
+Copy the template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and populate each variable described in the table below.
+Open `.env` in your editor and set each variable. The full reference table is below.
 
-### Environment Variables Reference
-
-All variables are loaded at startup. Variables marked **Required** will cause the pipeline to exit immediately if absent. Variables marked **Optional** have defaults that are safe for MVP use.
-
-#### Data Ingestion Agent
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Required* | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Required* | — | API key for MetalpriceAPI crude feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chains |
-| `EIA_API_KEY` | Required | — | API key for EIA supply/inventory data |
-| `PRICE_REFRESH_INTERVAL_SEC` | Optional | `60` | Market price polling cadence in seconds |
-| `EIA_REFRESH_INTERVAL_SEC` | Optional | `86400` | EIA data polling cadence (default: daily) |
-| `HISTORICAL_RETENTION_DAYS` | Optional | `365` | Days of raw history to retain on disk |
+| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for WTI / Brent price feed |
+| `POLYGON_API_KEY` | ⬜ Optional | `""` | Polygon.io key for higher-fidelity options data |
+| `EIA_API_KEY` | ✅ Phase 2 | — | EIA Open Data key for inventory & refinery data |
+| `NEWSAPI_KEY` | ✅ Phase 2 | — | NewsAPI key for headline ingestion |
+| `GDELT_ENABLED` | ⬜ Optional | `true` | Set `false` to skip GDELT event ingestion |
+| `QUIVER_QUANT_API_KEY` | ⬜ Optional | `""` | Quiver Quant key for insider conviction scores |
+| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit API OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit API OAuth client secret |
+| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `STOCKTWITS_API_KEY` | ⬜ Optional | `""` | Stocktwits API key for narrative velocity |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ Optional | `""` | MarineTraffic free-tier key for tanker data |
+| `DATA_RETENTION_DAYS` | ⬜ Optional | `180` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ Optional | `5` | Polling cadence for minute-level market data feeds |
+| `OUTPUT_DIR` | ⬜ Optional | `./output` | Directory where JSON output files are written |
+| `LOG_LEVEL` | ⬜ Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_PHASE` | ⬜ Optional | `1` | Active phase (`1`–`3`); controls which agents & signals are enabled |
 
-> \* Provide at least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY`.
+#### Minimal `.env` for Phase 1
 
-#### Event Detection Agent
+```dotenv
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+PIPELINE_PHASE=1
+OUTPUT_DIR=./output
+LOG_LEVEL=INFO
+```
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `NEWS_API_KEY` | Required | — | API key for NewsAPI energy headlines |
-| `GDELT_ENABLED` | Optional | `true` | Enable GDELT geopolitical feed (no key needed) |
-| `EVENT_CONFIDENCE_THRESHOLD` | Optional | `0.5` | Minimum confidence score to surface an event |
-| `EVENT_INTENSITY_THRESHOLD` | Optional | `0.3` | Minimum intensity score to surface an event |
+#### Full `.env` for Phase 3
 
-#### Feature Generation Agent
+```dotenv
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+EIA_API_KEY=your_eia_key
+NEWSAPI_KEY=your_newsapi_key
+GDELT_ENABLED=true
+QUIVER_QUANT_API_KEY=your_quiver_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_secret
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_API_KEY=your_stocktwits_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+DATA_RETENTION_DAYS=365
+MARKET_DATA_INTERVAL_MINUTES=5
+OUTPUT_DIR=./output
+LOG_LEVEL=INFO
+PIPELINE_PHASE=3
+```
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `QUIVER_API_KEY` | Optional | — | API key for Quiver Quant insider conviction data |
-| `REDDIT_CLIENT_ID` | Optional | — | Reddit PRAW client ID for sentiment velocity |
-| `REDDIT_CLIENT_SECRET` | Optional | — | Reddit PRAW client secret |
-| `REDDIT_USER_AGENT` | Optional | `energy-agent/1.0` | Reddit PRAW user agent string |
-| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
-| `VESSEL_FINDER_API_KEY` | Optional | — | Alternative tanker data source key |
+### 5. Initialise the Data Store
 
-#### Strategy Evaluation Agent
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `MIN_EDGE_SCORE` | Optional | `0.30` | Minimum edge score for a candidate to appear in output |
-| `MAX_CANDIDATES` | Optional | `20` | Maximum number of ranked candidates to emit per run |
-| `DEFAULT_EXPIRATION_DAYS` | Optional | `30` | Default target expiration when not overridden by signal |
-
-#### Output & Storage
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `OUTPUT_DIR` | Optional | `./output` | Directory where JSON output files are written |
-| `DATA_STORE_DIR` | Optional | `./data` | Directory for historical raw and derived data |
-| `LOG_LEVEL` | Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-
-### 3. Verify Configuration
-
-Run the built-in config check before your first full run:
+Run the initialisation script to create the local SQLite database and required directory structure:
 
 ```bash
-python -m agent.cli check-config
+python -m agent.init_store
 ```
 
-Expected output when all required variables are present:
+Expected output:
 
 ```
-[OK] Data Ingestion Agent     — all required keys present
-[OK] Event Detection Agent    — all required keys present
-[OK] Feature Generation Agent — optional keys: QUIVER_API_KEY missing (non-fatal)
-[OK] Strategy Evaluation Agent
-[OK] Output directories       — ./output, ./data created
-Configuration check passed.
+[INFO] Creating data directory: ./data
+[INFO] Initialising historical store (retention: 180 days)
+[INFO] Store initialised successfully.
 ```
-
-Missing optional keys produce `[WARN]` lines and are non-fatal. Missing required keys produce `[FAIL]` and abort the check.
-
-### 4. Initialize the Data Store
-
-Create the on-disk historical store and run an initial backfill:
-
-```bash
-python -m agent.cli init-store --backfill-days 30
-```
-
-This fetches up to 30 days of historical price, options, and inventory data. Use `--backfill-days 365` to build a full year of history for backtesting purposes (takes longer and consumes more API quota).
 
 ---
 
@@ -243,179 +206,187 @@ This fetches up to 30 days of historical price, options, and inventory data. Use
 ```mermaid
 sequenceDiagram
     participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Data Store
-    participant Out as JSON Output
+    participant DI as Data Ingestion Agent
+    participant ED as Event Detection Agent
+    participant FG as Feature Generation Agent
+    participant SE as Strategy Evaluation Agent
+    participant FS as File System (JSON)
 
-    CLI->>DIA: run(instruments, refresh_interval)
-    DIA->>Store: write market_state object
-    DIA-->>EDA: market_state ready signal
+    CLI->>DI: run ingestion
+    DI-->>DI: fetch prices, ETFs, options chains
+    DI-->>CLI: market state object ready
 
-    EDA->>Store: read market_state
-    EDA->>EDA: score events (confidence, intensity)
-    EDA->>Store: write event_scores
-    EDA-->>FGA: events ready signal
+    CLI->>ED: run event detection
+    ED-->>ED: scan GDELT / NewsAPI / EIA
+    ED-->>CLI: event scores appended to market state
 
-    FGA->>Store: read market_state + event_scores
-    FGA->>FGA: compute derived signals
-    FGA->>Store: write features_store
-    FGA-->>SEA: features ready signal
+    CLI->>FG: run feature generation
+    FG-->>FG: compute vol gaps, curve steepness, dispersion, etc.
+    FG-->>CLI: derived features store updated
 
-    SEA->>Store: read features_store
-    SEA->>SEA: evaluate & rank candidates
-    SEA->>Out: write ranked_candidates.json
-    SEA-->>CLI: pipeline complete
+    CLI->>SE: run strategy evaluation
+    SE-->>SE: score & rank candidate structures
+    SE->>FS: write candidates_<timestamp>.json
+    SE-->>CLI: pipeline complete
 ```
 
-### Single Run (One-Shot)
-
-Execute the full four-agent pipeline once and write results to `./output`:
+### Running the Full Pipeline (Single Execution)
 
 ```bash
-python -m agent.cli run
+python -m agent.pipeline run
 ```
 
-To override the output directory for this run:
-
-```bash
-python -m agent.cli run --output-dir /tmp/eo-results
-```
-
-### Continuous Mode
-
-Run the pipeline on a repeating cadence driven by `PRICE_REFRESH_INTERVAL_SEC`:
-
-```bash
-python -m agent.cli run --continuous
-```
-
-Press `Ctrl+C` to stop gracefully. The pipeline will finish the current cycle before exiting.
+This executes all four agents in sequence and writes a timestamped JSON file to `OUTPUT_DIR`.
 
 ### Running Individual Agents
 
-Each agent can be executed in isolation for development or debugging:
+You can invoke any agent in isolation for development or debugging:
 
 ```bash
 # Data Ingestion only
-python -m agent.cli run --agent ingestion
+python -m agent.pipeline run --stage ingest
 
-# Event Detection only (reads existing market_state from store)
-python -m agent.cli run --agent event-detection
+# Event Detection only
+python -m agent.pipeline run --stage events
 
 # Feature Generation only
-python -m agent.cli run --agent feature-generation
+python -m agent.pipeline run --stage features
 
 # Strategy Evaluation only
-python -m agent.cli run --agent strategy-evaluation
+python -m agent.pipeline run --stage evaluate
 ```
 
-### Selecting MVP Phase
+### Scheduling Continuous Execution
 
-The pipeline respects the phased rollout defined in the system design. Use `--phase` to limit which data sources and signals are active:
+For production use, run the pipeline on a recurring schedule. The market data layer refreshes on a **minutes-level cadence**; slower feeds (EIA, EDGAR) update **daily or weekly**.
 
-| Flag | Phase | What Is Active |
-|---|---|---|
-| `--phase 1` | Core Market Signals | Crude benchmarks, USO/XLE prices, IV surface, long straddles & spreads |
-| `--phase 2` | Supply & Event Augmentation | Phase 1 + EIA data, GDELT/NewsAPI event detection, supply disruption index |
-| `--phase 3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider data, Reddit/Stocktwits sentiment, shipping data |
-| `--phase 4` | High-Fidelity Enhancements | Phase 3 + OPIS pricing, exotic structures (when implemented) |
-
-```bash
-# Run Phase 2 pipeline
-python -m agent.cli run --phase 2
-```
-
-The default is `--phase 3` (all currently implemented signals).
-
-### Scheduled Execution (cron example)
-
-To run the pipeline every 5 minutes via cron:
+#### Using cron (Linux / macOS)
 
 ```bash
 crontab -e
 ```
 
-Add the following line (adjust paths as needed):
+Add the following entries:
 
 ```cron
-*/5 * * * * /home/user/energy-options-agent/.venv/bin/python \
-    -m agent.cli run \
-    --output-dir /home/user/energy-options-agent/output \
-    >> /home/user/energy-options-agent/logs/pipeline.log 2>&1
+# Full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
+*/5 9-17 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run >> logs/pipeline.log 2>&1
+
+# EIA/EDGAR slow-feed refresh — daily at 06:00
+0 6 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run --stage ingest --feeds slow >> logs/slow_ingest.log 2>&1
 ```
+
+#### Using Docker
+
+```bash
+# Build the image
+docker build -t energy-options-agent:1.0 .
+
+# Run a single pipeline execution
+docker run --rm --env-file .env energy-options-agent:1.0
+
+# Run continuously with a 5-minute internal loop
+docker run -d --env-file .env \
+  -v "$(pwd)/output:/app/output" \
+  -v "$(pwd)/data:/app/data" \
+  energy-options-agent:1.0 --loop --interval 300
+```
+
+### Useful CLI Flags
+
+| Flag | Description |
+|---|---|
+| `--stage <name>` | Run a single agent stage: `ingest`, `events`, `features`, `evaluate` |
+| `--feeds slow` | Restrict ingestion to daily/weekly feeds (EIA, EDGAR) only |
+| `--dry-run` | Execute pipeline without writing output files |
+| `--loop` | Run continuously (Docker / daemon mode) |
+| `--interval <seconds>` | Polling interval when `--loop` is active (default: `300`) |
+| `--log-level DEBUG` | Override `LOG_LEVEL` for this run |
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output Location
 
-Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
+Each pipeline run writes a file to `OUTPUT_DIR` (default `./output`):
 
 ```
 output/
-└── ranked_candidates_20260315T142301Z.json
+└── candidates_2026-03-15T14:32:07Z.json
 ```
 
-A symlink `output/latest.json` always points to the most recent file.
+The latest run is also symlinked as `output/candidates_latest.json`.
 
 ### Output Schema
 
-Each element in the output array is a **strategy candidate**:
+Each file contains a JSON array of strategy candidates, one object per ranked opportunity.
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | enum string | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | integer (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | float `[0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signals and their assessed levels |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output File
+### Example Output
 
 ```json
-{
-  "generated_at": "2026-03-15T14:23:01Z",
-  "phase": 3,
-  "candidate_count": 4,
-  "candidates": [
-    {
-      "instrument": "USO",
-      "structure": "long_straddle",
-      "expiration": 30,
-      "edge_score": 0.72,
-      "signals": {
-        "tanker_disruption_index": "high",
-        "volatility_gap": "positive",
-        "narrative_velocity": "rising",
-        "supply_shock_probability": "elevated"
-      },
-      "generated_at": "2026-03-15T14:23:01Z"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
     },
-    {
-      "instrument": "XLE",
-      "structure": "call_spread",
-      "expiration": 21,
-      "edge_score": 0.51,
-      "signals": {
-        "volatility_gap": "positive",
-        "sector_dispersion": "high",
-        "insider_conviction": "bullish"
-      },
-      "generated_at": "2026-03-15T14:23:01Z"
+    "generated_at": "2026-03-15T14:32:07Z"
+  },
+  {
+    "instrument": "XOM",
+    "structure": "call_spread",
+    "expiration": 45,
+    "edge_score": 0.31,
+    "signals": {
+      "volatility_gap": "positive",
+      "insider_conviction": "elevated",
+      "futures_curve_steepness": "backwardated"
     },
-    {
-      "instrument": "CL=F",
-      "structure": "put_spread",
-      "expiration": 14,
-      "edge_score": 0.44,
-      "signals": {
-        "futures_curve_steepness": "contango_widening",
-        "eia_inventory_surprise": "bearish",
-        "narrative_velocity": "stable"
-      },
-      "generated_at": "2026
+    "generated_at": "2026-03-15T14:32:07Z"
+  }
+]
+```
+
+### Reading the Edge Score
+
+| `edge_score` range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
+| `0.40 – 0.69` | Moderate confluence — worth monitoring |
+| `0.20 – 0.39` | Weak signal — low conviction; use with caution |
+| `0.00 – 0.19` | Minimal signal — typically filtered from default output |
+
+> The edge score is a composite heuristic and **does not constitute financial advice**. Always apply independent judgement and risk management before acting on any candidate.
+
+### Signal Reference
+
+The `signals` object can contain any of the following keys, populated by the Feature Generation Agent:
+
+| Signal key | Source agent | What it measures |
+|---|---|---|
+| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Feature Generation | Contango / backwardation in the crude futures curve |
+| `sector_dispersion` | Feature Generation | Cross-sector correlation breakdown |
+| `insider_conviction` | Feature Generation | Weighted score of recent executive trades (EDGAR) |
+| `narrative_velocity` | Feature Generation | Headline acceleration from Reddit / Stocktwits / news |
+| `supply_shock_probability` | Feature Generation | Modelled probability of near-term supply disruption |
+| `tanker_disruption_index` | Event Detection | Shipping flow anomalies (MarineTraffic / VesselFinder) |
+| `refinery_utilization` | Event Detection | EIA refinery utilisation delta |
+| `geopolitical_intensity` | Event Detection | GDELT/NewsAPI event confidence × intensity score |
+
+### Consuming Output in thinkorsw

--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -73,6 +73,10 @@ _MIN_EDGE_SCORE: float = 0.10
 _DISPERSION_HIGH_THRESHOLD: float = 0.15  # CV > 15% = high dispersion
 _DISPERSION_MEDIUM_THRESHOLD: float = 0.05  # CV > 5%  = medium dispersion
 
+# Thresholds for supply shock probability labels
+_SUPPLY_SHOCK_HIGH_THRESHOLD: float = 0.60  # probability > 60% = high
+_SUPPLY_SHOCK_MEDIUM_THRESHOLD: float = 0.30  # probability > 30% = medium
+
 # Phase 2 multiplier weights for supply shock and futures curve steepness
 _SUPPLY_SHOCK_WEIGHT: float = 0.30
 _CURVE_STEEPNESS_WEIGHT: float = 0.15
@@ -92,8 +96,8 @@ def compute_edge_score(
     amplify the base score when present.
 
     Formula:
-        base = vol_gap_norm * 0.70 + disp_norm * 0.30
-        score = base * (1 + 0.30 * supply_shock) * (1 + 0.15 * |curve_steepness|)
+        base = vol_gap_norm * _VOL_GAP_WEIGHT + disp_norm * _DISPERSION_WEIGHT
+        score = base * (1 + _SUPPLY_SHOCK_WEIGHT * supply_shock) * (1 + _CURVE_STEEPNESS_WEIGHT * |curve_steepness|)
         return min(score, 1.0)
 
     When supply_shock_probability or futures_curve_steepness is None, the
@@ -102,8 +106,10 @@ def compute_edge_score(
     Args:
         instrument: Ticker symbol of the instrument to evaluate.
         feature_set: Computed signals from Feature Generation Agent.
-        supply_shock_probability: From FeatureSet, or None if unavailable.
-        futures_curve_steepness: From FeatureSet, or None if unavailable.
+        supply_shock_probability: Float in [0.0, 1.0], or None if unavailable.
+            Pydantic validation on FeatureSet.supply_shock_probability enforces range.
+        futures_curve_steepness: Unbounded float (WTI futures curve slope; contango > 0).
+            None if unavailable.
 
     Returns:
         Float in [0.0, 1.0]. Higher = stronger signal confluence.
@@ -176,15 +182,15 @@ def _supply_shock_label(feature_set: FeatureSet) -> str:
         feature_set: Current FeatureSet from Feature Generation Agent.
 
     Returns:
-        'high' if probability > 0.6, 'medium' if > 0.3, 'low' if > 0,
-        'none' if None or 0.
+        'high' if probability > _SUPPLY_SHOCK_HIGH_THRESHOLD, 'medium' if > _SUPPLY_SHOCK_MEDIUM_THRESHOLD,
+        'low' if > 0, 'none' if None or 0.
     """
     prob = feature_set.supply_shock_probability
     if prob is None or prob == 0.0:
         return "none"
-    if prob > 0.6:
+    if prob > _SUPPLY_SHOCK_HIGH_THRESHOLD:
         return "high"
-    if prob > 0.3:
+    if prob > _SUPPLY_SHOCK_MEDIUM_THRESHOLD:
         return "medium"
     return "low"
 

--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -73,17 +73,37 @@ _MIN_EDGE_SCORE: float = 0.10
 _DISPERSION_HIGH_THRESHOLD: float = 0.15  # CV > 15% = high dispersion
 _DISPERSION_MEDIUM_THRESHOLD: float = 0.05  # CV > 5%  = medium dispersion
 
+# Phase 2 multiplier weights for supply shock and futures curve steepness
+_SUPPLY_SHOCK_WEIGHT: float = 0.30
+_CURVE_STEEPNESS_WEIGHT: float = 0.15
 
-def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
+
+def compute_edge_score(
+    instrument: str,
+    feature_set: FeatureSet,
+    supply_shock_probability: float | None = None,
+    futures_curve_steepness: float | None = None,
+) -> float:
     """
     Compute a composite edge score for a given instrument from the FeatureSet.
 
-    Scoring is static/heuristic for Phase 1 MVP.
-    ML-based dynamic weighting is explicitly deferred (ESOD Section 8).
+    Phase 1 base score: weighted sum of volatility gap and sector dispersion.
+    Phase 2 multipliers: supply shock probability and futures curve steepness
+    amplify the base score when present.
+
+    Formula:
+        base = vol_gap_norm * 0.70 + disp_norm * 0.30
+        score = base * (1 + 0.30 * supply_shock) * (1 + 0.15 * |curve_steepness|)
+        return min(score, 1.0)
+
+    When supply_shock_probability or futures_curve_steepness is None, the
+    corresponding multiplier is 1.0 (no effect), preserving Phase 1 behavior.
 
     Args:
         instrument: Ticker symbol of the instrument to evaluate.
         feature_set: Computed signals from Feature Generation Agent.
+        supply_shock_probability: From FeatureSet, or None if unavailable.
+        futures_curve_steepness: From FeatureSet, or None if unavailable.
 
     Returns:
         Float in [0.0, 1.0]. Higher = stronger signal confluence.
@@ -104,7 +124,13 @@ def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
     disp_norm = feature_set.sector_dispersion if feature_set.sector_dispersion is not None else 0.0
     disp_contribution = disp_norm * _DISPERSION_WEIGHT
 
-    return vol_gap_contribution + disp_contribution
+    base_score = vol_gap_contribution + disp_contribution
+
+    # --- Phase 2 multipliers ---
+    shock_multiplier = 1.0 + _SUPPLY_SHOCK_WEIGHT * (supply_shock_probability or 0.0)
+    curve_multiplier = 1.0 + _CURVE_STEEPNESS_WEIGHT * abs(futures_curve_steepness or 0.0)
+
+    return min(base_score * shock_multiplier * curve_multiplier, 1.0)
 
 
 def _vol_gap_label(instrument: str, feature_set: FeatureSet) -> str:
@@ -143,6 +169,41 @@ def _dispersion_label(feature_set: FeatureSet) -> str:
     return "low"
 
 
+def _supply_shock_label(feature_set: FeatureSet) -> str:
+    """Return human-readable supply shock probability label.
+
+    Args:
+        feature_set: Current FeatureSet from Feature Generation Agent.
+
+    Returns:
+        'high' if probability > 0.6, 'medium' if > 0.3, 'low' if > 0,
+        'none' if None or 0.
+    """
+    prob = feature_set.supply_shock_probability
+    if prob is None or prob == 0.0:
+        return "none"
+    if prob > 0.6:
+        return "high"
+    if prob > 0.3:
+        return "medium"
+    return "low"
+
+
+def _curve_steepness_label(feature_set: FeatureSet) -> str:
+    """Return human-readable futures curve steepness label.
+
+    Args:
+        feature_set: Current FeatureSet from Feature Generation Agent.
+
+    Returns:
+        'contango' if steepness > 0, 'backwardation' if < 0, 'flat' if None or 0.
+    """
+    steep = feature_set.futures_curve_steepness
+    if steep is None or steep == 0.0:
+        return "flat"
+    return "contango" if steep > 0 else "backwardation"
+
+
 def evaluate_strategies(feature_set: FeatureSet) -> list[StrategyCandidate]:
     """
     Evaluate all eligible option structures across all in-scope instruments.
@@ -164,13 +225,20 @@ def evaluate_strategies(feature_set: FeatureSet) -> list[StrategyCandidate]:
     candidates: list[StrategyCandidate] = []
 
     for instrument in INSTRUMENTS_IN_SCOPE:
-        edge_score = compute_edge_score(instrument, feature_set)
+        edge_score = compute_edge_score(
+            instrument,
+            feature_set,
+            supply_shock_probability=feature_set.supply_shock_probability,
+            futures_curve_steepness=feature_set.futures_curve_steepness,
+        )
         if edge_score < _MIN_EDGE_SCORE:
             continue
 
         signals: dict[str, str] = {
             "volatility_gap": _vol_gap_label(instrument, feature_set),
             "sector_dispersion": _dispersion_label(feature_set),
+            "supply_shock_probability": _supply_shock_label(feature_set),
+            "futures_curve_steepness": _curve_steepness_label(feature_set),
         }
 
         for structure in _PHASE_1_STRUCTURES:

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -35,11 +35,15 @@ def _make_vg(instrument: str, gap: float) -> VolatilityGap:
 def _make_feature_set(
     gaps: list[VolatilityGap],
     sector_dispersion: float | None = None,
+    supply_shock_probability: float | None = None,
+    futures_curve_steepness: float | None = None,
 ) -> FeatureSet:
     return FeatureSet(
         snapshot_time=datetime.now(tz=UTC),
         volatility_gaps=gaps,
         sector_dispersion=sector_dispersion,
+        supply_shock_probability=supply_shock_probability,
+        futures_curve_steepness=futures_curve_steepness,
     )
 
 
@@ -93,6 +97,57 @@ class TestComputeEdgeScore:
         fs = _make_feature_set([_make_vg("USO", 1.0)], sector_dispersion=1.0)
         score = compute_edge_score("USO", fs)
         assert 0.0 <= score <= 1.0
+
+    # --- Phase 2 multiplier tests ---
+
+    def test_phase1_unchanged_when_none(self) -> None:
+        """When supply_shock and curve_steepness are None, score matches Phase 1."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        score_none = compute_edge_score(
+            "USO", fs, supply_shock_probability=None, futures_curve_steepness=None,
+        )
+        score_base = compute_edge_score("USO", fs)
+        assert score_none == score_base
+
+    def test_supply_shock_increases_score(self) -> None:
+        """Non-zero supply_shock_probability increases edge score."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        base = compute_edge_score("USO", fs)
+        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        assert boosted > base
+
+    def test_curve_steepness_increases_score(self) -> None:
+        """Non-zero futures_curve_steepness increases edge score."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        base = compute_edge_score("USO", fs)
+        boosted = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        assert boosted > base
+
+    def test_both_multipliers_compound(self) -> None:
+        """Both multipliers together produce a higher score than either alone."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        shock_only = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        curve_only = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        both = compute_edge_score(
+            "USO", fs, supply_shock_probability=0.5, futures_curve_steepness=0.05,
+        )
+        assert both > shock_only
+        assert both > curve_only
+
+    def test_multipliers_cap_at_one(self) -> None:
+        """Even with large multipliers, score is capped at 1.0."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=1.0)
+        score = compute_edge_score(
+            "USO", fs, supply_shock_probability=1.0, futures_curve_steepness=0.5,
+        )
+        assert score == 1.0
+
+    def test_negative_curve_steepness_uses_abs(self) -> None:
+        """Negative curve steepness (backwardation) also boosts score via abs()."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        pos = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        neg = compute_edge_score("USO", fs, futures_curve_steepness=-0.05)
+        assert abs(pos - neg) < 1e-9
 
 
 class TestEvaluateStrategies:
@@ -176,13 +231,15 @@ class TestEvaluateStrategies:
         assert all(c.expiration == 30 for c in result)
 
     def test_signals_dict_keys(self) -> None:
-        """signals dict must contain 'volatility_gap' and 'sector_dispersion' keys."""
+        """signals dict must contain all four signal keys."""
         fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result = evaluate_strategies(fs)
         assert result
         assert "volatility_gap" in result[0].signals
         assert "sector_dispersion" in result[0].signals
+        assert "supply_shock_probability" in result[0].signals
+        assert "futures_curve_steepness" in result[0].signals
 
     def test_signals_positive_gap_high_dispersion(self) -> None:
         """Positive gap + high dispersion → correct signal labels."""
@@ -202,3 +259,60 @@ class TestEvaluateStrategies:
         uso = next((c for c in result if c.instrument == "USO"), None)
         assert uso is not None
         assert uso.signals["volatility_gap"] == "negative"
+
+    def test_supply_shock_label_high(self) -> None:
+        """supply_shock_probability > 0.6 → 'high' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, supply_shock_probability=0.8,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["supply_shock_probability"] == "high"
+
+    def test_supply_shock_label_none(self) -> None:
+        """supply_shock_probability None → 'none' label."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["supply_shock_probability"] == "none"
+
+    def test_curve_steepness_label_contango(self) -> None:
+        """Positive futures_curve_steepness → 'contango' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=0.03,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "contango"
+
+    def test_curve_steepness_label_backwardation(self) -> None:
+        """Negative futures_curve_steepness → 'backwardation' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=-0.02,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "backwardation"
+
+    def test_curve_steepness_label_flat(self) -> None:
+        """futures_curve_steepness None → 'flat' label."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "flat"
+
+    def test_evaluate_passes_phase2_signals_to_edge_score(self) -> None:
+        """evaluate_strategies passes feature_set Phase 2 fields to compute_edge_score."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.10)],
+            sector_dispersion=0.2,
+            supply_shock_probability=0.5,
+            futures_curve_steepness=0.04,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        # With Phase 2 multipliers the score should be higher than Phase 1 base
+        fs_none = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result_none = evaluate_strategies(fs_none)
+        assert result[0].edge_score > result_none[0].edge_score


### PR DESCRIPTION
## What Changed

Updates `compute_edge_score()` to accept `supply_shock_probability` and `futures_curve_steepness` as optional multipliers (both default `None` for backward compat). Adds `_supply_shock_label()` and `_curve_steepness_label()` helpers. Expands the `signals` dict on `StrategyCandidate` to include both Phase 2 signal keys.

Formula: `score = base × (1 + 0.30 × shock) × (1 + 0.15 × |curve|)`, capped at 1.0.

## What the Agent Did

- Claude Code updated `compute_edge_score()` signature and body
- Added module-level weight constants and two private label helpers
- Updated `evaluate_strategies()` to pass Phase 2 fields from FeatureSet
- Generated unit tests for multiplier interactions, cap behavior, and label edge cases

## What Was Manually Reviewed

- Backward compatibility: callers passing neither new parameter get identical Phase 1 scores — verified by `test_phase1_unchanged_when_none`
- Cap at 1.0 via `min(..., 1.0)` — correct
- `abs()` on curve steepness ensures backwardation also boosts score — verified by `test_negative_curve_steepness_uses_abs`
- Label functions read from `feature_set` (source of truth for display), not from the parameter copy passed to compute_edge_score

## Testing

- [x] `pytest` run locally — all tests pass
- [x] New tests added for this change
- [ ] Integration test included (not required — pure computation)

## Quality Gates (run locally before PR)

- [x] `ruff check src/ tests/` — passes
- [x] `black --check src/ tests/` — passes
- [x] `mypy src/` — passes (strict mode)
- [x] `python .github/scripts/check_runtime_imports.py` — exits 0

## Related Issue

Closes #108

## Notes for Reviewer

Depends on #106 (supply_shock_probability) and #107 (futures_curve_steepness) — both already merged to develop.