### PR TITLE
Add UAT report snapshot for #112

### DIFF
--- a/docs/uat_reports/112-uat-report-2026-03-19.md
+++ b/docs/uat_reports/112-uat-report-2026-03-19.md
@@ -1,0 +1,53 @@
+# UAT Run Snapshot — Issue #112
+Date: 2026-03-19
+
+Summary
+- Runner: `scripts/uat_run.py` (offline replay)
+- Env: Local venv; `DATABASE_URL` present in `.env`; TimescaleDB running.
+
+Backtest evaluate() (GDELT sample):
+```
+{
+  "threshold": 2.0,
+  "hold_days": 3,
+  "events": { "count": 0, "mean": 0.0, "median": 0.0, "std": 0.0 },
+  "non_events": { "count": 13, "mean": 0.08920825546201107, "median": 0.04363479648159152, "std": 0.07859866688969086 }
+}
+```
+
+Pipeline output (injected DetectedEvent)
+- Candidates produced: 3
+
+```
+[
+  {
+    "instrument": "CL=F",
+    "structure": "long_straddle",
+    "edge_score": 0.6828022799999999,
+    "signals": {
+      "volatility_gap": "positive",
+      "sector_dispersion": "medium",
+      "supply_shock_probability": "high",
+      "futures_curve_steepness": "backwardation"
+    }
+  },
+  {
+    "instrument": "CL=F",
+    "structure": "call_spread",
+    "edge_score": 0.6828022799999999,
+    "signals": { ... }
+  },
+  {
+    "instrument": "CL=F",
+    "structure": "put_spread",
+    "edge_score": 0.6828022799999999,
+    "signals": { ... }
+  }
+]
+```
+
+Notes
+- Offline run printed candidates to stdout; with `DATABASE_URL` set the runner can persist candidates to the `strategy_candidates` table.
+- If you want these rows persisted now, I can re-run the UAT with persistence and capture example DB rows.
+
+Saved by agent: 2026-03-19


### PR DESCRIPTION
Adds UAT run snapshot docs/uat_reports/112-uat-report-2026-03-19.md produced during local UAT. Persists run output and notes for issue #112.