### PR TITLE
test(strategy-evaluation): correlated instruments produce 18 candidates

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -278,3 +278,12 @@ Issue #128 implemented on `test/128-degraded-mode-pipeline`:
 - Regression now asserts degraded mode still returns a non-empty list of `StrategyCandidate` objects and that event-driven signal labels stay at defaults (`supply_shock_probability="none"`, `futures_curve_steepness="flat"`).
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #128 In Review, PR #139 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 2)
+
+Issue #129 implemented on `test/129-correlated-instruments-candidate-count`:
+- Added `test_correlated_instruments_yield_18_equal_score_candidates()` to `tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py`.
+- Regression asserts exactly 18 candidates (6 in-scope instruments × 3 structures), identical edge scores across all candidates, and deterministic order under equal-score stable sorting.
+- Test docstring documents that 18 correlated candidates are expected behavior and references concentration filter issue #132 for future de-duplication.
+- Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
+- #129 In Review, PR #140 opened 2026-03-18

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -331,3 +331,50 @@ class TestEvaluateStrategies:
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result_none = evaluate_strategies(fs_none)
         assert result[0].edge_score > result_none[0].edge_score
+
+    def test_correlated_instruments_yield_18_equal_score_candidates(self) -> None:
+        """All 6 in-scope instruments above threshold produce 18 deterministic candidates.
+
+        18 candidates is expected behavior when all instruments are correlated;
+        see concentration filter issue #132 for future de-duplication behavior.
+        """
+        instruments = ["USO", "XLE", "XOM", "CVX", "CL=F", "BZ=F"]
+        fs = _make_feature_set(
+            [_make_vg(instrument, 0.20) for instrument in instruments],
+            sector_dispersion=0.50,
+        )
+
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+
+        assert len(result) == 18
+        assert len({candidate.edge_score for candidate in result}) == 1
+
+        # All scores are equal, so sorted(desc) preserves insertion order (stable sort).
+        assert [candidate.edge_score for candidate in result] == sorted(
+            (candidate.edge_score for candidate in result),
+            reverse=True,
+        )
+
+        expected_order = [
+            ("USO", "long_straddle"),
+            ("USO", "call_spread"),
+            ("USO", "put_spread"),
+            ("XLE", "long_straddle"),
+            ("XLE", "call_spread"),
+            ("XLE", "put_spread"),
+            ("XOM", "long_straddle"),
+            ("XOM", "call_spread"),
+            ("XOM", "put_spread"),
+            ("CVX", "long_straddle"),
+            ("CVX", "call_spread"),
+            ("CVX", "put_spread"),
+            ("CL=F", "long_straddle"),
+            ("CL=F", "call_spread"),
+            ("CL=F", "put_spread"),
+            ("BZ=F", "long_straddle"),
+            ("BZ=F", "call_spread"),
+            ("BZ=F", "put_spread"),
+        ]
+        actual_order = [(candidate.instrument, candidate.structure) for candidate in result]
+        assert actual_order == expected_order


### PR DESCRIPTION
## Summary
- add a regression test covering correlated in-scope instruments where all six pass threshold
- assert evaluate_strategies returns exactly 18 candidates (6 instruments x 3 structures)
- assert all candidates have identical edge_score and deterministic order under stable sort
- document expected 18-candidate behavior and reference concentration filter issue #132

## Validation
- pytest tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py -q
- pytest -m "not integration"
- bash scripts/local_check.sh

Closes #129