### PR TITLE
chore(infra): TimescaleDB migration script and documentation (#111)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -296,3 +296,13 @@ Issue #127 implemented on `test/127-phase2-multiplier-zero-effect`:
 - Existing coverage for curve steepness increase (`0.05`) and max-value clamping (`<= 1.0`) remains in place and passes.
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #127 In Review, PR #141 opened 2026-03-18
+- #127 In Review, PR #141 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 4)
+
+Issue #111 implemented on `chore/111-timescaledb-migration-plan`:
+- Created `db/migrate_timescaledb.sql`: idempotent migration script enabling `CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE` and `create_hypertable` calls (with `if_not_exists => TRUE`) for all four partition candidates: `market_prices.timestamp`, `options_chain.timestamp`, `eia_inventory.fetched_at`, `detected_events.detected_at`. Full rollback procedure documented as inline comments.
+- Created `docs/timescaledb_migration.md`: migration guide covering PRD §6.2 trigger criteria, pre-migration checklist, step-by-step apply/verify commands, rollback procedure, and Docker Compose note.
+- AC audit: `db/schema.sql` header and `docker-compose.yml` TimescaleDB image were both already satisfying their respective ACs (pre-existing); no existing files modified.
+- Gate: `pytest -m "not integration"` 248 passed; `bash scripts/local_check.sh` ALL STAGES PASSED.
+- #111 In Review, PR #142 opened 2026-03-18

--- a/db/migrate_timescaledb.sql
+++ b/db/migrate_timescaledb.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- db/migrate_timescaledb.sql — TimescaleDB hypertable migration
+-- Energy Options Opportunity Agent
+-- =============================================================================
+--
+-- Purpose: Convert the four time-series partitioning candidates defined in
+--   db/schema.sql to TimescaleDB hypertables.
+--
+-- Migration triggers (PRD §6.2) — run this script when ANY of the following:
+--   1. Historical data exceeds 6 months of tick-level market data.
+--   2. Backtesting range queries consistently exceed 5 seconds.
+--   3. Team size grows beyond a single contributor.
+--
+-- Idempotency: All statements use IF NOT EXISTS / if_not_exists => TRUE.
+--   Safe to run multiple times against the same database; existing hypertables
+--   produce a NOTICE, not an error.
+--
+-- Pre-migration requirements:
+--   - PostgreSQL 15+ running (matches docker-compose.yml: timescale/timescaledb:2.15.2-pg15)
+--   - db/schema.sql already applied (all four tables must exist)
+--   - TimescaleDB extension available in the PostgreSQL cluster
+--
+-- Apply:
+--   psql $DATABASE_URL -f db/schema.sql          # if not already applied
+--   psql $DATABASE_URL -f db/migrate_timescaledb.sql
+--
+-- Verify:
+--   SELECT hypertable_name, num_dimensions FROM timescaledb_information.hypertables;
+-- =============================================================================
+
+
+-- Step 1: Enable the TimescaleDB extension
+CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+
+
+-- Step 2: Convert time-series tables to hypertables
+--
+-- market_prices — partition by timestamp (tick-level WTI, Brent, USO, XLE, XOM, CVX)
+SELECT create_hypertable('market_prices', 'timestamp', if_not_exists => TRUE);
+
+-- options_chain — partition by timestamp (tick-level options records)
+SELECT create_hypertable('options_chain', 'timestamp', if_not_exists => TRUE);
+
+-- eia_inventory — partition by fetched_at (weekly EIA petroleum status reports)
+SELECT create_hypertable('eia_inventory', 'fetched_at', if_not_exists => TRUE);
+
+-- detected_events — partition by detected_at (classified energy market events)
+SELECT create_hypertable('detected_events', 'detected_at', if_not_exists => TRUE);
+
+
+-- =============================================================================
+-- ROLLBACK PROCEDURE
+-- =============================================================================
+--
+-- TimescaleDB does not provide a direct "undo hypertable" command. To revert
+-- a table from a hypertable back to a regular PostgreSQL table:
+--
+--   1. Export the data:
+--        \COPY market_prices TO '/tmp/market_prices_backup.csv' CSV HEADER;
+--        (repeat for each hypertable)
+--
+--   2. Drop the hypertable (this drops all chunks and data):
+--        DROP TABLE market_prices;
+--        DROP TABLE options_chain;
+--        DROP TABLE eia_inventory;
+--        DROP TABLE detected_events;
+--
+--   3. Re-create as regular tables (re-apply db/schema.sql):
+--        psql $DATABASE_URL -f db/schema.sql
+--
+--   4. Re-import data:
+--        \COPY market_prices FROM '/tmp/market_prices_backup.csv' CSV HEADER;
+--        (repeat for each table)
+--
+--   5. Drop the extension (optional — only if no other databases use it):
+--        DROP EXTENSION IF EXISTS timescaledb CASCADE;
+--
+-- WARNING: Steps 2–3 are destructive. Always back up data before rolling back.
+-- =============================================================================

--- a/docs/timescaledb_migration.md
+++ b/docs/timescaledb_migration.md
@@ -1,0 +1,202 @@
+# TimescaleDB Migration Guide
+
+**Energy Options Opportunity Agent — PRD §6.2**
+
+---
+
+## Overview
+
+The Energy Options Opportunity Agent uses PostgreSQL 15 for Phase 1. Phase 2
+adds TimescaleDB — a PostgreSQL extension that converts regular tables into
+hypertables (time-partitioned tables). This delivers faster time-range queries
+for backtesting and long-lived market-data series with zero application code
+changes.
+
+Schema design guarantees zero-friction migration: all time-series tables already
+use `TIMESTAMPTZ` columns, and no ORM or query changes are required. The
+migration is a single-file SQL script applied once.
+
+---
+
+## Migration Triggers
+
+**Run the migration when ANY of the following is true (PRD §6.2):**
+
+| # | Trigger | How to check |
+|---|---------|-------------|
+| 1 | Historical data exceeds **6 months** of tick-level market data | `SELECT count(*), min(timestamp), max(timestamp) FROM market_prices;` |
+| 2 | Backtesting range queries **consistently exceed 5 seconds** | Run a 30-day window query; `EXPLAIN ANALYZE SELECT ... WHERE timestamp BETWEEN ...` |
+| 3 | Team size grows **beyond a single contributor** | Sprint planning / team roster |
+
+---
+
+## Tables Being Converted
+
+| Table | Partition column | Data description |
+|-------|-----------------|-----------------|
+| `market_prices` | `timestamp` | WTI, Brent, USO, XLE, XOM, CVX tick prices |
+| `options_chain` | `timestamp` | Options records for USO, XLE, XOM, CVX |
+| `eia_inventory` | `fetched_at` | Weekly EIA petroleum status reports |
+| `detected_events` | `detected_at` | Classified energy market events |
+
+---
+
+## Pre-Migration Checklist
+
+Before running the migration script, confirm:
+
+- [ ] PostgreSQL 15+ is running (`SELECT version();`)
+- [ ] `db/schema.sql` has been applied: all four tables exist
+  ```sql
+  SELECT table_name FROM information_schema.tables
+  WHERE table_name IN ('market_prices','options_chain','eia_inventory','detected_events');
+  ```
+- [ ] `docker-compose.yml` is using `timescale/timescaledb:2.15.2-pg15`
+  (already updated — see Docker Compose section below)
+- [ ] Database backup taken if live data is present
+  ```bash
+  pg_dump $DATABASE_URL > backup_$(date +%Y%m%d).sql
+  ```
+
+---
+
+## Step-by-Step Migration
+
+### 1. Start the database (Docker Compose)
+
+```bash
+docker compose up -d
+docker compose ps   # confirm db service is healthy
+```
+
+### 2. Apply the base schema (if not already applied)
+
+```bash
+psql $DATABASE_URL -f db/schema.sql
+```
+
+### 3. Apply the TimescaleDB migration
+
+```bash
+psql $DATABASE_URL -f db/migrate_timescaledb.sql
+```
+
+Expected output:
+
+```
+CREATE EXTENSION
+create_hypertable
+------------------
+ (1,1)
+(1 row)
+
+create_hypertable
+------------------
+ (2,1)
+(1 row)
+
+create_hypertable
+------------------
+ (3,1)
+(1 row)
+
+create_hypertable
+------------------
+ (4,1)
+(1 row)
+```
+
+If running against a database where the migration was already applied, each
+`create_hypertable` call returns a `NOTICE` ("table is already a hypertable")
+and exits successfully — the script is fully idempotent.
+
+### 4. Verify
+
+```sql
+SELECT hypertable_name, num_dimensions, num_chunks
+FROM timescaledb_information.hypertables;
+```
+
+Expected: 4 rows — `market_prices`, `options_chain`, `eia_inventory`, `detected_events`.
+
+```bash
+# Quick schema spot-check:
+psql $DATABASE_URL -c "\d market_prices"
+psql $DATABASE_URL -c "\d options_chain"
+```
+
+---
+
+## Docker Compose
+
+`docker-compose.yml` uses `timescale/timescaledb:2.15.2-pg15` — the TimescaleDB
+image that bundles PostgreSQL 15 and the extension pre-installed. No additional
+Docker changes are required before running the migration.
+
+To restart with a clean database (development only — destroys all data):
+
+```bash
+docker compose down -v
+docker compose up -d
+psql $DATABASE_URL -f db/schema.sql
+psql $DATABASE_URL -f db/migrate_timescaledb.sql
+```
+
+---
+
+## Rollback Procedure
+
+TimescaleDB does not provide a direct "undo hypertable" command. If you need to
+revert the four tables to regular PostgreSQL tables:
+
+**Step 1 — Back up data (before rolling back)**
+
+```bash
+psql $DATABASE_URL -c "\COPY market_prices    TO '/tmp/market_prices_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY options_chain    TO '/tmp/options_chain_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY eia_inventory    TO '/tmp/eia_inventory_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY detected_events  TO '/tmp/detected_events_bak.csv'  CSV HEADER"
+```
+
+**Step 2 — Drop the hypertables** (destructive — loses all data in the tables)
+
+```sql
+DROP TABLE market_prices;
+DROP TABLE options_chain;
+DROP TABLE eia_inventory;
+DROP TABLE detected_events;
+```
+
+**Step 3 — Re-create as regular tables**
+
+```bash
+psql $DATABASE_URL -f db/schema.sql
+```
+
+**Step 4 — Re-import data**
+
+```bash
+psql $DATABASE_URL -c "\COPY market_prices    FROM '/tmp/market_prices_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY options_chain    FROM '/tmp/options_chain_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY eia_inventory    FROM '/tmp/eia_inventory_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY detected_events  FROM '/tmp/detected_events_bak.csv'  CSV HEADER"
+```
+
+**Step 5 — Drop the extension** (only if no other databases use TimescaleDB)
+
+```sql
+DROP EXTENSION IF EXISTS timescaledb CASCADE;
+```
+
+> **Warning:** Steps 2–3 are destructive. Always complete Step 1 first.
+
+---
+
+## References
+
+- PRD §6.2 — TimescaleDB Migration
+- PRD §12.7 — Coverage Gaps (migration plan flagged)
+- `db/schema.sql` — base schema; all hypertable candidates annotated in header
+- `db/migrate_timescaledb.sql` — idempotent migration script
+- `docker-compose.yml` — `timescale/timescaledb:2.15.2-pg15` image
+- [TimescaleDB docs: create_hypertable](https://docs.timescale.com/api/latest/hypertable/create_hypertable/)


### PR DESCRIPTION
## Summary

Closes #111

Delivers the TimescaleDB migration path required by PRD §6.2 before Phase 2 releases to production.

## Changes

- **`db/migrate_timescaledb.sql`** (new): Idempotent migration script
  - `CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE`
  - `create_hypertable` for all 4 candidates: `market_prices.timestamp`, `options_chain.timestamp`, `eia_inventory.fetched_at`, `detected_events.detected_at`
  - Full rollback procedure documented as inline comments
- **`docs/timescaledb_migration.md`** (new): Migration guide
  - PRD §6.2 trigger criteria (6-month data, 5s query threshold, team growth)
  - Pre-migration checklist
  - Step-by-step apply + verify commands
  - Rollback procedure
  - Docker Compose note

## AC Coverage

- [x] `db/migrate_timescaledb.sql` created with all 5 idempotent SQL statements
- [x] Rollback section comment included in SQL script
- [x] `db/schema.sql` header already references `migrate_timescaledb.sql` (line 22, pre-existing)
- [x] `docs/timescaledb_migration.md` created with triggers, checklist, commands, rollback, Docker note
- [x] `docker-compose.yml` already uses `timescale/timescaledb:2.15.2-pg15` (pre-existing)
- [x] `pytest -m "not integration"`: 248 passed (no code changes)

## Gate

`bash scripts/local_check.sh` → ALL STAGES PASSED