### PR TITLE
test(strategy-evaluation): phase2 multiplier coverage for compute_edge_score

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -287,3 +287,12 @@ Issue #129 implemented on `test/129-correlated-instruments-candidate-count`:
 - Test docstring documents that 18 correlated candidates are expected behavior and references concentration filter issue #132 for future de-duplication.
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #129 In Review, PR #140 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 3)
+
+Issue #127 implemented on `test/127-phase2-multiplier-zero-effect`:
+- Updated `test_supply_shock_increases_score()` in `tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py` to use the explicit AC value `supply_shock_probability=0.8`.
+- Added `test_zero_effect_inputs_equivalent_to_none()` to assert zero-effect equivalence (`supply_shock_probability=0.0`, `futures_curve_steepness=0.0`) versus `None` inputs.
+- Existing coverage for curve steepness increase (`0.05`) and max-value clamping (`<= 1.0`) remains in place and passes.
+- Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
+- #127 In Review, PR #141 opened 2026-03-18

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -113,10 +113,10 @@ class TestComputeEdgeScore:
         assert score_none == score_base
 
     def test_supply_shock_increases_score(self) -> None:
-        """Non-zero supply_shock_probability increases edge score."""
+        """supply_shock_probability=0.8 increases score vs None."""
         fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
         base = compute_edge_score("USO", fs)
-        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.8)
         assert boosted > base
 
     def test_curve_steepness_increases_score(self) -> None:
@@ -157,6 +157,23 @@ class TestComputeEdgeScore:
         pos = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
         neg = compute_edge_score("USO", fs, futures_curve_steepness=-0.05)
         assert abs(pos - neg) < 1e-9
+
+    def test_zero_effect_inputs_equivalent_to_none(self) -> None:
+        """supply_shock=0.0 and curve_steepness=0.0 match None/None behavior."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        score_none = compute_edge_score(
+            "USO",
+            fs,
+            supply_shock_probability=None,
+            futures_curve_steepness=None,
+        )
+        score_zero = compute_edge_score(
+            "USO",
+            fs,
+            supply_shock_probability=0.0,
+            futures_curve_steepness=0.0,
+        )
+        assert score_zero == score_none
 
 
 class TestEvaluateStrategies:


### PR DESCRIPTION
## Summary
- align supply-shock multiplier coverage with explicit 0.8 acceptance criterion
- add zero-effect equivalence regression for supply_shock_probability=0.0 and futures_curve_steepness=0.0 versus None/None
- keep coverage fully in strategy-evaluation unit tests with no new dependencies

## Validation
- pytest tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py -q
- pytest -m "not integration"
- bash scripts/local_check.sh

Closes #127