### PR TITLE
release: Phase 2 — Supply & Event Augmentation (v0.2.0)

### DIFF
--- a/.claude/skills/review/TODOS-format.md
+++ b/.claude/skills/review/TODOS-format.md
@@ -1,0 +1,62 @@
+# TODOS.md Format Reference
+
+Shared reference for the canonical TODOS.md format. Referenced by `/ship` (Step 5.5) and `/plan-ceo-review` (TODOS.md updates section) to ensure consistent TODO item structure.
+
+---
+
+## File Structure
+
+```markdown
+# TODOS
+
+## <Skill/Component>     ← e.g., ## Browse, ## Ship, ## Review, ## Infrastructure
+<items sorted P0 first, then P1, P2, P3, P4>
+
+## Completed
+<finished items with completion annotation>
+```
+
+**Sections:** Organize by skill or component (`## Browse`, `## Ship`, `## Review`, `## QA`, `## Retro`, `## Infrastructure`). Within each section, sort items by priority (P0 at top).
+
+---
+
+## TODO Item Format
+
+Each item is an H3 under its section:
+
+```markdown
+### <Title>
+
+**What:** One-line description of the work.
+
+**Why:** The concrete problem it solves or value it unlocks.
+
+**Context:** Enough detail that someone picking this up in 3 months understands the motivation, the current state, and where to start.
+
+**Effort:** S / M / L / XL
+**Priority:** P0 / P1 / P2 / P3 / P4
+**Depends on:** <prerequisites, or "None">
+```
+
+**Required fields:** What, Why, Context, Effort, Priority
+**Optional fields:** Depends on, Blocked by
+
+---
+
+## Priority Definitions
+
+- **P0** — Blocking: must be done before next release
+- **P1** — Critical: should be done this cycle
+- **P2** — Important: do when P0/P1 are clear
+- **P3** — Nice-to-have: revisit after adoption/usage data
+- **P4** — Someday: good idea, no urgency
+
+---
+
+## Completed Item Format
+
+When an item is completed, move it to the `## Completed` section preserving its original content and appending:
+
+```markdown
+**Completed:** vX.Y.Z (YYYY-MM-DD)
+```

--- a/.claude/skills/review/checklist.md
+++ b/.claude/skills/review/checklist.md
@@ -1,0 +1,176 @@
+# Pre-Landing Review Checklist — Energy Options Opportunity Agent
+
+## Instructions
+
+Review the `git diff origin/develop` output for the issues listed below. Be specific — cite `file:line` and suggest fixes. Skip anything that's fine. Only flag real problems.
+
+**Three-pass review:**
+- **Pass 0 (HARD RULES):** Energy Options architectural constraints. Any violation is a blocker — no exceptions, no PRs merged with these open.
+- **Pass 1 (CRITICAL):** SQL & Data Safety, Race Conditions, LLM Trust Boundary, Enum Completeness.
+- **Pass 2 (INFORMATIONAL):** All remaining categories.
+
+All findings get action via Fix-First Review: obvious mechanical fixes are applied automatically,
+genuinely ambiguous issues are batched into a single user question.
+
+**Output format:**
+
+```
+Pre-Landing Review: N issues (X hard-rule violations, Y critical, Z informational)
+
+**AUTO-FIXED:**
+- [file:line] Problem → fix applied
+
+**NEEDS INPUT:**
+- [file:line] Problem description
+  Recommended fix: suggested fix
+```
+
+If no issues found: `Pre-Landing Review: No issues found.`
+
+Be terse. For each issue: one line describing the problem, one line with the fix. No preamble, no summaries, no "looks good overall."
+
+---
+
+## Pass 0 — HARD RULES (Energy Options)
+
+These are CI-enforced constraints from the ESOD. Any violation is a BLOCKER. Treat as CRITICAL / ASK — never AUTO-FIX without user confirmation.
+
+#### LangChain/LangGraph Ban
+- Any `import langchain` or `from langchain` anywhere in `src/`
+- Any `import langgraph` or `from langgraph` anywhere in `src/`
+- Zero tolerance. No exceptions.
+
+#### LLM Instantiation
+- Any direct instantiation of OpenAI, Anthropic SDK, or other LLM clients outside `src/core/llm_wrapper.py`
+- Pattern to flag: `from openai import`, `import anthropic`, `OpenAI()`, `Anthropic()` in any file other than `src/core/llm_wrapper.py`
+
+#### External API Retry Policy
+- Any external API call (HTTP, third-party SDK) that does NOT use `@with_retry()` from `src/core/retry.py`
+- Flag: bare `requests.get()`, `requests.post()`, or external SDK calls without the retry decorator
+
+#### Pydantic Validation at Boundaries
+- Inbound data (from external APIs, DB queries returning raw dicts, agent-to-agent message passing) that is NOT validated through a Pydantic model before being processed
+- Flag: raw `dict` or unvalidated `Any` passed directly into processing functions
+
+#### Type Hints on Public Functions
+- Any new or modified public function (no leading `_`) in `src/` missing parameter type hints or return type annotation
+- This is mypy strict — `Any` as a workaround also counts as a flag
+
+#### TimescaleDB Date Columns
+- Any new database column that stores a timestamp or datetime using `TIMESTAMP` without timezone, `datetime`, or Python `datetime.datetime` without UTC enforcement
+- Required: `TIMESTAMPTZ` in SQL DDL; `datetime` with `timezone=True` in SQLAlchemy models
+
+#### Parameterized SQL Only
+- Any SQL string built with Python f-strings, `.format()`, or `%` interpolation
+- Required: parameterized queries (`%s`, `:param`, or ORM) for all values — even integers
+
+#### PostgreSQL Only (no SQLite in src/)
+- Any `sqlite` import or SQLite connection string in `src/`
+- SQLite is test-only (`tests/` is fine)
+
+---
+
+## Pass 1 — CRITICAL
+
+#### SQL & Data Safety
+- String interpolation in SQL (use parameterized queries — see Pass 0)
+- TOCTOU races: check-then-set patterns that should be atomic `WHERE` + `UPDATE`
+- N+1 queries: missing batching for loops over DB results
+
+#### Race Conditions & Concurrency
+- Read-check-write without uniqueness constraint or conflict handling on concurrent agent writes
+- Status transitions on pipeline stages that don't use atomic `WHERE old_status = ? UPDATE SET new_status`
+
+#### LLM Output Trust Boundary
+- LLM-generated values (strategy names, ticker symbols, numeric scores) written to DB or passed downstream without format/range validation
+- Structured tool output (arrays, dicts from LLM) accepted without shape checks before DB writes or Pydantic parsing
+- LLM-generated numeric values (edge scores, probabilities) not clamped to valid ranges before storage
+
+#### Enum & Value Completeness
+When the diff introduces a new pipeline stage status, strategy type, signal type, or ticker symbol:
+- Trace through every consumer (strategy evaluator, feature generator, output schema). Use Grep → Read (not just grep).
+- Check `case`/`if-elif` chains — does the new value fall through to a wrong default?
+
+---
+
+## Pass 2 — INFORMATIONAL
+
+#### Conditional Side Effects
+- Pipeline stage functions that branch on a condition but forget to apply a side effect (e.g., logging, DB write) on one branch
+- Log messages claiming an action happened when the action was conditionally skipped
+
+#### Magic Numbers & String Coupling
+- Bare numeric literals for financial thresholds, score weights, or time windows — should be named constants
+- Ticker symbols or strategy names hardcoded in multiple places
+
+#### Dead Code & Consistency
+- Variables assigned but never read
+- Docstrings or comments describing old behavior after code changed
+
+#### LLM Prompt Issues
+- 0-indexed lists in prompts (LLMs reliably return 1-indexed)
+- Prompt text listing available tools/capabilities that don't match what's actually wired in the agent
+- Score ranges or thresholds stated in both the prompt and code that could drift
+
+#### Test Gaps
+- New pipeline stage functions without unit tests
+- Tests that assert output type but not value correctness (e.g., "returns a list" but not "list contains expected strategies")
+- Missing negative-path tests for invalid input (bad ticker, missing price data, malformed options chain)
+- External API calls in tests that should be mocked
+
+#### Completeness Gaps
+- Partial Pydantic model coverage (fields typed as `Any` or `dict` where a typed model would cost <15 min CC)
+- Missing edge case handling for known data quality issues (NaN prices, empty options chains, zero-volume contracts)
+- Features implemented at 80-90% when 100% is achievable with modest additional code
+
+#### Time Window Safety
+- Date-key lookups that assume "today" is consistent across timezones — use UTC explicitly
+- Mismatched time windows between price ingestion and event detection (e.g., one uses hourly, another daily)
+
+---
+
+## Severity Classification
+
+```
+HARD RULES (blocker):             CRITICAL (highest severity):      INFORMATIONAL (lower severity):
+├─ LangChain/LangGraph ban        ├─ SQL & Data Safety              ├─ Conditional Side Effects
+├─ LLM instantiation outside      ├─ Race Conditions & Concurrency  ├─ Magic Numbers & String Coupling
+│  llm_wrapper.py                 ├─ LLM Output Trust Boundary      ├─ Dead Code & Consistency
+├─ Missing @with_retry()          └─ Enum & Value Completeness      ├─ LLM Prompt Issues
+├─ Missing Pydantic validation                                        ├─ Test Gaps
+├─ Missing type hints                                                 ├─ Completeness Gaps
+├─ Non-TIMESTAMPTZ date cols                                          └─ Time Window Safety
+├─ Non-parameterized SQL
+└─ SQLite in src/
+```
+
+---
+
+## Fix-First Heuristic
+
+```
+AUTO-FIX (agent fixes without asking):     ASK (needs human judgment):
+├─ Dead code / unused variables            ├─ Hard rule violations (always ASK)
+├─ Stale comments contradicting code       ├─ Security (injection, trust boundary)
+├─ Magic numbers → named constants         ├─ Race conditions
+├─ Missing LLM output range clamping       ├─ Design decisions
+├─ Stale docstrings                        ├─ Large fixes (>20 lines)
+└─ Missing test for trivial happy path     ├─ Enum completeness
+                                           ├─ Removing functionality
+                                           └─ Anything changing agent output schema
+```
+
+**Rule of thumb:** If the fix is mechanical and a senior engineer would apply it
+without discussion, it's AUTO-FIX. If reasonable engineers could disagree, it's ASK.
+Hard rule violations are always ASK — they may indicate a design problem, not just a typo.
+
+---
+
+## Suppressions — DO NOT flag these
+
+- "Add a comment explaining why this threshold was chosen" — thresholds change during tuning, comments rot
+- "This assertion could be tighter" when the assertion already covers the behavior
+- Suggesting consistency-only changes when the existing pattern is harmless
+- Score weight or threshold changes — these are tuned empirically
+- `Any` type hints on test helper functions (tests/ only, not src/)
+- ANYTHING already addressed in the diff you're reviewing — read the FULL diff before commenting

--- a/.claude/skills/review/greptile-triage.md
+++ b/.claude/skills/review/greptile-triage.md
@@ -1,0 +1,220 @@
+# Greptile Comment Triage
+
+Shared reference for fetching, filtering, and classifying Greptile review comments on GitHub PRs. Both `/review` (Step 2.5) and `/ship` (Step 3.75) reference this document.
+
+---
+
+## Fetch
+
+Run these commands to detect the PR and fetch comments. Both API calls run in parallel.
+
+```bash
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+PR_NUMBER=$(gh pr view --json number --jq '.number' 2>/dev/null)
+```
+
+**If either fails or is empty:** Skip Greptile triage silently. This integration is additive — the workflow works without it.
+
+```bash
+# Fetch line-level review comments AND top-level PR comments in parallel
+gh api repos/$REPO/pulls/$PR_NUMBER/comments \
+  --jq '.[] | select(.user.login == "greptile-apps[bot]") | select(.position != null) | {id: .id, path: .path, line: .line, body: .body, html_url: .html_url, source: "line-level"}' > /tmp/greptile_line.json &
+gh api repos/$REPO/issues/$PR_NUMBER/comments \
+  --jq '.[] | select(.user.login == "greptile-apps[bot]") | {id: .id, body: .body, html_url: .html_url, source: "top-level"}' > /tmp/greptile_top.json &
+wait
+```
+
+**If API errors or zero Greptile comments across both endpoints:** Skip silently.
+
+The `position != null` filter on line-level comments automatically skips outdated comments from force-pushed code.
+
+---
+
+## Suppressions Check
+
+Derive the project-specific history path:
+```bash
+REMOTE_SLUG=$(browse/bin/remote-slug 2>/dev/null || ~/.claude/skills/gstack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+PROJECT_HISTORY="$HOME/.gstack/projects/$REMOTE_SLUG/greptile-history.md"
+```
+
+Read `$PROJECT_HISTORY` if it exists (per-project suppressions). Each line records a previous triage outcome:
+
+```
+<date> | <repo> | <type:fp|fix|already-fixed> | <file-pattern> | <category>
+```
+
+**Categories** (fixed set): `race-condition`, `null-check`, `error-handling`, `style`, `type-safety`, `security`, `performance`, `correctness`, `other`
+
+Match each fetched comment against entries where:
+- `type == fp` (only suppress known false positives, not previously fixed real issues)
+- `repo` matches the current repo
+- `file-pattern` matches the comment's file path
+- `category` matches the issue type in the comment
+
+Skip matched comments as **SUPPRESSED**.
+
+If the history file doesn't exist or has unparseable lines, skip those lines and continue — never fail on a malformed history file.
+
+---
+
+## Classify
+
+For each non-suppressed comment:
+
+1. **Line-level comments:** Read the file at the indicated `path:line` and surrounding context (±10 lines)
+2. **Top-level comments:** Read the full comment body
+3. Cross-reference the comment against the full diff (`git diff origin/main`) and the review checklist
+4. Classify:
+   - **VALID & ACTIONABLE** — a real bug, race condition, security issue, or correctness problem that exists in the current code
+   - **VALID BUT ALREADY FIXED** — a real issue that was addressed in a subsequent commit on the branch. Identify the fixing commit SHA.
+   - **FALSE POSITIVE** — the comment misunderstands the code, flags something handled elsewhere, or is stylistic noise
+   - **SUPPRESSED** — already filtered in the suppressions check above
+
+---
+
+## Reply APIs
+
+When replying to Greptile comments, use the correct endpoint based on comment source:
+
+**Line-level comments** (from `pulls/$PR/comments`):
+```bash
+gh api repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies \
+  -f body="<reply text>"
+```
+
+**Top-level comments** (from `issues/$PR/comments`):
+```bash
+gh api repos/$REPO/issues/$PR_NUMBER/comments \
+  -f body="<reply text>"
+```
+
+**If a reply POST fails** (e.g., PR was closed, no write permission): warn and continue. Do not stop the workflow for a failed reply.
+
+---
+
+## Reply Templates
+
+Use these templates for every Greptile reply. Always include concrete evidence — never post vague replies.
+
+### Tier 1 (First response) — Friendly, evidence-included
+
+**For FIXES (user chose to fix the issue):**
+
+```
+**Fixed** in `<commit-sha>`.
+
+\`\`\`diff
+- <old problematic line(s)>
++ <new fixed line(s)>
+\`\`\`
+
+**Why:** <1-sentence explanation of what was wrong and how the fix addresses it>
+```
+
+**For ALREADY FIXED (issue addressed in a prior commit on the branch):**
+
+```
+**Already fixed** in `<commit-sha>`.
+
+**What was done:** <1-2 sentences describing how the existing commit addresses this issue>
+```
+
+**For FALSE POSITIVES (the comment is incorrect):**
+
+```
+**Not a bug.** <1 sentence directly stating why this is incorrect>
+
+**Evidence:**
+- <specific code reference showing the pattern is safe/correct>
+- <e.g., "The nil check is handled by `ActiveRecord::FinderMethods#find` which raises RecordNotFound, not nil">
+
+**Suggested re-rank:** This appears to be a `<style|noise|misread>` issue, not a `<what Greptile called it>`. Consider lowering severity.
+```
+
+### Tier 2 (Greptile re-flags after prior reply) — Firm, overwhelming evidence
+
+Use Tier 2 when escalation detection (below) identifies a prior GStack reply on the same thread. Include maximum evidence to close the discussion.
+
+```
+**This has been reviewed and confirmed as [intentional/already-fixed/not-a-bug].**
+
+\`\`\`diff
+<full relevant diff showing the change or safe pattern>
+\`\`\`
+
+**Evidence chain:**
+1. <file:line permalink showing the safe pattern or fix>
+2. <commit SHA where it was addressed, if applicable>
+3. <architecture rationale or design decision, if applicable>
+
+**Suggested re-rank:** Please recalibrate — this is a `<actual category>` issue, not `<claimed category>`. [Link to specific file change permalink if helpful]
+```
+
+---
+
+## Escalation Detection
+
+Before composing a reply, check if a prior GStack reply already exists on this comment thread:
+
+1. **For line-level comments:** Fetch replies via `gh api repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies`. Check if any reply body contains GStack markers: `**Fixed**`, `**Not a bug.**`, `**Already fixed**`.
+
+2. **For top-level comments:** Scan the fetched issue comments for replies posted after the Greptile comment that contain GStack markers.
+
+3. **If a prior GStack reply exists AND Greptile posted again on the same file+category:** Use Tier 2 (firm) templates.
+
+4. **If no prior GStack reply exists:** Use Tier 1 (friendly) templates.
+
+If escalation detection fails (API error, ambiguous thread): default to Tier 1. Never escalate on ambiguity.
+
+---
+
+## Severity Assessment & Re-ranking
+
+When classifying comments, also assess whether Greptile's implied severity matches reality:
+
+- If Greptile flags something as a **security/correctness/race-condition** issue but it's actually a **style/performance** nit: include `**Suggested re-rank:**` in the reply requesting the category be corrected.
+- If Greptile flags a low-severity style issue as if it were critical: push back in the reply.
+- Always be specific about why the re-ranking is warranted — cite code and line numbers, not opinions.
+
+---
+
+## History File Writes
+
+Before writing, ensure both directories exist:
+```bash
+REMOTE_SLUG=$(browse/bin/remote-slug 2>/dev/null || ~/.claude/skills/gstack/browse/bin/remote-slug 2>/dev/null || basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+mkdir -p "$HOME/.gstack/projects/$REMOTE_SLUG"
+mkdir -p ~/.gstack
+```
+
+Append one line per triage outcome to **both** files (per-project for suppressions, global for retro):
+- `~/.gstack/projects/$REMOTE_SLUG/greptile-history.md` (per-project)
+- `~/.gstack/greptile-history.md` (global aggregate)
+
+Format:
+```
+<YYYY-MM-DD> | <owner/repo> | <type> | <file-pattern> | <category>
+```
+
+Example entries:
+```
+2026-03-13 | garrytan/myapp | fp | app/services/auth_service.rb | race-condition
+2026-03-13 | garrytan/myapp | fix | app/models/user.rb | null-check
+2026-03-13 | garrytan/myapp | already-fixed | lib/payments.rb | error-handling
+```
+
+---
+
+## Output Format
+
+Include a Greptile summary in the output header:
+```
++ N Greptile comments (X valid, Y fixed, Z FP)
+```
+
+For each classified comment, show:
+- Classification tag: `[VALID]`, `[FIXED]`, `[FALSE POSITIVE]`, `[SUPPRESSED]`
+- File:line reference (for line-level) or `[top-level]` (for top-level)
+- One-line body summary
+- Permalink URL (the `html_url` field)

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -269,3 +269,12 @@ Phase 2 planning (issue #23) complete:
 - Issue #23 closed.
 
 Sprint 6 ready to start. No blockers.
+
+## Sprint Notes (2026-03-18, session 1)
+
+Issue #128 implemented on `test/128-degraded-mode-pipeline`:
+- Strengthened `tests/pipeline/test_pipeline.py` degraded-mode coverage to mock only `run_ingestion()`, `run_event_detection()`, and `run_feature_generation()` while exercising real `evaluate_strategies()`.
+- Regression now asserts `run_pipeline()` logs a WARNING containing "degraded mode" when `run_event_detection()` raises `EventDetectionError`.
+- Regression now asserts degraded mode still returns a non-empty list of `StrategyCandidate` objects and that event-driven signal labels stay at defaults (`supply_shock_probability="none"`, `futures_curve_steepness="flat"`).
+- Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
+- #128 In Review, PR #139 opened 2026-03-18

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -296,3 +296,13 @@ Issue #127 implemented on `test/127-phase2-multiplier-zero-effect`:
 - Existing coverage for curve steepness increase (`0.05`) and max-value clamping (`<= 1.0`) remains in place and passes.
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #127 In Review, PR #141 opened 2026-03-18
+- #127 In Review, PR #141 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 4)
+
+Issue #111 implemented on `chore/111-timescaledb-migration-plan`:
+- Created `db/migrate_timescaledb.sql`: idempotent migration script enabling `CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE` and `create_hypertable` calls (with `if_not_exists => TRUE`) for all four partition candidates: `market_prices.timestamp`, `options_chain.timestamp`, `eia_inventory.fetched_at`, `detected_events.detected_at`. Full rollback procedure documented as inline comments.
+- Created `docs/timescaledb_migration.md`: migration guide covering PRD §6.2 trigger criteria, pre-migration checklist, step-by-step apply/verify commands, rollback procedure, and Docker Compose note.
+- AC audit: `db/schema.sql` header and `docker-compose.yml` TimescaleDB image were both already satisfying their respective ACs (pre-existing); no existing files modified.
+- Gate: `pytest -m "not integration"` 248 passed; `bash scripts/local_check.sh` ALL STAGES PASSED.
+- #111 In Review, PR #142 opened 2026-03-18

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -278,3 +278,12 @@ Issue #128 implemented on `test/128-degraded-mode-pipeline`:
 - Regression now asserts degraded mode still returns a non-empty list of `StrategyCandidate` objects and that event-driven signal labels stay at defaults (`supply_shock_probability="none"`, `futures_curve_steepness="flat"`).
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #128 In Review, PR #139 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 2)
+
+Issue #129 implemented on `test/129-correlated-instruments-candidate-count`:
+- Added `test_correlated_instruments_yield_18_equal_score_candidates()` to `tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py`.
+- Regression asserts exactly 18 candidates (6 in-scope instruments × 3 structures), identical edge scores across all candidates, and deterministic order under equal-score stable sorting.
+- Test docstring documents that 18 correlated candidates are expected behavior and references concentration filter issue #132 for future de-duplication.
+- Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
+- #129 In Review, PR #140 opened 2026-03-18

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -256,3 +256,16 @@ two independent blocks at the bottom of the file — git merges them as clean ap
 - Sprint issues have changed status but the table has not been updated
 - The last session was >24 hours ago and sprint notes have no new entries
 - Status still says "PLANNING" after sprint_start.sh was run
+
+## Sprint Notes (2026-03-15, Phase 2 Planning)
+
+Phase 1 release complete — v0.1.0 tagged and shipped (PR #99, merge commit ffff9dc).
+
+Phase 2 planning (issue #23) complete:
+- Created Sprint milestones: Sprint 6 (Event Detection Data Layer), Sprint 7 (Event Orchestration & Feature Updates), Sprint 8 (Phase 2 QA & Release)
+- Created 14 issues: #100–#113 covering all Phase 2 scope from PRD §4.2, §8, §10
+- Key decisions recorded: NewsAPI key confirmed, eia_inventory as separate DB table, LLM classification via llm_wrapper.py for classify_event, Phase 2 in new sprints (6–8)
+- Fixed CI false-positives blocking PR #99: PR review agent now exempts develop branch and develop→main release PRs; doc-gen workflow skips push for protected head branches
+- Issue #23 closed.
+
+Sprint 6 ready to start. No blockers.

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -306,3 +306,9 @@ Issue #111 implemented on `chore/111-timescaledb-migration-plan`:
 - AC audit: `db/schema.sql` header and `docker-compose.yml` TimescaleDB image were both already satisfying their respective ACs (pre-existing); no existing files modified.
 - Gate: `pytest -m "not integration"` 248 passed; `bash scripts/local_check.sh` ALL STAGES PASSED.
 - #111 In Review, PR #142 opened 2026-03-18
+
+## Sprint Notes (2026-03-21, release)
+
+Issue #113 — Phase 2 release PR opened:
+- All AC items verified: local_check.sh clean on develop, Sprint 6+7 closed, #110/#111/#112/#23 all closed.
+- #113 In Review, PR #147 opened 2026-03-21

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -287,3 +287,12 @@ Issue #129 implemented on `test/129-correlated-instruments-candidate-count`:
 - Test docstring documents that 18 correlated candidates are expected behavior and references concentration filter issue #132 for future de-duplication.
 - Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
 - #129 In Review, PR #140 opened 2026-03-18
+
+## Sprint Notes (2026-03-18, session 3)
+
+Issue #127 implemented on `test/127-phase2-multiplier-zero-effect`:
+- Updated `test_supply_shock_increases_score()` in `tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py` to use the explicit AC value `supply_shock_probability=0.8`.
+- Added `test_zero_effect_inputs_equivalent_to_none()` to assert zero-effect equivalence (`supply_shock_probability=0.0`, `futures_curve_steepness=0.0`) versus `None` inputs.
+- Existing coverage for curve steepness increase (`0.05`) and max-value clamping (`<= 1.0`) remains in place and passes.
+- Gate: `pytest -m "not integration"` and `bash scripts/local_check.sh` both passed.
+- #127 In Review, PR #141 opened 2026-03-18

--- a/db/migrate_timescaledb.sql
+++ b/db/migrate_timescaledb.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- db/migrate_timescaledb.sql — TimescaleDB hypertable migration
+-- Energy Options Opportunity Agent
+-- =============================================================================
+--
+-- Purpose: Convert the four time-series partitioning candidates defined in
+--   db/schema.sql to TimescaleDB hypertables.
+--
+-- Migration triggers (PRD §6.2) — run this script when ANY of the following:
+--   1. Historical data exceeds 6 months of tick-level market data.
+--   2. Backtesting range queries consistently exceed 5 seconds.
+--   3. Team size grows beyond a single contributor.
+--
+-- Idempotency: All statements use IF NOT EXISTS / if_not_exists => TRUE.
+--   Safe to run multiple times against the same database; existing hypertables
+--   produce a NOTICE, not an error.
+--
+-- Pre-migration requirements:
+--   - PostgreSQL 15+ running (matches docker-compose.yml: timescale/timescaledb:2.15.2-pg15)
+--   - db/schema.sql already applied (all four tables must exist)
+--   - TimescaleDB extension available in the PostgreSQL cluster
+--
+-- Apply:
+--   psql $DATABASE_URL -f db/schema.sql          # if not already applied
+--   psql $DATABASE_URL -f db/migrate_timescaledb.sql
+--
+-- Verify:
+--   SELECT hypertable_name, num_dimensions FROM timescaledb_information.hypertables;
+-- =============================================================================
+
+
+-- Step 1: Enable the TimescaleDB extension
+CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+
+
+-- Step 2: Convert time-series tables to hypertables
+--
+-- market_prices — partition by timestamp (tick-level WTI, Brent, USO, XLE, XOM, CVX)
+SELECT create_hypertable('market_prices', 'timestamp', if_not_exists => TRUE);
+
+-- options_chain — partition by timestamp (tick-level options records)
+SELECT create_hypertable('options_chain', 'timestamp', if_not_exists => TRUE);
+
+-- eia_inventory — partition by fetched_at (weekly EIA petroleum status reports)
+SELECT create_hypertable('eia_inventory', 'fetched_at', if_not_exists => TRUE);
+
+-- detected_events — partition by detected_at (classified energy market events)
+SELECT create_hypertable('detected_events', 'detected_at', if_not_exists => TRUE);
+
+
+-- =============================================================================
+-- ROLLBACK PROCEDURE
+-- =============================================================================
+--
+-- TimescaleDB does not provide a direct "undo hypertable" command. To revert
+-- a table from a hypertable back to a regular PostgreSQL table:
+--
+--   1. Export the data:
+--        \COPY market_prices TO '/tmp/market_prices_backup.csv' CSV HEADER;
+--        (repeat for each hypertable)
+--
+--   2. Drop the hypertable (this drops all chunks and data):
+--        DROP TABLE market_prices;
+--        DROP TABLE options_chain;
+--        DROP TABLE eia_inventory;
+--        DROP TABLE detected_events;
+--
+--   3. Re-create as regular tables (re-apply db/schema.sql):
+--        psql $DATABASE_URL -f db/schema.sql
+--
+--   4. Re-import data:
+--        \COPY market_prices FROM '/tmp/market_prices_backup.csv' CSV HEADER;
+--        (repeat for each table)
+--
+--   5. Drop the extension (optional — only if no other databases use it):
+--        DROP EXTENSION IF EXISTS timescaledb CASCADE;
+--
+-- WARNING: Steps 2–3 are destructive. Always back up data before rolling back.
+-- =============================================================================

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,6 @@
 -- =============================================================================
 -- db/schema.sql — Energy Options Opportunity Agent
--- Phase 1 schema: Ingestion Agent tables
+-- Phase 1 + Phase 2 schema
 -- =============================================================================
 --
 -- Design principles (PRD Section 6.1):
@@ -10,6 +10,8 @@
 --   - Hypertable candidates (Phase 2, PRD Section 6.2):
 --       * market_prices   → partition by timestamp
 --       * options_chain   → partition by timestamp
+--       * eia_inventory   → partition by fetched_at
+--       * detected_events → partition by detected_at
 --
 -- TimescaleDB migration triggers (PRD Section 6.2) — convert to hypertables
 -- when ANY of the following conditions is met:
@@ -17,12 +19,11 @@
 --   2. Backtesting range queries consistently exceed 5 seconds.
 --   3. Team size grows beyond a single contributor.
 --
--- Migration command (no schema changes required):
---   SELECT create_hypertable('market_prices', 'timestamp');
---   SELECT create_hypertable('options_chain', 'timestamp');
+-- Migration script: db/migrate_timescaledb.sql (see issue #111)
 --
 -- Apply:  psql $DATABASE_URL -f db/schema.sql
--- Verify: \d market_prices    \d options_chain    \d feature_sets    \d strategy_candidates
+-- Verify: \d market_prices    \d options_chain    \d feature_sets
+--         \d strategy_candidates    \d eia_inventory    \d detected_events
 -- =============================================================================
 
 
@@ -112,3 +113,52 @@ CREATE TABLE IF NOT EXISTS feature_sets (
 
 CREATE INDEX IF NOT EXISTS idx_feature_sets_snapshot_time
     ON feature_sets (snapshot_time DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- eia_inventory
+--
+-- Stores weekly EIA petroleum status report records fetched by the Event
+-- Detection Agent (fetch_eia_data). One row per reporting period (week).
+-- UNIQUE on period ensures re-ingestion is idempotent (ON CONFLICT DO NOTHING).
+-- Hypertable candidate: partition by fetched_at.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS eia_inventory (
+    id                          BIGSERIAL       PRIMARY KEY,
+    period                      TEXT            NOT NULL,
+    crude_stocks_mb             NUMERIC(12, 3),
+    refinery_utilization_pct    NUMERIC(6, 3),
+    source                      TEXT            NOT NULL DEFAULT 'eia',
+    fetched_at                  TIMESTAMPTZ     NOT NULL,
+    CONSTRAINT uq_eia_inventory_period UNIQUE (period)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eia_inventory_period
+    ON eia_inventory (period DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- detected_events
+--
+-- Stores classified energy market events produced by the Event Detection Agent
+-- (classify_event → write_detected_events). event_id is a deterministic hash
+-- of the source URL — UNIQUE ensures re-classification is idempotent.
+-- affected_instruments is a JSONB array of ticker strings.
+-- Hypertable candidate: partition by detected_at.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS detected_events (
+    id                      BIGSERIAL       PRIMARY KEY,
+    event_id                TEXT            NOT NULL,
+    event_type              TEXT            NOT NULL,
+    description             TEXT            NOT NULL,
+    source                  TEXT            NOT NULL,
+    confidence_score        NUMERIC(5, 4)   NOT NULL,
+    intensity               TEXT            NOT NULL,
+    detected_at             TIMESTAMPTZ     NOT NULL,
+    affected_instruments    JSONB,
+    raw_headline            TEXT,
+    CONSTRAINT uq_detected_events_event_id UNIQUE (event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_detected_events_detected_at
+    ON detected_events (detected_at DESC);

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
+> **Version 1.0 · March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline end-to-end. It assumes you are comfortable with Python, virtual environments, and basic CLI usage.
 
 ---
 
@@ -18,377 +18,379 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline that identifies options trading opportunities driven by oil market instability. It consumes market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies with full signal explainability.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that surfaces options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical news, and alternative datasets, then produces structured, ranked candidate options strategies.
 
-### Pipeline Architecture
-
-The system is composed of four loosely coupled agents. Data flows **unidirectionally** through the pipeline:
+### What the pipeline does
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
-        A8[Sentiment\nReddit / Stocktwits]
+    subgraph Sources["External Data Sources"]
+        A1[Alpha Vantage / MetalpriceAPI\nCrude Prices]
+        A2[yfinance / Polygon.io\nETF & Equity Prices + Options]
+        A3[EIA API\nInventory & Utilization]
+        A4[GDELT / NewsAPI\nNews & Geo Events]
+        A5[SEC EDGAR / Quiver Quant\nInsider Activity]
+        A6[MarineTraffic / VesselFinder\nShipping & Tanker Flows]
+        A7[Reddit / Stocktwits\nNarrative Sentiment]
     end
 
-    subgraph Pipeline
-        B1["① Data Ingestion Agent\nFetch & Normalize"]
-        B2["② Event Detection Agent\nSupply & Geo Signals"]
-        B3["③ Feature Generation Agent\nDerived Signal Computation"]
-        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Pipeline["Agent Pipeline"]
+        B["① Data Ingestion Agent\nFetch & Normalize"]
+        C["② Event Detection Agent\nSupply & Geo Signals"]
+        D["③ Feature Generation Agent\nDerived Signal Computation"]
+        E["④ Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Output
-        C1[Ranked Candidates\nJSON / Dashboard]
+    subgraph Output["Output"]
+        F[Ranked Candidate JSON\nEdge-scored Opportunities]
     end
 
-    A1 & A2 & A3 & A4 --> B1
-    A5 --> B2
-    A6 & A7 & A8 --> B3
-
-    B1 -->|Unified Market State| B2
-    B2 -->|Scored Events| B3
-    B3 -->|Derived Features| B4
-    B4 --> C1
+    Sources --> B
+    B -->|Unified Market State| C
+    C -->|Scored Events| D
+    D -->|Derived Features| E
+    E --> F
 ```
 
-### Agents at a Glance
+### In-scope instruments and strategies
 
-| Agent | Role | Key Outputs |
-|---|---|---|
-| **Data Ingestion** | Fetch & Normalize | Unified market state object; historical store |
-| **Event Detection** | Supply & Geo Signals | Events with confidence and intensity scores |
-| **Feature Generation** | Derived Signal Computation | Volatility gaps, curve steepness, narrative velocity, etc. |
-| **Strategy Evaluation** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
-
-### In-Scope Instruments (MVP)
-
-| Category | Instruments |
+| Category | Items |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| **Crude futures** | Brent Crude, WTI (`CL=F`) |
+| **ETFs** | USO, XLE |
+| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
 
-### In-Scope Option Structures (MVP)
-
-- Long straddles
-- Call / put spreads
-- Calendar spreads
-
-> **Advisory only.** Automated trade execution is explicitly out of scope for the MVP. All output is intended for human review.
+> **Advisory only.** The system generates recommendations but performs no automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| Operating System | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 5 GB (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| Memory | 2 GB RAM |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS on port 443 |
+| OS | Linux, macOS, or Windows (WSL2 recommended on Windows) |
 
-### Required Knowledge
+### Required accounts and API keys
 
-- Comfortable running Python scripts and CLI commands
-- Familiarity with virtual environments (`venv` or `conda`)
-- Basic understanding of options terminology (implied volatility, strikes, expiration)
+All sources are free or free-tier. Obtain credentials before proceeding.
 
-### API Accounts
+| Service | Purpose | Sign-up URL |
+|---|---|---|
+| Alpha Vantage | Crude spot/futures prices | <https://www.alphavantage.co/support/#api-key> |
+| MetalpriceAPI | Supplemental commodity prices | <https://metalpriceapi.com> |
+| Polygon.io | Options chains (free tier) | <https://polygon.io> |
+| EIA API | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
+| NewsAPI | News & geopolitical events | <https://newsapi.org> |
+| SEC EDGAR | Insider activity (no key required) | <https://efts.sec.gov/LATEST/search-index?q=%22form-type%22:%224%22> |
+| Quiver Quant | Insider conviction scores (optional) | <https://www.quiverquant.com> |
 
-You must obtain API keys or free-tier access for the following services before running the pipeline. All sources are free or low-cost.
+> **Yahoo Finance / yfinance** and **GDELT** require no API key. **MarineTraffic** and **VesselFinder** offer free tiers; register at their respective sites if you want shipping signals in Phase 3.
 
-| Data Layer | Source | Sign-up URL | Cost |
-|---|---|---|---|
-| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free |
-| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free |
-| ETF / Equity | yfinance (Yahoo Finance) | No key required | Free |
-| Options Chains | Polygon.io | https://polygon.io | Free / Limited |
-| Supply & Inventory | EIA API | https://www.eia.gov/opendata | Free |
-| News & Geo Events | NewsAPI | https://newsapi.org | Free |
-| News & Geo Events (alt) | GDELT | https://www.gdeltproject.org | Free |
-| Insider Activity | SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free |
-| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free / Limited |
-| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
-| Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free |
-| Sentiment (alt) | Stocktwits | https://api.stocktwits.com/developers | Free |
+### Python dependencies
+
+Install dependencies from the project's `requirements.txt` after cloning (see [Setup & Configuration](#setup--configuration)).
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows (PowerShell)
+python -m venv .venv
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-All runtime configuration is provided through environment variables. Copy the example file and populate it with your credentials:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and fill in the values described in the table below.
+Open `.env` in your editor and fill in each value. The full set of recognised environment variables is listed below.
 
-#### Environment Variable Reference
+#### Environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | No | — | API key for MetalpriceAPI (fallback crude feed) |
-| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA supply and inventory data |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/news events |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
-| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic shipping data |
-| `REDDIT_CLIENT_ID` | No | — | Reddit PRAW application client ID |
-| `REDDIT_CLIENT_SECRET` | No | — | Reddit PRAW application client secret |
-| `REDDIT_USER_AGENT` | No | `energy-agent/1.0` | Reddit PRAW user agent string |
-| `STOCKTWITS_API_KEY` | No | — | Stocktwits API key for sentiment feed |
-| `DATA_DIR` | No | `./data` | Root directory for raw and derived data storage |
-| `OUTPUT_DIR` | No | `./output` | Directory where ranked JSON candidates are written |
-| `HISTORY_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
-| `MARKET_DATA_INTERVAL_SECONDS` | No | `60` | Polling cadence for minute-level market data feeds |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_MODE` | No | `full` | Run mode: `full`, `ingest_only`, `features_only`, `evaluate_only` |
-| `MIN_EDGE_SCORE` | No | `0.30` | Minimum edge score threshold for a candidate to appear in output |
-| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | ✅ | — | API key for MetalpriceAPI commodity feed |
+| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | ✅ | — | API key for EIA inventory/refinery data |
+| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI news/geo event feed |
+| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider signals (Phase 3) |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
+| `DATA_DIR` | ⬜ | `./data` | Local path for storing raw and derived historical data |
+| `OUTPUT_DIR` | ⬜ | `./output` | Directory where ranked candidate JSON files are written |
+| `LOG_LEVEL` | ⬜ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
+| `EIA_REFRESH_SCHEDULE` | ⬜ | `weekly` | Refresh schedule for EIA data (`daily` or `weekly`) |
+| `EDGAR_REFRESH_SCHEDULE` | ⬜ | `daily` | Refresh schedule for SEC EDGAR insider filings |
+| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Number of days of historical data to retain on disk |
+| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`4`); controls which agents are enabled |
+| `INSTRUMENTS` | ⬜ | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to evaluate |
+| `OPTION_STRUCTURES` | ⬜ | `long_straddle,call_spread,put_spread,calendar_spread` | Comma-separated list of eligible option structures |
+| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score `[0.0–1.0]` for a candidate to appear in output |
 
-> **Tip:** Variables marked **No** under *Required* activate optional data layers (shipping, insider, sentiment). The pipeline degrades gracefully when these keys are absent — see [Troubleshooting](#troubleshooting).
+> **Tip:** Variables marked ⬜ are optional for Phase 1 but may be required by later phases. Leave optional keys blank or commented out if their Phase has not been activated.
 
-#### Example `.env` File
+#### Minimal `.env` for Phase 1
 
 ```dotenv
-# Core credentials (required)
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+METALPRICE_API_KEY=your_metalprice_key
+POLYGON_API_KEY=your_polygon_key
+EIA_API_KEY=your_eia_key
+NEWS_API_KEY=your_newsapi_key
 
-# Optional enrichment layers
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-QUIVER_QUANT_API_KEY=YOUR_QUIVER_KEY_HERE
-MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
-REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
-REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
-REDDIT_USER_AGENT=energy-agent/1.0
-
-# Runtime settings
+# Optional overrides
 DATA_DIR=./data
 OUTPUT_DIR=./output
-HISTORY_DAYS=365
-MARKET_DATA_INTERVAL_SECONDS=60
 LOG_LEVEL=INFO
-PIPELINE_MODE=full
-MIN_EDGE_SCORE=0.30
-MAX_CANDIDATES=20
+PIPELINE_PHASE=1
+EDGE_SCORE_THRESHOLD=0.30
 ```
 
-### 5. Initialise the Data Directory
-
-Create the storage structure required for historical raw and derived data:
+### 5. Initialise local data storage
 
 ```bash
-python scripts/init_storage.py
+python -m agent init
 ```
 
-Expected output:
+This creates the directory structure under `DATA_DIR` and writes empty schema files for the historical store.
 
 ```
-[INFO] Created directory: ./data/raw
-[INFO] Created directory: ./data/derived
-[INFO] Created directory: ./output
-[INFO] Storage initialised successfully.
+data/
+├── raw/
+│   ├── prices/
+│   ├── options/
+│   ├── eia/
+│   ├── events/
+│   ├── insider/
+│   └── shipping/
+└── derived/
+    ├── features/
+    └── market_state/
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Execution Flow
+### Pipeline execution flow
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant CLI as pipeline.py (CLI)
+    participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (output/)
+    participant Store as Local Data Store
+    participant Out as Output (JSON)
 
-    User->>CLI: python pipeline.py --mode full
-    CLI->>DIA: run()
-    DIA-->>CLI: market_state (unified object)
-    CLI->>EDA: run(market_state)
-    EDA-->>CLI: event_signals (scored events)
-    CLI->>FGA: run(market_state, event_signals)
-    FGA-->>CLI: derived_features (vol gaps, curve, etc.)
-    CLI->>SEA: run(market_state, event_signals, derived_features)
-    SEA-->>CLI: ranked_candidates[]
-    CLI->>FS: write candidates_<timestamp>.json
-    CLI-->>User: Summary printed to stdout
+    User->>CLI: python -m agent run
+    CLI->>DIA: trigger ingestion
+    DIA->>Store: fetch & persist raw feeds
+    DIA-->>EDA: emit unified market state
+    EDA->>Store: score & persist events
+    EDA-->>FGA: emit scored event list
+    FGA->>Store: compute & persist derived features
+    FGA-->>SEA: emit feature vector
+    SEA->>Out: write ranked candidate JSON
+    SEA-->>CLI: pipeline complete
+    CLI-->>User: exit 0 / log summary
 ```
 
-### Full Pipeline Run
+### Running once (single-shot)
 
-Run all four agents in sequence:
+Execute a full pipeline run against current market data and exit:
 
 ```bash
-python pipeline.py --mode full
+python -m agent run
 ```
 
-### Partial / Single-Agent Runs
+On success the process exits with code `0` and writes one or more candidate files to `OUTPUT_DIR`.
 
-Use `--mode` to run only a subset of the pipeline. This is useful for debugging or when feeding pre-computed intermediate data.
+### Running with a specific phase
+
+Override the active phase at the command line without changing `.env`:
 
 ```bash
-# Re-ingest raw market data only
-python pipeline.py --mode ingest_only
-
-# Regenerate features from cached market state
-python pipeline.py --mode features_only
-
-# Re-evaluate strategies using the latest cached features
-python pipeline.py --mode evaluate_only
+python -m agent run --phase 2
 ```
 
-### Scheduled Continuous Execution
+### Running individual agents
 
-For production use, drive the pipeline on a regular cadence using `cron` (Linux/macOS) or Task Scheduler (Windows):
+Each agent can be executed in isolation for debugging or incremental development:
 
 ```bash
-# Example: run the full pipeline every 5 minutes during market hours
-crontab -e
+# Step 1 – ingest and normalize market data
+python -m agent run --agent ingestion
+
+# Step 2 – detect and score supply/geo events
+python -m agent run --agent events
+
+# Step 3 – compute derived features
+python -m agent run --agent features
+
+# Step 4 – evaluate and rank strategies
+python -m agent run --agent strategy
 ```
+
+> Agents consume inputs from the shared data store, so they can be run independently as long as upstream outputs are already present on disk.
+
+### Scheduled / continuous operation
+
+The pipeline is designed for a minutes-level market data cadence and slower daily/weekly cadences for EIA and EDGAR. Use `cron` (Linux/macOS) or Task Scheduler (Windows) to automate runs.
+
+**Example cron entries:**
 
 ```cron
-*/5 9-17 * * 1-5 /path/to/.venv/bin/python /path/to/pipeline.py --mode full >> /var/log/energy-agent.log 2>&1
+# Full pipeline every 5 minutes during trading hours (Mon–Fri, 09:00–17:00 ET)
+*/5 9-17 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent run >> logs/pipeline.log 2>&1
+
+# EIA and EDGAR refresh once daily at 06:00
+0 6 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent run --agent ingestion --feeds eia,edgar >> logs/slow_feeds.log 2>&1
 ```
 
-> **Note:** Market data refreshes on a minutes-level cadence. Slower feeds (EIA inventory, EDGAR insider filings) update daily or weekly; the pipeline applies the appropriate polling frequency per source automatically.
-
-### Verbose / Debug Mode
+### Running inside Docker (optional)
 
 ```bash
-python pipeline.py --mode full --log-level DEBUG
-```
+docker build -t energy-options-agent .
 
-Or set `LOG_LEVEL=DEBUG` in your `.env` file for persistent debug output.
-
-### Running Inside Docker
-
-A `Dockerfile` and `docker-compose.yml` are provided for containerised deployment on a single VM or local machine:
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run with your .env file mounted
-docker run --env-file .env \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/output:/app/output \
-  energy-options-agent:latest
+docker run --rm \
+  --env-file .env \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/output:/app/output" \
+  energy-options-agent python -m agent run
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output Location
+### Output location
 
-After each run, candidates are written to the directory specified by `OUTPUT_DIR` (default: `./output`):
+After each pipeline run, ranked candidates are written to `OUTPUT_DIR` (default `./output`) as timestamped JSON files:
 
 ```
 output/
-└── candidates_2026-03-15T14:32:00Z.json
+└── candidates_20260315T143002Z.json
 ```
 
-A `candidates_latest.json` symlink is also updated to always point to the most recent file.
+### Output schema
 
-### Output Schema
-
-Each ranked candidate is a JSON object with the following fields:
+Each file contains a JSON array of candidate objects. Every candidate exposes the following fields:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `structure` | `enum` | Options structure: `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
 | `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current values |
+| `signals` | `object` | Map of contributing signals and their qualitative state |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Candidate
+### Example output
 
 ```json
-{
-  "instrument": "USO",
-  "structure": "long_straddle",
-  "expiration": 30,
-  "edge_score": 0.47,
-  "signals": {
-    "tanker_disruption_index": "high",
-    "volatility_gap": "positive",
-    "narrative_velocity": "rising"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
+    },
+    "generated_at": "2026-03-15T14:30:02Z"
   },
-  "generated_at": "2026-03-15T14:32:00Z"
-}
+  {
+    "instrument": "XLE",
+    "structure": "call_spread",
+    "expiration": 21,
+    "edge_score": 0.38,
+    "signals": {
+      "volatility_gap": "positive",
+      "supply_shock_probability": "elevated",
+      "sector_dispersion": "widening"
+    },
+    "generated_at": "2026-03-15T14:30:02Z"
+  }
+]
 ```
 
-### Reading the Edge Score
+### Reading the edge score
 
-The `edge_score` is the primary ranking signal. It is a composite of all contributing derived features, normalised to `[0.0, 1.0]`.
-
-| Edge Score Range | Interpretation |
+| Edge Score | Interpretation |
 |---|---|
-| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
-| `0.50 – 0.69` | Moderate signal confluence — worth monitoring |
-| `0.30 – 0.49` | Weak confluence — lower conviction, proceed with caution |
-| `< 0.30` | Below threshold — filtered out by default (`MIN_EDGE_SCORE`) |
+| `0.70 – 1.00` | Strong signal confluence; high-conviction candidate |
+| `0.50 – 0.69` | Moderate confluence; worth monitoring closely |
+| `0.30 – 0.49` | Weak but non-trivial signal; treat as low-priority |
+| `< 0.30` | Below threshold; filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
 
-> Candidates are ordered by `edge_score` descending. Review the `signals` object for every candidate to understand **why** the score was assigned before acting on any recommendation.
+### Understanding contributing signals
 
-### Contributing Signals Reference
+The `signals` object explains *why* a candidate was ranked. Common signal keys and their meanings:
 
-The `signals` object may contain any of the following keys, depending on which data layers are active:
+| Signal Key | What it measures |
+|---|---|
+| `volatility_gap` | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Contango or backwardation in the crude curve |
+| `sector_dispersion` | Spread between energy sub-sector returns |
+| `insider_conviction` | Aggregated insider buying/selling intensity (EDGAR) |
+| `narrative_velocity` | Acceleration of energy-related headlines or social mentions |
+| `supply_shock_probability` | Composite probability of a near-term supply disruption |
+| `tanker_disruption_index` | Shipping-flow anomalies at key chokepoints |
 
-| Signal Key | Source Layer | Possible Values |
+### Visualising output in thinkorswim
+
+The JSON output is compatible with any JSON-capable dashboard. To load into thinkorswim:
+
+1. Point a **thinkScript** custom scan or watchlist import at the `OUTPUT_DIR` path (or a local HTTP server serving the JSON files).
+2. Map `instrument` to the symbol column and `edge_score` to a custom column for sorting.
+3. Use the `signals` map fields as annotation columns for context.
+
+---
+
+## Troubleshooting
+
+### Common errors and fixes
+
+| Symptom | Likely Cause | Resolution |
 |---|---|---|
-| `volatility_gap` | Feature Generation | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | Feature Generation | `contango`, `backwardation`, `flat` |
-| `sector_dispersion` | Feature Generation | `high`, `moderate`, `low` |
-| `insider_conviction_score` | Alternative Signals | `high`, `moderate`, `low` |
-| `narrative_velocity` | Alternative Signals | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | Event Detection | `high`, `moderate`, `low` |
-| `tanker_disruption_index` | Event Detection | `high`, `moderate`, `low` |
-| `eia_inventory_surprise` | Event Detection | `bullish`, `bearish`, `neutral` |
-
-###
+| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | Missing or unset environment variable | Confirm `.env` is populated and loaded; re-run `source .env` or verify your shell exports the variable |
+| `HTTPError 429 Too Many Requests` | API rate limit exceeded | Increase `MARKET_DATA_INTERVAL_MINUTES`; check free-tier rate limits for the affected source |
+|

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline end-to-end. It assumes you are comfortable with Python, the command line, and environment variables, but have not worked with this project before.
+> This guide walks you through configuring, running, and interpreting results from the full four-agent pipeline. It assumes you are comfortable with Python and the command line but are new to this project.
 
 ---
 
@@ -18,55 +18,73 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It is advisory only — no orders are placed automatically.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
 
 ### What the pipeline does
 
-The pipeline runs four loosely coupled agents in sequence, each writing results to a shared state that the next agent consumes:
+| Stage | Agent | Output |
+|---|---|---|
+| **1 · Ingest** | Data Ingestion Agent | Unified market state object |
+| **2 · Detect** | Event Detection Agent | Scored supply / geopolitical events |
+| **3 · Derive** | Feature Generation Agent | Volatility gaps, curve metrics, shock probabilities |
+| **4 · Rank** | Strategy Evaluation Agent | Ranked opportunities with edge scores |
+
+### In-scope instruments (MVP)
+
+| Class | Symbols |
+|---|---|
+| Crude futures | Brent, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy equities | XOM, CVX |
+
+### In-scope option structures (MVP)
+
+`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
+
+> **Advisory only.** The system produces ranked recommendations; it does **not** execute trades automatically.
+
+---
+
+### Pipeline Architecture
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Crude prices\nWTI · Brent]
-        A2[ETF / Equity prices\nUSO · XLE · XOM · CVX]
-        A3[Options chains\nstrike · expiry · IV · volume]
+    subgraph Inputs
+        A1[(Crude / ETF\nPrices)]
+        A2[(Options\nChains)]
+        A3[(EIA Supply\nData)]
+        A4[(News /\nGDELT)]
+        A5[(Insider /\nShipping /\nSentiment)]
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[News & geo feeds\nGDELT · NewsAPI]
-        B2[Supply signals\nEIA · shipping]
-        B3[Confidence &\nintensity scoring]
+    subgraph Agent_1["① Data Ingestion Agent"]
+        B[Fetch & Normalize\nAll Feeds]
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Volatility gap\nrealised vs implied]
-        C2[Futures curve\nsteepness]
-        C3[Supply shock\nprobability]
-        C4[Narrative velocity\ninsider conviction]
+    subgraph Agent_2["② Event Detection Agent"]
+        C[Detect Supply Disruptions\nGeopolitical Events\nScore Confidence / Intensity]
     end
 
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate eligible\nstructures]
-        D2[Compute edge score\n0.0 – 1.0]
-        D3[Rank &\nexplain candidates]
+    subgraph Agent_3["③ Feature Generation Agent"]
+        D[Compute Derived Signals\nVol Gap · Curve · Dispersion\nInsider · Narrative · Shock Prob]
     end
 
-    Ingestion -->|market state object| Events
-    Events    -->|scored events| Features
-    Features  -->|derived features store| Strategy
-    Strategy  -->|JSON output| E[(candidates.json)]
+    subgraph Agent_4["④ Strategy Evaluation Agent"]
+        E[Evaluate Option Structures\nRank by Edge Score\nAttach Signal References]
+    end
+
+    subgraph Output
+        F[(JSON Candidates\nfor Dashboard /\nthinkorswim)]
+    end
+
+    A1 & A2 & A3 & A4 & A5 --> B
+    B -->|market_state| C
+    C -->|event_scores| D
+    D -->|features_store| E
+    E --> F
 ```
 
-### In-scope instruments & option structures
-
-| Category | Items |
-|---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
-| Option structures | Long straddles, call/put spreads, calendar spreads |
-
-> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
+Data flows **unidirectionally**. Each agent is independently deployable; a failure in one agent degrades output quality but does not crash the pipeline.
 
 ---
 
@@ -77,285 +95,316 @@ flowchart LR
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| Operating system | Linux, macOS, or Windows (WSL recommended) |
-| Memory | 2 GB RAM |
-| Storage | 5 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS on port 443 |
+| RAM | 2 GB available |
+| Disk | 5 GB free (grows with retained history) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Deployment target | Local machine, single VM, or Docker container |
 
-### Required accounts & API keys
+### External accounts & API keys
 
-All data sources used in the MVP are free or have a free tier. Obtain credentials before running the pipeline.
+All primary data sources are free or have a usable free tier.
 
-| Data source | What it provides | Sign-up URL |
+| Source | Used for | Sign-up URL |
 |---|---|---|
-| Alpha Vantage | WTI / Brent spot & futures prices | https://www.alphavantage.co/support/#api-key |
-| Yahoo Finance (`yfinance`) | ETF, equity, and options chain data | *(no key required)* |
-| Polygon.io | Options chain supplement (free tier) | https://polygon.io/dashboard/signup |
-| EIA API | Weekly inventory & refinery utilisation | https://www.eia.gov/opendata/register.php |
-| GDELT | News & geopolitical event stream | *(no key required — HTTP download)* |
-| NewsAPI | Headline news feed | https://newsapi.org/register |
-| SEC EDGAR | Insider trading filings | *(no key required)* |
-| Quiver Quant | Structured insider data (free tier) | https://www.quiverquant.com/signup/ |
-| MarineTraffic | Tanker flow data (free tier) | https://www.marinetraffic.com/en/p/register |
-| Reddit API (`praw`) | Retail sentiment & narrative velocity | https://www.reddit.com/prefs/apps |
-| Stocktwits | Retail sentiment stream | https://api.stocktwits.com/developers/apps/new |
+| Alpha Vantage | WTI / Brent spot prices | <https://www.alphavantage.co/support/#api-key> |
+| yfinance / Yahoo Finance | ETF & equity prices, options chains | No key required |
+| Polygon.io *(optional)* | Higher-quality options data | <https://polygon.io> |
+| EIA API | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
+| GDELT | News & geopolitical events | No key required |
+| NewsAPI *(optional)* | Supplemental news feed | <https://newsapi.org> |
+| SEC EDGAR | Insider activity | No key required |
+| Quiver Quant *(optional)* | Parsed insider trades | <https://www.quiverquant.com> |
+| MarineTraffic / VesselFinder | Tanker flow data | Free tier at respective sites |
+| Reddit | Retail sentiment | No key required (public API) |
+| Stocktwits | Narrative velocity | No key required (public API) |
+
+### Python dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+Core libraries expected in `requirements.txt`:
+
+```text
+yfinance>=0.2
+requests>=2.31
+pandas>=2.0
+numpy>=1.26
+python-dotenv>=1.0
+schedule>=1.2
+```
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1 · Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2 · Create a virtual environment
 
 ```bash
 python -m venv .venv
-
-# Linux / macOS
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.\.venv\Scripts\Activate.ps1
-```
-
-### 3. Install dependencies
-
-```bash
-pip install --upgrade pip
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows PowerShell
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 3 · Create the environment file
 
-Copy the provided template and fill in your credentials:
+Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and supply values for every variable in the table below.
+Then open `.env` in your editor and populate each variable (see table below).
 
-#### Environment variable reference
+### 4 · Environment variables reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for WTI / Brent crude price feeds |
-| `POLYGON_API_KEY` | ✅ | — | Polygon.io key for supplemental options chain data |
-| `EIA_API_KEY` | ✅ | — | EIA Open Data key for inventory & refinery utilisation |
-| `NEWS_API_KEY` | ✅ | — | NewsAPI key for headline energy news |
-| `QUIVER_QUANT_API_KEY` | ⬜ | — | Quiver Quant key for structured insider activity (Phase 3) |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | MarineTraffic key for tanker flow data (Phase 3) |
-| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit OAuth client ID for PRAW (Phase 3) |
-| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit OAuth client secret for PRAW (Phase 3) |
-| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | User-agent string sent with Reddit requests |
-| `STOCKTWITS_ACCESS_TOKEN` | ⬜ | — | Stocktwits bearer token for sentiment feed (Phase 3) |
-| `DATA_DIR` | ✅ | `./data` | Root directory for raw and derived data storage |
-| `OUTPUT_DIR` | ✅ | `./output` | Directory where ranked candidates JSON is written |
-| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `HISTORY_DAYS` | ⬜ | `365` | Days of historical data to retain (recommended: 180–365) |
-| `PRICE_REFRESH_MINUTES` | ⬜ | `5` | Cadence (minutes) for market data refresh during a run |
-| `SLOW_FEED_SCHEDULE` | ⬜ | `daily` | Refresh schedule for EIA / EDGAR feeds (`daily` or `weekly`) |
-| `PIPELINE_PHASE` | ⬜ | `1` | MVP phase to activate (`1`, `2`, or `3`); controls which agents and signals are enabled |
+| `ALPHA_VANTAGE_API_KEY` | **Yes** | — | API key for crude price feeds |
+| `EIA_API_KEY` | **Yes** | — | API key for EIA inventory & refinery data |
+| `POLYGON_API_KEY` | No | — | Higher-quality options chain data (falls back to yfinance if unset) |
+| `NEWS_API_KEY` | No | — | NewsAPI key for supplemental news (GDELT used if unset) |
+| `QUIVER_QUANT_API_KEY` | No | — | Parsed insider trade data (falls back to raw EDGAR if unset) |
+| `MARINE_TRAFFIC_API_KEY` | No | — | Tanker flow data from MarineTraffic |
+| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes) |
+| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA data polling (hours) |
+| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for insider data polling (hours) |
+| `HISTORY_RETENTION_DAYS` | No | `180` | Days of raw and derived history to retain (180–365 recommended) |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
+| `LOG_LEVEL` | No | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F` | Comma-separated list of instruments to monitor |
+| `EDGE_SCORE_THRESHOLD` | No | `0.30` | Minimum edge score for a candidate to be included in output |
 
-> **Required (✅)** variables must be set before any agent will run. Optional (⬜) variables unlock Phase 2 / Phase 3 signals; the pipeline runs in a reduced-signal mode without them.
-
-#### Minimal `.env` for Phase 1
+**Example `.env`:**
 
 ```dotenv
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-POLYGON_API_KEY=your_polygon_key
-EIA_API_KEY=your_eia_key
-NEWS_API_KEY=your_newsapi_key
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
+EIA_API_KEY=your_eia_key_here
 
-DATA_DIR=./data
+# Optional — remove or leave blank to use free fallbacks
+POLYGON_API_KEY=
+NEWS_API_KEY=
+QUIVER_QUANT_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+
+# Tuning
+DATA_REFRESH_INTERVAL_MINUTES=5
+EIA_REFRESH_INTERVAL_HOURS=24
+EDGAR_REFRESH_INTERVAL_HOURS=24
+HISTORY_RETENTION_DAYS=180
 OUTPUT_DIR=./output
-PIPELINE_PHASE=1
+LOG_LEVEL=INFO
+INSTRUMENTS=USO,XLE,XOM,CVX,CL=F
+EDGE_SCORE_THRESHOLD=0.30
 ```
 
-### 5. Initialise the data directory
+### 5 · Verify configuration
 
 ```bash
-python -m agent.cli init
+python -m agent.cli check-config
 ```
 
-This creates the `DATA_DIR` and `OUTPUT_DIR` folder structure and writes a `config.json` derived from your `.env`.
+Expected output:
+
+```
+[✓] ALPHA_VANTAGE_API_KEY  — set
+[✓] EIA_API_KEY            — set
+[!] POLYGON_API_KEY        — not set (fallback: yfinance)
+[!] NEWS_API_KEY           — not set (fallback: GDELT)
+[!] QUIVER_QUANT_API_KEY   — not set (fallback: EDGAR)
+[!] MARINE_TRAFFIC_API_KEY — not set (fallback: disabled)
+Configuration valid. Ready to run.
+```
+
+Items marked `[!]` are optional; the pipeline continues with free fallbacks.
+
+### 6 · Initialise the data store
+
+Run the one-time bootstrap to create local storage directories and seed historical data:
+
+```bash
+python -m agent.cli bootstrap
+```
+
+This may take several minutes on first run as it fetches historical prices required for volatility and curve calculations.
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution modes
+### Pipeline flow (setup sequence)
 
-| Mode | Command | When to use |
-|---|---|---|
-| Full pipeline (all agents, once) | `python -m agent.cli run` | On-demand analysis |
-| Single agent | `python -m agent.cli run --agent <name>` | Debug or incremental re-run |
-| Continuous / scheduled | `python -m agent.cli run --loop` | Live monitoring |
-| Dry run (no output written) | `python -m agent.cli run --dry-run` | Validate config without side effects |
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Ingestion as Data Ingestion Agent
+    participant Events as Event Detection Agent
+    participant Features as Feature Generation Agent
+    participant Strategy as Strategy Evaluation Agent
+    participant Store as Output Store
 
-### Run the full pipeline once
+    User->>CLI: python -m agent.cli run
+    CLI->>Ingestion: fetch_and_normalize()
+    Ingestion-->>CLI: market_state
+    CLI->>Events: detect_events(market_state)
+    Events-->>CLI: event_scores
+    CLI->>Features: generate_features(market_state, event_scores)
+    Features-->>CLI: features_store
+    CLI->>Strategy: evaluate_strategies(features_store)
+    Strategy-->>CLI: ranked_candidates[]
+    CLI->>Store: write_output(ranked_candidates)
+    Store-->>User: ./output/candidates_<timestamp>.json
+```
+
+### Single pipeline run
+
+Execute one complete pass through all four agents and write results to `OUTPUT_DIR`:
 
 ```bash
 python -m agent.cli run
 ```
 
-Expected console output:
+### Continuous (scheduled) run
 
-```
-[2026-03-15 09:00:01 UTC] INFO  pipeline      Starting full pipeline run (phase=1)
-[2026-03-15 09:00:02 UTC] INFO  ingestion     Fetching WTI spot price ... OK (104.32)
-[2026-03-15 09:00:03 UTC] INFO  ingestion     Fetching Brent spot price ... OK (107.81)
-[2026-03-15 09:00:05 UTC] INFO  ingestion     Fetching options chain: USO ... OK (312 contracts)
-[2026-03-15 09:00:08 UTC] INFO  events        Scanning GDELT feed ... 4 energy events detected
-[2026-03-15 09:00:09 UTC] INFO  events        Scanning NewsAPI feed ... 2 supply disruption events
-[2026-03-15 09:00:10 UTC] INFO  features      Computing volatility gap (USO) ... +0.083
-[2026-03-15 09:00:11 UTC] INFO  features      Computing futures curve steepness (WTI) ... contango +1.4%
-[2026-03-15 09:00:13 UTC] INFO  strategy      Evaluating long_straddle on USO (30d) ... edge_score=0.47
-[2026-03-15 09:00:14 UTC] INFO  strategy      Evaluating call_spread on XLE (45d) ... edge_score=0.31
-[2026-03-15 09:00:15 UTC] INFO  pipeline      Run complete. 5 candidates written to ./output/candidates.json
-```
-
-### Run a single agent
-
-Useful when you want to re-run only one stage — for example, after receiving an EIA data update — without re-fetching market prices.
+Run the pipeline on a recurring schedule driven by `DATA_REFRESH_INTERVAL_MINUTES`:
 
 ```bash
-# Agent names: ingestion | events | features | strategy
+python -m agent.cli run --continuous
+```
+
+Stop with **Ctrl + C**. The scheduler respects the slower cadences configured for EIA and EDGAR feeds automatically.
+
+### Run a single agent in isolation
+
+Each agent can be invoked independently for testing or debugging:
+
+```bash
+# Run only the Data Ingestion Agent
+python -m agent.cli run --agent ingestion
+
+# Run only the Event Detection Agent (requires existing market_state)
+python -m agent.cli run --agent events
+
+# Run only the Feature Generation Agent (requires market_state + event_scores)
+python -m agent.cli run --agent features
+
+# Run only the Strategy Evaluation Agent (requires features_store)
 python -m agent.cli run --agent strategy
 ```
 
-### Run continuously with automatic refresh
+### Command reference
 
-```bash
-python -m agent.cli run --loop --interval 300   # refresh every 5 minutes
-```
-
-Press `Ctrl+C` to stop. The pipeline tolerates delayed or missing upstream data; individual feed failures are logged as warnings and the run continues with the most recent cached data.
-
-### Activate Phase 2 or Phase 3 signals
-
-Set `PIPELINE_PHASE` in your `.env` (or pass it inline) to unlock additional signal layers:
-
-```bash
-# Phase 2: adds EIA supply signals and GDELT/NewsAPI event-driven edge scoring
-PIPELINE_PHASE=2 python -m agent.cli run
-
-# Phase 3: additionally adds insider conviction, narrative velocity, and shipping data
-PIPELINE_PHASE=3 python -m agent.cli run
-```
-
-> Phase 4 features (OPIS pricing, exotic structures, automated execution) are not yet implemented and are reserved for future releases.
-
-### Agent data-flow sequence
-
-```mermaid
-sequenceDiagram
-    participant CLI as CLI (agent.cli run)
-    participant IA  as Data Ingestion Agent
-    participant EA  as Event Detection Agent
-    participant FA  as Feature Generation Agent
-    participant SA  as Strategy Evaluation Agent
-    participant FS  as Filesystem (data/ & output/)
-
-    CLI->>IA: start_ingestion(config)
-    IA-->>FS: write market_state.json
-    IA-->>CLI: ingestion complete
-
-    CLI->>EA: start_event_detection(market_state)
-    EA-->>FS: write scored_events.json
-    EA-->>CLI: event detection complete
-
-    CLI->>FA: start_feature_generation(market_state, scored_events)
-    FA-->>FS: write derived_features.json
-    FA-->>CLI: feature generation complete
-
-    CLI->>SA: start_strategy_evaluation(derived_features)
-    SA-->>FS: write candidates.json
-    SA-->>CLI: strategy evaluation complete
-
-    CLI-->>CLI: print summary & exit
-```
+| Command | Description |
+|---|---|
+| `check-config` | Validate environment variables and API key reachability |
+| `bootstrap` | Initialise data store and seed historical data (run once) |
+| `run` | Execute a single pipeline pass |
+| `run --continuous` | Execute on a repeating schedule |
+| `run --agent <name>` | Execute a single agent in isolation |
+| `run --dry-run` | Run all agents but suppress writing output files |
+| `run --instruments XOM,CVX` | Override `INSTRUMENTS` for this run only |
+| `run --log-level DEBUG` | Override `LOG_LEVEL` for this run only |
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output location
+
+Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR` (default `./output`):
 
 ```
-output/
-└── candidates.json          ← ranked list of strategy candidates (latest run)
-└── candidates_<timestamp>.json   ← timestamped archive of each run
+./output/
+  candidates_2026-03-15T14:32:00Z.json
+  candidates_2026-03-15T14:37:00Z.json
+  ...
 ```
 
 ### Output schema
 
-Each element in the `candidates` array conforms to the following schema:
+Each file contains an array of **candidate objects**. Every candidate has the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument — e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Options structure: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | integer (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | float `[0.0 – 1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
+| `signals` | object | Map of contributing signals and their qualitative levels |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example output
+### Example output file
 
 ```json
-{
-  "run_id": "2026-03-15T09:00:15Z",
-  "phase": 1,
-  "candidates": [
-    {
-      "instrument": "USO",
-      "structure": "long_straddle",
-      "expiration": 30,
-      "edge_score": 0.47,
-      "signals": {
-        "tanker_disruption_index": "high",
-        "volatility_gap": "positive",
-        "narrative_velocity": "rising"
-      },
-      "generated_at": "2026-03-15T09:00:13Z"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
     },
-    {
-      "instrument": "XLE",
-      "structure": "call_spread",
-      "expiration": 45,
-      "edge_score": 0.31,
-      "signals": {
-        "volatility_gap": "positive",
-        "futures_curve_steepness": "contango"
-      },
-      "generated_at": "2026-03-15T09:00:14Z"
-    }
-  ]
-}
+    "generated_at": "2026-03-15T14:32:00Z"
+  },
+  {
+    "instrument": "XLE",
+    "structure": "call_spread",
+    "expiration": 45,
+    "edge_score": 0.38,
+    "signals": {
+      "supply_shock_probability": "elevated",
+      "futures_curve_steepness": "steep",
+      "sector_dispersion": "high"
+    },
+    "generated_at": "2026-03-15T14:32:00Z"
+  }
+]
 ```
 
-### Reading the edge score
+### Reading the `edge_score`
 
-| Edge score range | Interpretation | Suggested action |
+| Score range | Interpretation | Suggested action |
 |---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High-priority review; examine all contributing signals |
-| `0.45 – 0.69` | Moderate confluence | Worth investigating alongside your own analysis |
-| `0.20 – 0.44` | Weak / noisy signal | Low confidence; treat as background information |
-| `0.00 – 0.19` | Negligible edge | Typically noise; not actionable on its own |
+| `0.70 – 1.00` | Strong signal confluence | High priority for review |
+| `0.50 – 0.69` | Moderate confluence | Worth evaluating with additional context |
+| `0.30 – 0.49` | Weak but notable signal | Monitor; revisit on next run |
+| `< 0.30` | Below threshold | Filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
 
-> The edge score reflects signal confluence only. It is **not** a probability of profit and does **not** account for bid/ask spreads, liquidity, or position sizing. The system is **advisory only** — no trades are placed automatically.
+> **Note:** Edge scores are computed from heuristic functions in the MVP. They indicate relative opportunity strength within this run; they are **not** a guarantee of profitability.
 
-### Reading the signals map
+### Reading the `signals` map
 
-Each key in the `signals` object corresponds to a derived feature. Common keys and their meanings:
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Qualitative values indicate direction or intensity:
 
-| Signal key | Possible values | What it means |
+| Signal key | What it measures | Values |
 |---|---|---|
-| `volatility_gap` | `positive`, `negative`, `neutral` | Realised vol is above (`positive`) or below implied vol |
-| `futures_curve_steepness` | `contango`, `backwardation
+| `volatility_gap` | Realized vs. implied volatility divergence | `positive` · `negative` · `neutral` |
+| `futures_curve_steepness` | Steepness of the WTI / Brent futures curve | `steep` · `flat` · `inverted` |
+| `sector_dispersion` | Cross-sector price correlation breakdown | `high` · `moderate` · `low` |
+| `insider_conviction` | Aggregated insider trade signal | `strong` · `moderate` · `weak` |
+| `narrative_velocity` | Rate of change in energy news headlines | `rising` · `stable` · `falling` |
+| `supply_shock_probability` | Modelled probability of a supply disruption | `elevated` · `moderate` · `low` |
+| `tanker_disruption_index` | Shipping flow anomalies at key chokepoints | `high` · `moderate` · `low` |
+
+### Consuming output in thinkorswim or a custom dashboard
+
+The JSON output is compatible with any JSON-capable dashboard. To load candidates into thinkorswim or a spreadsheet tool, you can transform the output with the included helper:
+
+```bash
+python -m agent.cli export --format csv --input ./output/candidates_2026-03-15T14:32:00Z.json
+```
+
+This

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide walks you through installing, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
+> **Version 1.0 · March 2026**
+> This guide walks you through installing, configuring, and running the full four-agent pipeline from a clean environment to a ranked list of options trading opportunities.
 
 ---
 
@@ -18,48 +18,44 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline composed of four loosely coupled agents. It ingests market data, supply signals, news events, and alternative datasets, then produces a ranked list of candidate options strategies with full explainability.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**. It is advisory only — no trades are placed automatically.
 
 ### Pipeline Architecture
 
+The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**. Data flows in one direction only.
+
 ```mermaid
 flowchart LR
-    subgraph Feeds["External Data Feeds"]
-        F1(Alpha Vantage / MetalpriceAPI)
-        F2(Yahoo Finance / yfinance)
-        F3(EIA API)
-        F4(GDELT / NewsAPI)
-        F5(SEC EDGAR / Quiver Quant)
-        F6(MarineTraffic / VesselFinder)
-        F7(Reddit / Stocktwits)
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[EIA Supply Data]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nEDGAR / Quiver Quant]
+        A7[Shipping Data\nMarineTraffic / VesselFinder]
+        A8[Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Pipeline["Four-Agent Pipeline"]
-        A1["📥 Data Ingestion Agent\n─────────────────\nFetch & Normalize\nMarket State Object"]
-        A2["🔍 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nConfidence + Intensity Scores"]
-        A3["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol Gaps, Curve, Dispersion…"]
-        A4["🏆 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge Scores + Explainability"]
+    subgraph Pipeline
+        B[Data Ingestion Agent\nFetch & Normalize]
+        C[Event Detection Agent\nSupply & Geo Signals]
+        D[Feature Generation Agent\nDerived Signal Computation]
+        E[Strategy Evaluation Agent\nOpportunity Ranking]
     end
 
-    OUT["📄 JSON Output\nRanked Candidate Strategies"]
+    subgraph Output
+        F[Ranked Candidates\nJSON / Dashboard]
+    end
 
-    Feeds --> A1
-    A1 -->|"Unified Market State"| A2
-    A2 -->|"Event Scores"| A3
-    A3 -->|"Derived Features"| A4
-    A4 --> OUT
+    A1 & A2 & A3 & A4 --> B
+    A5 --> C
+    A6 & A7 & A8 --> D
+    B --> C
+    C --> D
+    D --> E
+    E --> F
 ```
-
-Data flows **unidirectionally** through the pipeline. Each agent can be deployed and updated independently without disrupting the others.
-
-### What Each Agent Does
-
-| Agent | Role | Key Outputs |
-|---|---|---|
-| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical price/vol store |
-| **Event Detection Agent** | Supply & Geo Signals | Confidence and intensity scores per detected event |
-| **Feature Generation Agent** | Derived Signal Computation | Vol gaps, curve steepness, sector dispersion, supply shock probability, etc. |
-| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with `edge_score` and contributing signals |
 
 ### In-Scope Instruments
 
@@ -78,7 +74,7 @@ Data flows **unidirectionally** through the pipeline. Each agent can be deployed
 | Put Spread | `put_spread` |
 | Calendar Spread | `calendar_spread` |
 
-> ⚠️ **Advisory Only.** The system generates ranked recommendations. No automated trade execution occurs in this release.
+> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
@@ -88,42 +84,49 @@ Data flows **unidirectionally** through the pipeline. Each agent can be deployed
 
 | Requirement | Minimum |
 |---|---|
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| RAM | 2 GB available |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| RAM | 2 GB |
 | Disk | 5 GB free (for 6–12 months of historical data) |
 | Network | Outbound HTTPS access to all data source APIs |
 
-### Required Software
+### Required Accounts & API Keys
+
+Register for free-tier accounts at each provider before proceeding. All sources listed below have a free or free-limited tier sufficient for MVP operation.
+
+| Provider | Used By | Sign-up URL | Notes |
+|---|---|---|---|
+| Alpha Vantage or MetalpriceAPI | Data Ingestion | https://www.alphavantage.co / https://metalpriceapi.com | WTI & Brent spot/futures |
+| Polygon.io | Data Ingestion | https://polygon.io | Options chains; free tier is limited |
+| EIA Open Data | Data Ingestion | https://www.eia.gov/opendata | Inventory & refinery data |
+| NewsAPI | Event Detection | https://newsapi.org | Energy headlines |
+| GDELT | Event Detection | https://www.gdeltproject.org | Geopolitical events; no key required |
+| SEC EDGAR | Feature Generation | https://www.sec.gov/developer | Insider activity; no key required |
+| Quiver Quant | Feature Generation | https://www.quiverquant.com | Insider conviction; free tier available |
+| MarineTraffic or VesselFinder | Feature Generation | https://www.marinetraffic.com | Tanker flows; free tier |
+| Reddit (PRAW) | Feature Generation | https://www.reddit.com/prefs/apps | Narrative/sentiment velocity |
+
+### Python Dependencies
+
+Install dependencies into a virtual environment:
 
 ```bash
-# Verify Python version
-python --version   # must be >= 3.10
-
-# Verify pip
-pip --version
-
-# Verify git
-git --version
+python -m venv .venv
+source .venv/bin/activate        # Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install -r requirements.txt
 ```
 
-### API Accounts
+A minimal `requirements.txt` should include:
 
-You must obtain free (or free-tier) API keys from the following services before running the pipeline. All are zero-cost for the MVP data volumes.
-
-| Service | URL | Used By | Notes |
-|---|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Data Ingestion | WTI / Brent spot & futures |
-| NewsAPI | https://newsapi.org/register | Event Detection | Energy headlines |
-| EIA Open Data | https://www.eia.gov/opendata/ | Event Detection | Inventory & refinery data |
-| Polygon.io | https://polygon.io | Data Ingestion | Options chains (free tier) |
-| Quiver Quant | https://www.quiverquant.com | Feature Generation | Insider trade data |
-| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Feature Generation | No key required |
-| GDELT | https://www.gdeltproject.org | Event Detection | No key required |
-| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Feature Generation | Free tier |
-| Reddit API | https://www.reddit.com/prefs/apps | Feature Generation | Narrative velocity |
-| Yahoo Finance / yfinance | (no key needed) | Data Ingestion | ETF & equity prices |
-| Stocktwits | https://api.stocktwits.com/developers | Feature Generation | Sentiment |
+```text
+yfinance>=0.2
+requests>=2.31
+pandas>=2.0
+numpy>=1.26
+praw>=7.7
+python-dotenv>=1.0
+```
 
 ---
 
@@ -136,209 +139,213 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create the Environment File
 
-```bash
-python -m venv .venv
-
-# macOS / Linux
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.\.venv\Scripts\Activate.ps1
-```
-
-### 3. Install Dependencies
-
-```bash
-pip install --upgrade pip
-pip install -r requirements.txt
-```
-
-### 4. Configure Environment Variables
-
-The pipeline reads all secrets and tunable parameters from environment variables. The recommended approach is a `.env` file in the project root (loaded automatically at startup via `python-dotenv`).
+The pipeline reads all secrets and tuneable parameters from environment variables. Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value:
+Then open `.env` in your editor and populate each variable described in the table below.
 
-```bash
-# ── API Keys ───────────────────────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-NEWS_API_KEY=your_newsapi_key
-EIA_API_KEY=your_eia_key
-POLYGON_API_KEY=your_polygon_key
-QUIVER_QUANT_API_KEY=your_quiverquant_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=energy-options-agent/1.0
-STOCKTWITS_API_TOKEN=your_stocktwits_token
+### Environment Variables Reference
 
-# ── Data Storage ────────────────────────────────────────────────────────────
-DATA_DIR=./data                  # Root directory for all persisted data
-RETENTION_DAYS=365               # Historical data retention window (days)
+All variables are loaded at startup. Variables marked **Required** will cause the pipeline to exit immediately if absent. Variables marked **Optional** have defaults that are safe for MVP use.
 
-# ── Pipeline Cadence ────────────────────────────────────────────────────────
-MARKET_DATA_INTERVAL_MINUTES=5   # Refresh cadence for prices & options
-EIA_FETCH_SCHEDULE=weekly        # weekly | daily
-EDGAR_FETCH_SCHEDULE=daily       # daily | weekly
-
-# ── Instruments ─────────────────────────────────────────────────────────────
-INSTRUMENTS=CL=F,BZ=F,USO,XLE,XOM,CVX   # Comma-separated list
-
-# ── Strategy Evaluation ─────────────────────────────────────────────────────
-EDGE_SCORE_THRESHOLD=0.30        # Minimum edge_score to include in output
-MAX_CANDIDATES=20                # Maximum ranked candidates per run
-OPTION_STRUCTURES=long_straddle,call_spread,put_spread,calendar_spread
-
-# ── Output ──────────────────────────────────────────────────────────────────
-OUTPUT_DIR=./output              # JSON output destination
-OUTPUT_FORMAT=json               # json (future: csv, dashboard)
-LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
-```
-
-#### Complete Environment Variable Reference
+#### Data Ingestion Agent
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | Crude price feed (WTI, Brent) |
-| `NEWS_API_KEY` | ✅ | — | Energy headline ingestion |
-| `EIA_API_KEY` | ✅ | — | Inventory & refinery utilization |
-| `POLYGON_API_KEY` | ✅ | — | Options chains (strike, expiry, IV, volume) |
-| `QUIVER_QUANT_API_KEY` | ✅ | — | Insider conviction data |
-| `MARINE_TRAFFIC_API_KEY` | ✅ | — | Tanker flow data |
-| `REDDIT_CLIENT_ID` | ✅ | — | Reddit API OAuth client ID |
-| `REDDIT_CLIENT_SECRET` | ✅ | — | Reddit API OAuth client secret |
-| `REDDIT_USER_AGENT` | ✅ | — | Reddit API user-agent string |
-| `STOCKTWITS_API_TOKEN` | ✅ | — | Stocktwits sentiment stream |
-| `DATA_DIR` | ✅ | `./data` | Root path for raw & derived data storage |
-| `RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain |
-| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Price & options refresh cadence |
-| `EIA_FETCH_SCHEDULE` | ❌ | `weekly` | EIA data pull frequency |
-| `EDGAR_FETCH_SCHEDULE` | ❌ | `daily` | EDGAR insider data pull frequency |
-| `INSTRUMENTS` | ❌ | `CL=F,BZ=F,USO,XLE,XOM,CVX` | Instruments to monitor |
-| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum score to surface a candidate |
-| `MAX_CANDIDATES` | ❌ | `20` | Maximum candidates emitted per run |
-| `OPTION_STRUCTURES` | ❌ | all four | Comma-separated list of eligible structures |
-| `OUTPUT_DIR` | ❌ | `./output` | Directory for JSON output files |
-| `OUTPUT_FORMAT` | ❌ | `json` | Output format (`json` in MVP) |
-| `LOG_LEVEL` | ❌ | `INFO` | Python logging level |
+| `ALPHA_VANTAGE_API_KEY` | Required* | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Required* | — | API key for MetalpriceAPI crude feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chains |
+| `EIA_API_KEY` | Required | — | API key for EIA supply/inventory data |
+| `PRICE_REFRESH_INTERVAL_SEC` | Optional | `60` | Market price polling cadence in seconds |
+| `EIA_REFRESH_INTERVAL_SEC` | Optional | `86400` | EIA data polling cadence (default: daily) |
+| `HISTORICAL_RETENTION_DAYS` | Optional | `365` | Days of raw history to retain on disk |
 
-### 5. Initialise Data Directories
+> \* Provide at least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY`.
+
+#### Event Detection Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `NEWS_API_KEY` | Required | — | API key for NewsAPI energy headlines |
+| `GDELT_ENABLED` | Optional | `true` | Enable GDELT geopolitical feed (no key needed) |
+| `EVENT_CONFIDENCE_THRESHOLD` | Optional | `0.5` | Minimum confidence score to surface an event |
+| `EVENT_INTENSITY_THRESHOLD` | Optional | `0.3` | Minimum intensity score to surface an event |
+
+#### Feature Generation Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `QUIVER_API_KEY` | Optional | — | API key for Quiver Quant insider conviction data |
+| `REDDIT_CLIENT_ID` | Optional | — | Reddit PRAW client ID for sentiment velocity |
+| `REDDIT_CLIENT_SECRET` | Optional | — | Reddit PRAW client secret |
+| `REDDIT_USER_AGENT` | Optional | `energy-agent/1.0` | Reddit PRAW user agent string |
+| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
+| `VESSEL_FINDER_API_KEY` | Optional | — | Alternative tanker data source key |
+
+#### Strategy Evaluation Agent
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `MIN_EDGE_SCORE` | Optional | `0.30` | Minimum edge score for a candidate to appear in output |
+| `MAX_CANDIDATES` | Optional | `20` | Maximum number of ranked candidates to emit per run |
+| `DEFAULT_EXPIRATION_DAYS` | Optional | `30` | Default target expiration when not overridden by signal |
+
+#### Output & Storage
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `OUTPUT_DIR` | Optional | `./output` | Directory where JSON output files are written |
+| `DATA_STORE_DIR` | Optional | `./data` | Directory for historical raw and derived data |
+| `LOG_LEVEL` | Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+
+### 3. Verify Configuration
+
+Run the built-in config check before your first full run:
 
 ```bash
-python -m agent.cli init
+python -m agent.cli check-config
 ```
 
-This command creates the `DATA_DIR` and `OUTPUT_DIR` subdirectory tree and validates that all required API keys are present before the first run.
-
-Expected output:
+Expected output when all required variables are present:
 
 ```
-[INFO] Data directory initialised at ./data
-[INFO] Output directory initialised at ./output
-[INFO] All required API keys present ✓
-[INFO] Ready to run.
+[OK] Data Ingestion Agent     — all required keys present
+[OK] Event Detection Agent    — all required keys present
+[OK] Feature Generation Agent — optional keys: QUIVER_API_KEY missing (non-fatal)
+[OK] Strategy Evaluation Agent
+[OK] Output directories       — ./output, ./data created
+Configuration check passed.
 ```
+
+Missing optional keys produce `[WARN]` lines and are non-fatal. Missing required keys produce `[FAIL]` and abort the check.
+
+### 4. Initialize the Data Store
+
+Create the on-disk historical store and run an initial backfill:
+
+```bash
+python -m agent.cli init-store --backfill-days 30
+```
+
+This fetches up to 30 days of historical price, options, and inventory data. Use `--backfill-days 365` to build a full year of history for backtesting purposes (takes longer and consumes more API quota).
 
 ---
 
 ## Running the Pipeline
 
-### Full Pipeline — Single Run
+### Pipeline Execution Flow
 
-Execute all four agents in sequence for a one-shot evaluation:
+```mermaid
+sequenceDiagram
+    participant CLI as CLI / Scheduler
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant Store as Data Store
+    participant Out as JSON Output
+
+    CLI->>DIA: run(instruments, refresh_interval)
+    DIA->>Store: write market_state object
+    DIA-->>EDA: market_state ready signal
+
+    EDA->>Store: read market_state
+    EDA->>EDA: score events (confidence, intensity)
+    EDA->>Store: write event_scores
+    EDA-->>FGA: events ready signal
+
+    FGA->>Store: read market_state + event_scores
+    FGA->>FGA: compute derived signals
+    FGA->>Store: write features_store
+    FGA-->>SEA: features ready signal
+
+    SEA->>Store: read features_store
+    SEA->>SEA: evaluate & rank candidates
+    SEA->>Out: write ranked_candidates.json
+    SEA-->>CLI: pipeline complete
+```
+
+### Single Run (One-Shot)
+
+Execute the full four-agent pipeline once and write results to `./output`:
 
 ```bash
 python -m agent.cli run
 ```
 
-The pipeline stages execute in order:
-
-```mermaid
-sequenceDiagram
-    participant CLI
-    participant Ingest as Data Ingestion Agent
-    participant Events as Event Detection Agent
-    participant Features as Feature Generation Agent
-    participant Strategy as Strategy Evaluation Agent
-    participant Output as JSON Output
-
-    CLI->>Ingest: start ingestion
-    Ingest-->>Ingest: fetch crude, ETF, equity prices
-    Ingest-->>Ingest: fetch options chains
-    Ingest-->>Ingest: normalize → market state object
-    Ingest->>Events: market state object
-    Events-->>Events: scan GDELT / NewsAPI
-    Events-->>Events: score supply disruptions, refinery outages, chokepoints
-    Events->>Features: market state + event scores
-    Features-->>Features: compute vol gaps, curve steepness, dispersion
-    Features-->>Features: compute insider conviction, narrative velocity
-    Features-->>Features: compute supply shock probability
-    Features->>Strategy: derived features store
-    Strategy-->>Strategy: evaluate long_straddle, spreads, calendar spreads
-    Strategy-->>Strategy: compute edge scores, attach contributing signals
-    Strategy->>Output: ranked candidates (JSON)
-    Output-->>CLI: ./output/candidates_<timestamp>.json
-```
-
-### Continuous Mode (Scheduled Refresh)
-
-To run the pipeline repeatedly on the `MARKET_DATA_INTERVAL_MINUTES` cadence, use the `--watch` flag:
+To override the output directory for this run:
 
 ```bash
-python -m agent.cli run --watch
+python -m agent.cli run --output-dir /tmp/eo-results
 ```
 
-Press `Ctrl+C` to stop. Each completed cycle writes a new timestamped output file to `OUTPUT_DIR`.
+### Continuous Mode
+
+Run the pipeline on a repeating cadence driven by `PRICE_REFRESH_INTERVAL_SEC`:
+
+```bash
+python -m agent.cli run --continuous
+```
+
+Press `Ctrl+C` to stop gracefully. The pipeline will finish the current cycle before exiting.
 
 ### Running Individual Agents
 
-Each agent can be invoked in isolation for debugging or incremental development:
+Each agent can be executed in isolation for development or debugging:
 
 ```bash
-# Agent 1 — fetch and normalize data only
-python -m agent.cli run --agent ingest
+# Data Ingestion only
+python -m agent.cli run --agent ingestion
 
-# Agent 2 — event detection only (requires a prior ingest run)
-python -m agent.cli run --agent events
+# Event Detection only (reads existing market_state from store)
+python -m agent.cli run --agent event-detection
 
-# Agent 3 — feature generation only (requires prior ingest + events)
-python -m agent.cli run --agent features
+# Feature Generation only
+python -m agent.cli run --agent feature-generation
 
-# Agent 4 — strategy evaluation only (requires all prior agents)
-python -m agent.cli run --agent strategy
+# Strategy Evaluation only
+python -m agent.cli run --agent strategy-evaluation
 ```
 
-### Filtering Output at Runtime
+### Selecting MVP Phase
 
-Override configuration values without editing `.env`:
+The pipeline respects the phased rollout defined in the system design. Use `--phase` to limit which data sources and signals are active:
+
+| Flag | Phase | What Is Active |
+|---|---|---|
+| `--phase 1` | Core Market Signals | Crude benchmarks, USO/XLE prices, IV surface, long straddles & spreads |
+| `--phase 2` | Supply & Event Augmentation | Phase 1 + EIA data, GDELT/NewsAPI event detection, supply disruption index |
+| `--phase 3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider data, Reddit/Stocktwits sentiment, shipping data |
+| `--phase 4` | High-Fidelity Enhancements | Phase 3 + OPIS pricing, exotic structures (when implemented) |
 
 ```bash
-# Raise the minimum edge score threshold
-python -m agent.cli run --edge-threshold 0.50
-
-# Limit to a single instrument
-python -m agent.cli run --instruments USO
-
-# Limit to one option structure
-python -m agent.cli run --structures long_straddle
-
-# Combine filters
-python -m agent.cli run --instruments XOM,CVX --structures call_spread,put_spread --edge-threshold 0.40
+# Run Phase 2 pipeline
+python -m agent.cli run --phase 2
 ```
 
-### Checking Pipeline Health
+The default is `--phase 3` (all currently implemented signals).
+
+### Scheduled Execution (cron example)
+
+To run the pipeline every 5 minutes via cron:
 
 ```bash
-python -m agent.cli status
+crontab -e
 ```
 
-Displays API connectivity, last successful run timestamp, record counts in the data store, and any feed errors.
+Add the following line (adjust paths as needed):
+
+```cron
+*/5 * * * * /home/user/energy-options-agent/.venv/bin/python \
+    -m agent.cli run \
+    --output-dir /home/user/energy-options-agent/output \
+    >> /home/user/energy-options-agent/logs/pipeline.log 2>&1
+```
 
 ---
 
@@ -346,49 +353,69 @@ Displays API connectivity, last successful run timestamp, record counts in the d
 
 ### Output File Location
 
-Each run produces a file in `OUTPUT_DIR` named:
+Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
-candidates_<ISO8601_UTC_timestamp>.json
+output/
+└── ranked_candidates_20260315T142301Z.json
 ```
 
-For example:
-
-```
-./output/candidates_2026-03-15T14_32_07Z.json
-```
+A symlink `output/latest.json` always points to the most recent file.
 
 ### Output Schema
 
-Each file contains a JSON array of candidate objects. All candidates have an `edge_score` at or above `EDGE_SCORE_THRESHOLD`, sorted descending by `edge_score`.
+Each element in the output array is a **strategy candidate**:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
-| `structure` | enum string | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signal names to qualitative levels |
+| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum string | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | integer (days) | Target expiration in calendar days from evaluation date |
+| `edge_score` | float `[0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signals and their assessed levels |
 | `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Annotated Example
+### Example Output File
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
+{
+  "generated_at": "2026-03-15T14:23:01Z",
+  "phase": 3,
+  "candidate_count": 4,
+  "candidates": [
+    {
+      "instrument": "USO",
+      "structure": "long_straddle",
+      "expiration": 30,
+      "edge_score": 0.72,
+      "signals": {
+        "tanker_disruption_index": "high",
+        "volatility_gap": "positive",
+        "narrative_velocity": "rising",
+        "supply_shock_probability": "elevated"
+      },
+      "generated_at": "2026-03-15T14:23:01Z"
     },
-    "generated_at": "2026-03-15T14:32:07Z"
-  },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 21,
-    
+    {
+      "instrument": "XLE",
+      "structure": "call_spread",
+      "expiration": 21,
+      "edge_score": 0.51,
+      "signals": {
+        "volatility_gap": "positive",
+        "sector_dispersion": "high",
+        "insider_conviction": "bullish"
+      },
+      "generated_at": "2026-03-15T14:23:01Z"
+    },
+    {
+      "instrument": "CL=F",
+      "structure": "put_spread",
+      "expiration": 14,
+      "edge_score": 0.44,
+      "signals": {
+        "futures_curve_steepness": "contango_widening",
+        "eia_inventory_surprise": "bearish",
+        "narrative_velocity": "stable"
+      },
+      "generated_at": "2026

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> Advisory only. The system produces ranked candidate opportunities; it does **not** execute trades automatically.
+> **Version 1.0 · March 2026**
+> This guide walks you through installing, configuring, and running the full four-agent pipeline end-to-end, and explains how to interpret the ranked output it produces.
 
 ---
 
@@ -18,114 +18,144 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that detects volatility mispricing in oil-related instruments and surfaces ranked options trading candidates.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
-### Pipeline architecture
+The system is **advisory only** — it does not execute trades.
+
+### Pipeline Architecture
+
+Data flows unidirectionally through four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Fetch crude prices\nETF / equity data\noptions chains]
-        A2[Normalize → unified\nmarket state object]
-        A1 --> A2
+    subgraph Sources["External Data Sources"]
+        S1["Crude Prices\n(Alpha Vantage / MetalpriceAPI)"]
+        S2["ETF / Equity Prices\n(Yahoo Finance / yfinance)"]
+        S3["Options Chains\n(Yahoo Finance / Polygon.io)"]
+        S4["Supply & Inventory\n(EIA API)"]
+        S5["News & Geo Events\n(GDELT / NewsAPI)"]
+        S6["Insider Activity\n(SEC EDGAR / Quiver Quant)"]
+        S7["Shipping / Logistics\n(MarineTraffic / VesselFinder)"]
+        S8["Narrative / Sentiment\n(Reddit / Stocktwits)"]
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[Monitor news &\ngeo feeds]
-        B2[Score supply\ndisruptions / events]
-        B1 --> B2
+    subgraph Agent1["① Data Ingestion Agent"]
+        A1["Fetch & Normalize\n→ Market State Object"]
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Compute volatility gaps\ncurve steepness\nsector dispersion\nnarrative velocity\nsupply shock probability]
+    subgraph Agent2["② Event Detection Agent"]
+        A2["Supply & Geo Signals\n→ Confidence / Intensity Scores"]
     end
 
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate eligible\noption structures]
-        D2[Rank by edge score\nwith signal references]
-        D1 --> D2
+    subgraph Agent3["③ Feature Generation Agent"]
+        A3["Derived Signal Computation\n→ Features Store"]
     end
 
-    RAW[(Raw feeds)] --> Ingestion
-    Ingestion -->|market state| Events
-    Events -->|scored events| Features
-    Features -->|derived signals| Strategy
-    Strategy -->|JSON output| OUT[(Ranked candidates)]
+    subgraph Agent4["④ Strategy Evaluation Agent"]
+        A4["Opportunity Ranking\n→ Edge-Scored Candidates"]
+    end
+
+    OUT["JSON Output\n(ranked candidates)"]
+
+    Sources --> Agent1
+    Agent1 --> Agent2
+    Agent2 --> Agent3
+    Agent3 --> Agent4
+    Agent4 --> OUT
 ```
 
-Data flows **unidirectionally** through the four agents; each agent is independently deployable and can be updated without disrupting the rest of the pipeline.
-
-### In-scope instruments
+### In-Scope Instruments
 
 | Category | Instruments |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | XOM (Exxon Mobil), CVX (Chevron) |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### MVP option structures
+### In-Scope Option Structures (MVP)
 
 | Structure | Enum value |
 |---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
+
+> **Out of scope for MVP:** exotic / multi-legged structures, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
 ## Prerequisites
 
-| Requirement | Minimum version / notes |
+### System Requirements
+
+| Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| pip | 22+ (or use `pipx` / a virtual-env manager) |
-| Git | Any recent version |
-| Internet access | Required for all live data feeds |
-| Local storage | ≥ 5 GB recommended for 6–12 months of historical data |
-| OS | Linux, macOS, or Windows (WSL2 recommended on Windows) |
+| Python | 3.10 or later |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| RAM | 2 GB |
+| Disk | 5 GB (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-> **Optional:** A Docker / container runtime if you prefer containerised deployment on a single VM.
+### Required Tools
 
-You will also need **free API keys** from the following services before running the pipeline:
+```bash
+# Verify Python version
+python --version   # must be >= 3.10
 
-| Service | Used for | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | WTI / Brent spot & futures prices | <https://www.alphavantage.co/support/#api-key> |
-| Polygon.io | Options chains (IV, strike, expiry, volume) | <https://polygon.io> |
-| EIA Open Data | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
-| NewsAPI | Energy news & geopolitical events | <https://newsapi.org> |
-| SEC EDGAR | Insider activity filings | No key required (public API) |
+# Verify pip
+pip --version
 
-> `yfinance`, `GDELT`, `MarineTraffic` free tier, and `Reddit` / `Stocktwits` public feeds do not require registration for basic access.
+# (Optional but recommended) Verify Docker if running containerised
+docker --version
+```
+
+### API Accounts
+
+You will need free-tier (or limited) accounts for the following services before configuring the pipeline:
+
+| Service | Purpose | Tier needed | Sign-up URL |
+|---|---|---|---|
+| Alpha Vantage | WTI / Brent spot & futures | Free | https://www.alphavantage.co |
+| Polygon.io | Options chains (strike, expiry, IV, volume) | Free / Limited | https://polygon.io |
+| EIA API | Inventory & refinery utilization | Free | https://www.eia.gov/opendata |
+| NewsAPI | News & geopolitical events | Free | https://newsapi.org |
+| GDELT | Geopolitical event stream | Free | https://www.gdeltproject.org |
+| SEC EDGAR | Insider activity | Free | https://efts.sec.gov/LATEST/search-index |
+| Quiver Quant | Insider activity (supplemental) | Free / Limited | https://www.quiverquant.com |
+| MarineTraffic | Tanker / shipping flows | Free tier | https://www.marinetraffic.com |
+| Reddit API | Narrative / sentiment | Free | https://www.reddit.com/dev/api |
+| Stocktwits | Narrative / sentiment | Free | https://api.stocktwits.com |
+
+> `yfinance` (Yahoo Finance) does not require an API key. GDELT is publicly accessible without registration.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # macOS / Linux
-# .venv\Scripts\activate         # Windows (PowerShell)
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows PowerShell
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 4. Configure Environment Variables
 
 Copy the provided template and populate it with your credentials:
 
@@ -133,264 +163,257 @@ Copy the provided template and populate it with your credentials:
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in the values described in the table below.
+Open `.env` in your editor and fill in every value. The table below documents all recognised environment variables.
 
-#### Environment variable reference
+#### Environment Variables Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for WTI / Brent crude price feed |
-| `POLYGON_API_KEY` | ✅ | — | API key for options chain data |
-| `EIA_API_KEY` | ✅ | — | API key for EIA inventory & refinery utilization feed |
-| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI geopolitical / energy news |
-| `YFINANCE_ENABLED` | ❌ | `true` | Set `false` to disable Yahoo Finance ETF / equity fallback |
-| `GDELT_ENABLED` | ❌ | `true` | Set `false` to disable GDELT continuous event feed |
-| `MARINE_TRAFFIC_ENABLED` | ❌ | `true` | Set `false` to disable tanker/shipping data (free tier) |
-| `REDDIT_ENABLED` | ❌ | `true` | Set `false` to disable Reddit narrative velocity feed |
-| `STOCKTWITS_ENABLED` | ❌ | `true` | Set `false` to disable Stocktwits sentiment feed |
-| `DATA_DIR` | ❌ | `./data` | Path for persisted raw and derived data |
-| `OUTPUT_DIR` | ❌ | `./output` | Path where ranked JSON candidates are written |
-| `HISTORY_MONTHS` | ❌ | `12` | Months of historical data to retain (minimum `6`) |
-| `MARKET_DATA_INTERVAL_SECONDS` | ❌ | `60` | Polling cadence for minute-level market data feeds |
-| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for crude price feeds (WTI, Brent) |
+| `POLYGON_API_KEY` | Yes | — | API key for options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA supply / inventory data |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI news & geo events |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider data (Phase 3) |
+| `MARINE_TRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flows (Phase 3) |
+| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth client ID (Phase 3) |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth client secret (Phase 3) |
+| `STOCKTWITS_ACCESS_TOKEN` | No | — | Stocktwits API access token (Phase 3) |
+| `DATA_STORE_PATH` | No | `./data` | Local path for persisted raw and derived data |
+| `OUTPUT_PATH` | No | `./output` | Directory where JSON candidate files are written |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_REFRESH_INTERVAL` | No | `60` | Minutes-level polling interval (seconds) for market data |
+| `HISTORICAL_RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `PHASE` | No | `1` | Active MVP phase: `1`, `2`, or `3` (controls which agents are enabled) |
 
-Example `.env` file:
+> Variables marked **No** are only required when running the corresponding MVP phase. The pipeline will log a warning and skip that data source if a key is absent, without failing.
+
+#### Example `.env`
 
 ```dotenv
-ALPHA_VANTAGE_API_KEY=YOUR_KEY_HERE
-POLYGON_API_KEY=YOUR_KEY_HERE
-EIA_API_KEY=YOUR_KEY_HERE
-NEWS_API_KEY=YOUR_KEY_HERE
+# --- Required ---
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
 
-DATA_DIR=./data
-OUTPUT_DIR=./output
-HISTORY_MONTHS=12
-MARKET_DATA_INTERVAL_SECONDS=60
+# --- Phase 3 (optional) ---
+QUIVER_QUANT_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+STOCKTWITS_ACCESS_TOKEN=
+
+# --- Pipeline settings ---
+DATA_STORE_PATH=./data
+OUTPUT_PATH=./output
 LOG_LEVEL=INFO
+MARKET_DATA_REFRESH_INTERVAL=60
+HISTORICAL_RETENTION_DAYS=365
+PHASE=1
 ```
 
-### 5. Initialise local storage
+### 5. Initialise the Data Store
+
+Run the initialisation script to create the local directory structure and seed the historical data store:
 
 ```bash
-python -m agent init
+python -m agent.init_store
 ```
 
-This creates the directories specified by `DATA_DIR` and `OUTPUT_DIR` and writes an empty schema-validated historical store.
+Expected output:
+
+```
+[INFO] Data store initialised at ./data
+[INFO] Output directory created at ./output
+[INFO] Historical retention set to 365 days
+```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline sequence (setup reference)
+### Pipeline Execution Sequence
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant CLI as agent CLI
+    participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (OUTPUT_DIR)
+    participant Store as Data Store
+    participant Out as JSON Output
 
-    User->>CLI: python -m agent run
-    CLI->>DIA: fetch & normalize market data
-    DIA-->>CLI: market state object
-    CLI->>EDA: detect & score events
-    EDA-->>CLI: scored event list
-    CLI->>FGA: compute derived signals
-    FGA-->>CLI: feature store
-    CLI->>SEA: evaluate & rank strategies
-    SEA-->>CLI: ranked candidates (JSON)
-    CLI->>FS: write candidates_<timestamp>.json
-    CLI-->>User: summary printed to stdout
+    User->>CLI: python -m agent.run
+    CLI->>DIA: start ingestion cycle
+    DIA->>Store: write market state object
+    DIA-->>CLI: ingestion complete
+    CLI->>EDA: start event detection
+    EDA->>Store: read market state
+    EDA->>Store: write scored events
+    EDA-->>CLI: event detection complete
+    CLI->>FGA: start feature generation
+    FGA->>Store: read market state + events
+    FGA->>Store: write derived features
+    FGA-->>CLI: features ready
+    CLI->>SEA: start strategy evaluation
+    SEA->>Store: read all features
+    SEA->>Out: write ranked candidates
+    SEA-->>CLI: evaluation complete
+    CLI-->>User: pipeline run finished
 ```
 
-### Run a single full-pipeline cycle
+### Running a Single Full Pipeline Pass
+
+Execute all four agents in sequence for one evaluation cycle:
 
 ```bash
-python -m agent run
+python -m agent.run
 ```
 
-The pipeline executes all four agents in sequence and writes a timestamped JSON file to `OUTPUT_DIR`.
+This command:
+1. Runs the **Data Ingestion Agent** — fetches and normalises all configured feeds.
+2. Runs the **Event Detection Agent** — scores supply and geopolitical events.
+3. Runs the **Feature Generation Agent** — computes all derived signals.
+4. Runs the **Strategy Evaluation Agent** — ranks candidate opportunities.
 
-### Run in continuous (scheduled) mode
+Output is written to `$OUTPUT_PATH/candidates_<ISO8601_timestamp>.json`.
+
+### Running in Continuous Mode
+
+To run the pipeline on a recurring cadence (respecting `MARKET_DATA_REFRESH_INTERVAL`):
 
 ```bash
-python -m agent run --continuous
+python -m agent.run --continuous
 ```
 
-Market data agents refresh on the cadence set by `MARKET_DATA_INTERVAL_SECONDS`. Slower feeds (EIA, EDGAR) refresh daily or weekly automatically per their source schedule.
+The pipeline will loop indefinitely, sleeping between cycles. Press `Ctrl+C` to stop gracefully.
 
-### Run a specific agent in isolation
+### Running Individual Agents
 
-Each agent can be invoked independently for testing or incremental development:
+Each agent can be invoked independently for debugging or incremental development:
 
 ```bash
-python -m agent run --agent ingestion    # Data Ingestion Agent only
-python -m agent run --agent events       # Event Detection Agent only
-python -m agent run --agent features     # Feature Generation Agent only
-python -m agent run --agent strategy     # Strategy Evaluation Agent only
+# Data Ingestion Agent only
+python -m agent.ingestion
+
+# Event Detection Agent only (requires a valid market state in the store)
+python -m agent.events
+
+# Feature Generation Agent only (requires market state + events)
+python -m agent.features
+
+# Strategy Evaluation Agent only (requires features store to be populated)
+python -m agent.strategy
 ```
 
-> **Note:** Running `strategy` in isolation requires a pre-populated feature store. Run `ingestion`, `events`, and `features` first, or use a previously persisted state.
+### Running with Docker
 
-### Useful CLI flags
+```bash
+# Build the image
+docker build -t energy-options-agent:latest .
 
-| Flag | Description |
+# Run a single pass, mounting local data and output directories
+docker run --rm \
+  --env-file .env \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/output:/app/output" \
+  energy-options-agent:latest
+
+# Run in continuous mode
+docker run --rm \
+  --env-file .env \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/output:/app/output" \
+  energy-options-agent:latest --continuous
+```
+
+### Selecting the Active MVP Phase
+
+Set `PHASE` in `.env` to control which data sources and scoring layers are active:
+
+| `PHASE` value | Active capabilities |
 |---|---|
-| `--continuous` | Run on a recurring schedule instead of once |
-| `--agent <name>` | Run a single named agent (`ingestion`, `events`, `features`, `strategy`) |
-| `--output-dir <path>` | Override `OUTPUT_DIR` for this run |
-| `--log-level <level>` | Override `LOG_LEVEL` for this run |
-| `--dry-run` | Execute pipeline but suppress file writes (useful for testing) |
+| `1` | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
+| `2` | Phase 1 + EIA inventory/refinery data, GDELT/NewsAPI event detection, supply disruption indices |
+| `3` | Phase 2 + insider trades (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic), full edge scoring |
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output File Location
 
-Each pipeline run writes a file named:
-
-```
-<OUTPUT_DIR>/candidates_<ISO8601_timestamp>.json
-```
-
-Example:
+Each pipeline run writes one JSON file to `$OUTPUT_PATH`:
 
 ```
-./output/candidates_2026-03-15T14-32-00Z.json
+./output/candidates_2026-03-15T14:32:00Z.json
 ```
 
-### Output schema
+### Output Schema
 
-Each element of the output array represents one ranked strategy candidate:
+Each file contains a JSON array of **strategy candidate objects**. Every candidate has the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | One of `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | `object` | Contributing signal map used to explain the score |
+| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | Option structure: `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values |
 | `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example candidate
+### Example Output
 
 ```json
-{
-  "instrument": "USO",
-  "structure": "long_straddle",
-  "expiration": 30,
-  "edge_score": 0.47,
-  "signals": {
-    "tanker_disruption_index": "high",
-    "volatility_gap": "positive",
-    "narrative_velocity": "rising"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
+    },
+    "generated_at": "2026-03-15T14:32:00Z"
   },
-  "generated_at": "2026-03-15T14:32:00Z"
-}
+  {
+    "instrument": "XLE",
+    "structure": "call_spread",
+    "expiration": 45,
+    "edge_score": 0.31,
+    "signals": {
+      "volatility_gap": "positive",
+      "supply_shock_probability": "elevated",
+      "sector_dispersion": "widening"
+    },
+    "generated_at": "2026-03-15T14:32:00Z"
+  }
+]
 ```
 
-### Understanding the `edge_score`
+### Reading the Edge Score
 
-The `edge_score` is a composite float between `0.0` and `1.0` that reflects the confluence of active signals for a given candidate. Use it to **prioritise review**, not as a standalone buy/sell signal.
-
-| Score range | Suggested interpretation |
+| `edge_score` range | Suggested interpretation |
 |---|---|
-| `0.75 – 1.00` | Strong signal confluence — highest priority for manual review |
-| `0.50 – 0.74` | Moderate confluence — worth investigating |
-| `0.25 – 0.49` | Weak confluence — monitor but low priority |
-| `0.00 – 0.24` | Minimal confluence — typically not actionable |
+| 0.70 – 1.00 | Strong signal confluence — worth close review |
+| 0.45 – 0.69 | Moderate confluence — monitor for confirmation |
+| 0.20 – 0.44 | Weak signal — low priority |
+| 0.00 – 0.19 | Minimal confluence — likely noise |
 
-### Understanding the `signals` map
+> The edge score is a composite heuristic, not a probability of profit. Always validate candidates against your own market view before acting.
 
-The `signals` object identifies **which derived signals contributed** to the `edge_score`, providing full explainability for each recommendation.
+### Signal Keys Reference
 
-| Signal key | What it measures |
-|---|---|
-| `volatility_gap` | Spread between realized and implied volatility |
-| `futures_curve_steepness` | Degree of contango or backwardation in the futures curve |
-| `sector_dispersion` | Cross-sector correlation divergence |
-| `insider_conviction_score` | Strength of recent executive insider trading activity |
-| `narrative_velocity` | Acceleration of energy-related headline volume |
-| `supply_shock_probability` | Modelled likelihood of a near-term supply disruption |
-| `tanker_disruption_index` | Shipping flow anomaly score from tanker/logistics feeds |
-
-### Using the output with thinkorswim
-
-The output is JSON-compatible and can be loaded into thinkorswim or any JSON-capable dashboard. Import the candidates file or pipe it to your preferred visualization tool:
-
-```bash
-# Pretty-print the most recent candidates file
-cat $(ls -t ./output/candidates_*.json | head -1) | python -m json.tool
-```
-
----
-
-## Troubleshooting
-
-### Common errors and fixes
-
-| Symptom | Likely cause | Resolution |
+| Signal key | Source agent | What it measures |
 |---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | Missing environment variable | Verify `.env` is populated and loaded; run `python -m agent check-env` |
-| `HTTP 429 – Too Many Requests` | API rate limit exceeded | Increase `MARKET_DATA_INTERVAL_SECONDS`; check the rate limits for the affected service |
-| `No candidates generated` | All edge scores below threshold, or empty feature store | Run with `--log-level DEBUG` to inspect signal values; confirm data feeds are returning data |
-| Pipeline stalls at `ingestion` stage | Network timeout or feed unavailable | The pipeline is designed to tolerate missing data; check logs for `WARN` messages about skipped feeds |
-| `FileNotFoundError` for `DATA_DIR` or `OUTPUT_DIR` | Storage not initialised | Run `python -m agent init` before the first `run` |
-| Old or stale candidates in output | Pipeline not re-run after market close | Confirm `--continuous` mode is active, or re-run manually |
-| `json.decoder.JSONDecodeError` in output file | Partial write from interrupted run | Delete the malformed file; re-run the pipeline |
-
-### Verifying your environment
-
-```bash
-python -m agent check-env
-```
-
-This command validates that all required environment variables are set and that each configured API key returns a successful test response.
-
-### Enabling debug logging
-
-```bash
-python -m agent run --log-level DEBUG
-```
-
-Debug output includes the raw market state object, per-event confidence scores, all computed feature values, and the full signal map for each evaluated candidate. Redirect to a file for easier inspection:
-
-```bash
-python -m agent run --log-level DEBUG 2>&1 | tee debug_$(date +%Y%m%dT%H%M%S).log
-```
-
-### Data feed status and resilience
-
-The pipeline is designed to **tolerate delayed or missing data without failing**. If a feed is unavailable:
-
-- The affected signal is marked as `unavailable` in the candidate's `signals` map.
-- The `edge_score` is computed from the remaining available signals.
-- A `WARNING` is emitted to the log with the name of the skipped source.
-
-To disable a feed explicitly (e.g., during testing), set the corresponding `*_ENABLED` variable to `false` in your `.env` file.
-
-### Data retention
-
-By default, the pipeline retains 12 months of raw and derived data (configurable via `HISTORY_MONTHS`). If your storage fills unexpectedly:
-
-```bash
-# Check current storage usage
-du -sh ./data
-
-# Reduce retention window (minimum supported: 6 months)
-# Edit .env: HISTORY_MONTHS=6
-python -m agent prune
-```
-
-### Getting help
-
-- Review the [System Design Document](./docs/system_design.md) for authoritative architecture details.
-- Open an issue on the project repository with the relevant log excerpt and your `.env` configuration (credentials redacted).
-
----
-
-> **Reminder:** This system is **advisory only**. Automated trade execution is out of scope for the current version. Always apply independent judgment before acting on any generated candidate.
+| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence (positive = IV underpriced) |
+| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the crude futures curve |
+| `sector_dispersion` | Feature Generation | Price divergence across energy equities and ETFs |
+| `insider_conviction_score` | Feature Generation | Aggregated insider buying/selling intensity (EDGAR/Quiver) |
+| `narrative_velocity` | Feature Generation | Rate of acceleration in energy-related headlines and retail posts |
+| `supply_shock_probability` | Feature Generation | Composite probability of an imminent supply disruption |
+| `tanker_disruption_index` | Event Detection | Severity of detected tanker route or

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> Advisory only. The system surfaces ranked options opportunities; it does **not** place trades automatically.
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
 
 ---
 
@@ -18,48 +18,70 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil-market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
+The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline that identifies options trading opportunities driven by oil market instability. It consumes market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies with full signal explainability.
 
-The pipeline is composed of four loosely coupled agents that execute in sequence:
+### Pipeline Architecture
+
+The system is composed of four loosely coupled agents. Data flows **unidirectionally** through the pipeline:
 
 ```mermaid
 flowchart LR
-    A([Raw Feeds]) --> B[Data Ingestion Agent\nFetch & Normalize]
-    B -->|Market State Object| C[Event Detection Agent\nSupply & Geo Signals]
-    C -->|Scored Events| D[Feature Generation Agent\nDerived Signal Computation]
-    D -->|Feature Store| E[Strategy Evaluation Agent\nOpportunity Ranking]
-    E --> F([JSON Output\nRanked Candidates])
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
+        A8[Sentiment\nReddit / Stocktwits]
+    end
 
-    style A fill:#f5f5f5,stroke:#999
-    style F fill:#f5f5f5,stroke:#999
-    style B fill:#dbeafe,stroke:#3b82f6
-    style C fill:#fef9c3,stroke:#ca8a04
-    style D fill:#dcfce7,stroke:#16a34a
-    style E fill:#fce7f3,stroke:#db2777
+    subgraph Pipeline
+        B1["① Data Ingestion Agent\nFetch & Normalize"]
+        B2["② Event Detection Agent\nSupply & Geo Signals"]
+        B3["③ Feature Generation Agent\nDerived Signal Computation"]
+        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+    end
+
+    subgraph Output
+        C1[Ranked Candidates\nJSON / Dashboard]
+    end
+
+    A1 & A2 & A3 & A4 --> B1
+    A5 --> B2
+    A6 & A7 & A8 --> B3
+
+    B1 -->|Unified Market State| B2
+    B2 -->|Scored Events| B3
+    B3 -->|Derived Features| B4
+    B4 --> C1
 ```
 
-| Agent | Role | Key Output |
-|---|---|---|
-| **Data Ingestion Agent** | Fetch & normalize prices, ETF/equity data, and options chains | Unified market state object |
-| **Event Detection Agent** | Monitor news and geopolitical feeds; score supply disruptions | Confidence- and intensity-scored event list |
-| **Feature Generation Agent** | Compute volatility gaps, curve steepness, narrative velocity, etc. | Derived features store |
-| **Strategy Evaluation Agent** | Evaluate eligible structures; rank by edge score | JSON array of ranked strategy candidates |
+### Agents at a Glance
 
-Data flows **unidirectionally** through the agents. Each agent can be deployed and updated independently without disrupting the rest of the pipeline.
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion** | Fetch & Normalize | Unified market state object; historical store |
+| **Event Detection** | Supply & Geo Signals | Events with confidence and intensity scores |
+| **Feature Generation** | Derived Signal Computation | Volatility gaps, curve steepness, narrative velocity, etc. |
+| **Strategy Evaluation** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
 
 ### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
 ### In-Scope Option Structures (MVP)
 
 - Long straddles
 - Call / put spreads
 - Calendar spreads
+
+> **Advisory only.** Automated trade execution is explicitly out of scope for the MVP. All output is intended for human review.
 
 ---
 
@@ -70,43 +92,35 @@ Data flows **unidirectionally** through the agents. Each agent can be deployed a
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Operating System | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to data provider endpoints |
+| Disk | 5 GB (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-### Required Tools
+### Required Knowledge
 
-```bash
-# Verify Python version
-python --version   # must be >= 3.10
+- Comfortable running Python scripts and CLI commands
+- Familiarity with virtual environments (`venv` or `conda`)
+- Basic understanding of options terminology (implied volatility, strikes, expiration)
 
-# Verify pip
-pip --version
+### API Accounts
 
-# (Recommended) Verify that venv is available
-python -m venv --help
-```
+You must obtain API keys or free-tier access for the following services before running the pipeline. All sources are free or low-cost.
 
-### API Keys & Accounts
-
-You must obtain credentials for the following services before running the pipeline. All tiers listed are **free or low-cost**.
-
-| Service | Used By | Sign-Up URL | Notes |
+| Data Layer | Source | Sign-up URL | Cost |
 |---|---|---|---|
-| Alpha Vantage | Crude prices (WTI, Brent) | <https://www.alphavantage.co/support/#api-key> | Free tier; rate-limited |
-| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required | Public API |
-| Polygon.io | Options data (fallback) | <https://polygon.io/> | Free tier available |
-| EIA API | Supply & inventory data | <https://www.eia.gov/opendata/> | Free; weekly cadence |
-| NewsAPI | News & geopolitical events | <https://newsapi.org/register> | Free developer tier |
-| GDELT | Geopolitical events | No key required | Public dataset |
-| SEC EDGAR | Insider activity | No key required | Public API |
-| Quiver Quant | Insider conviction scores | <https://www.quiverquant.com/> | Free/limited tier |
-| Reddit API | Narrative / sentiment | <https://www.reddit.com/prefs/apps> | Free; OAuth2 app required |
-| Stocktwits | Narrative / sentiment | <https://api.stocktwits.com/> | Free public stream |
-| MarineTraffic | Shipping / tanker flows | <https://www.marinetraffic.com/> | Free tier available |
-
-> **Tip:** For the MVP (Phase 1), only **Alpha Vantage**, **yfinance**, and optionally **Polygon.io** are strictly required. Additional keys unlock Phase 2 and Phase 3 signals.
+| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free |
+| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free |
+| ETF / Equity | yfinance (Yahoo Finance) | No key required | Free |
+| Options Chains | Polygon.io | https://polygon.io | Free / Limited |
+| Supply & Inventory | EIA API | https://www.eia.gov/opendata | Free |
+| News & Geo Events | NewsAPI | https://newsapi.org | Free |
+| News & Geo Events (alt) | GDELT | https://www.gdeltproject.org | Free |
+| Insider Activity | SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free |
+| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free / Limited |
+| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
+| Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free |
+| Sentiment (alt) | Stocktwits | https://api.stocktwits.com/developers | Free |
 
 ---
 
@@ -122,13 +136,9 @@ cd energy-options-agent
 ### 2. Create and Activate a Virtual Environment
 
 ```bash
-python -m venv .venv
-
-# Linux / macOS
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+python3 -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows (PowerShell)
 ```
 
 ### 3. Install Dependencies
@@ -140,65 +150,82 @@ pip install -r requirements.txt
 
 ### 4. Configure Environment Variables
 
-Copy the provided template and populate it with your credentials:
+All runtime configuration is provided through environment variables. Copy the example file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in the values described in the table below.
+Then open `.env` in your editor and fill in the values described in the table below.
 
 #### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for Alpha Vantage crude price feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options data fallback |
-| `EIA_API_KEY` | ✅ Phase 2 | — | API key for EIA supply & inventory feed |
-| `NEWS_API_KEY` | ✅ Phase 2 | — | API key for NewsAPI geopolitical/news feed |
-| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
-| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit OAuth2 application client ID |
-| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit OAuth2 application client secret |
-| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `MARINETRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic shipping feed |
-| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Polling interval for market data feeds (minutes cadence) |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `PHASE` | No | `1` | Active pipeline phase (`1`–`3`); controls which agents and signals are enabled |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | No | — | API key for MetalpriceAPI (fallback crude feed) |
+| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA supply and inventory data |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/news events |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
+| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic shipping data |
+| `REDDIT_CLIENT_ID` | No | — | Reddit PRAW application client ID |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit PRAW application client secret |
+| `REDDIT_USER_AGENT` | No | `energy-agent/1.0` | Reddit PRAW user agent string |
+| `STOCKTWITS_API_KEY` | No | — | Stocktwits API key for sentiment feed |
+| `DATA_DIR` | No | `./data` | Root directory for raw and derived data storage |
+| `OUTPUT_DIR` | No | `./output` | Directory where ranked JSON candidates are written |
+| `HISTORY_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_SECONDS` | No | `60` | Polling cadence for minute-level market data feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_MODE` | No | `full` | Run mode: `full`, `ingest_only`, `features_only`, `evaluate_only` |
+| `MIN_EDGE_SCORE` | No | `0.30` | Minimum edge score threshold for a candidate to appear in output |
+| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
 
-Example `.env` for a Phase 1 run:
+> **Tip:** Variables marked **No** under *Required* activate optional data layers (shipping, insider, sentiment). The pipeline degrades gracefully when these keys are absent — see [Troubleshooting](#troubleshooting).
+
+#### Example `.env` File
 
 ```dotenv
-# === Phase 1 — Core Market Signals ===
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=                        # optional fallback
-EIA_API_KEY=                            # required for Phase 2+
-NEWS_API_KEY=                           # required for Phase 2+
+# Core credentials (required)
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
 
-PHASE=1
-DATA_REFRESH_INTERVAL_MINUTES=5
-HISTORY_RETENTION_DAYS=365
+# Optional enrichment layers
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+QUIVER_QUANT_API_KEY=YOUR_QUIVER_KEY_HERE
+MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
+REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
+REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
+REDDIT_USER_AGENT=energy-agent/1.0
+
+# Runtime settings
+DATA_DIR=./data
 OUTPUT_DIR=./output
+HISTORY_DAYS=365
+MARKET_DATA_INTERVAL_SECONDS=60
 LOG_LEVEL=INFO
+PIPELINE_MODE=full
+MIN_EDGE_SCORE=0.30
+MAX_CANDIDATES=20
 ```
 
-> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` excludes it by default.
+### 5. Initialise the Data Directory
 
-### 5. Initialise the Database
-
-The pipeline stores historical raw and derived data locally (sized for 6–12 months of history):
+Create the storage structure required for historical raw and derived data:
 
 ```bash
-python manage.py init-db
+python scripts/init_storage.py
 ```
 
 Expected output:
 
 ```
-[INFO] Initialising database at ./data/market_state.db ...
-[INFO] Schema applied. Historical data retention set to 365 days.
-[INFO] Done.
+[INFO] Created directory: ./data/raw
+[INFO] Created directory: ./data/derived
+[INFO] Created directory: ./output
+[INFO] Storage initialised successfully.
 ```
 
 ---
@@ -209,180 +236,159 @@ Expected output:
 
 ```mermaid
 sequenceDiagram
-    participant CLI as User / Scheduler
+    participant User
+    participant CLI as pipeline.py (CLI)
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (JSON Output)
+    participant FS as File System (output/)
 
-    CLI->>DIA: python run_pipeline.py --phase 1
-    DIA->>DIA: Fetch crude, ETF/equity prices & options chains
-    DIA->>EDA: market_state object
-    EDA->>EDA: Score news / geo events (confidence + intensity)
-    EDA->>FGA: scored_events + market_state
-    FGA->>FGA: Compute volatility gaps, curve steepness, etc.
-    FGA->>SEA: derived_features store
-    SEA->>SEA: Evaluate structures; rank by edge_score
-    SEA->>FS: Write ranked_candidates_<timestamp>.json
-    FS-->>CLI: Pipeline complete ✓
+    User->>CLI: python pipeline.py --mode full
+    CLI->>DIA: run()
+    DIA-->>CLI: market_state (unified object)
+    CLI->>EDA: run(market_state)
+    EDA-->>CLI: event_signals (scored events)
+    CLI->>FGA: run(market_state, event_signals)
+    FGA-->>CLI: derived_features (vol gaps, curve, etc.)
+    CLI->>SEA: run(market_state, event_signals, derived_features)
+    SEA-->>CLI: ranked_candidates[]
+    CLI->>FS: write candidates_<timestamp>.json
+    CLI-->>User: Summary printed to stdout
 ```
 
-### Single Run
+### Full Pipeline Run
 
-Execute one full pass of the pipeline:
+Run all four agents in sequence:
 
 ```bash
-python run_pipeline.py
+python pipeline.py --mode full
 ```
 
-To override the active phase without editing `.env`:
+### Partial / Single-Agent Runs
+
+Use `--mode` to run only a subset of the pipeline. This is useful for debugging or when feeding pre-computed intermediate data.
 
 ```bash
-python run_pipeline.py --phase 2
+# Re-ingest raw market data only
+python pipeline.py --mode ingest_only
+
+# Regenerate features from cached market state
+python pipeline.py --mode features_only
+
+# Re-evaluate strategies using the latest cached features
+python pipeline.py --mode evaluate_only
 ```
 
-To specify a custom output directory for this run:
+### Scheduled Continuous Execution
+
+For production use, drive the pipeline on a regular cadence using `cron` (Linux/macOS) or Task Scheduler (Windows):
 
 ```bash
-python run_pipeline.py --output-dir /tmp/pipeline-out
+# Example: run the full pipeline every 5 minutes during market hours
+crontab -e
 ```
 
-### Continuous (Polling) Mode
+```cron
+*/5 9-17 * * 1-5 /path/to/.venv/bin/python /path/to/pipeline.py --mode full >> /var/log/energy-agent.log 2>&1
+```
 
-Run the pipeline on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence:
+> **Note:** Market data refreshes on a minutes-level cadence. Slower feeds (EIA inventory, EDGAR insider filings) update daily or weekly; the pipeline applies the appropriate polling frequency per source automatically.
+
+### Verbose / Debug Mode
 
 ```bash
-python run_pipeline.py --continuous
+python pipeline.py --mode full --log-level DEBUG
 ```
 
-Press `Ctrl+C` to stop. The pipeline will finish the current cycle before exiting cleanly.
+Or set `LOG_LEVEL=DEBUG` in your `.env` file for persistent debug output.
 
-### Running Individual Agents
+### Running Inside Docker
 
-Each agent can be executed independently for development or debugging:
+A `Dockerfile` and `docker-compose.yml` are provided for containerised deployment on a single VM or local machine:
 
 ```bash
-# Data Ingestion only
-python -m agents.data_ingestion
+# Build the image
+docker build -t energy-options-agent:latest .
 
-# Event Detection only (requires a saved market state)
-python -m agents.event_detection --state ./output/market_state_latest.json
-
-# Feature Generation only
-python -m agents.feature_generation --state ./output/market_state_latest.json
-
-# Strategy Evaluation only
-python -m agents.strategy_evaluation --features ./output/features_latest.json
+# Run with your .env file mounted
+docker run --env-file .env \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  energy-options-agent:latest
 ```
-
-### Phase-by-Phase Feature Availability
-
-| Phase | Name | Signals Enabled | Additional Keys Needed |
-|---|---|---|---|
-| 1 | Core Market Signals & Options | Crude prices, ETF/equity prices, IV surface, long straddles, call/put spreads | `ALPHA_VANTAGE_API_KEY` |
-| 2 | Supply & Event Augmentation | + EIA inventory, refinery utilisation, GDELT/NewsAPI event detection, supply disruption indices | `EIA_API_KEY`, `NEWS_API_KEY` |
-| 3 | Alternative / Contextual Signals | + Insider trades, narrative velocity (Reddit/Stocktwits), shipping data, cross-sector correlation | `REDDIT_CLIENT_ID/SECRET`, optionally `QUIVER_QUANT_API_KEY`, `MARINETRAFFIC_API_KEY` |
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output Location
 
-After each pipeline run, a timestamped JSON file is written to `OUTPUT_DIR`:
+After each run, candidates are written to the directory specified by `OUTPUT_DIR` (default: `./output`):
 
 ```
-./output/ranked_candidates_2026-03-15T14:32:00Z.json
+output/
+└── candidates_2026-03-15T14:32:00Z.json
 ```
 
-A symlink `ranked_candidates_latest.json` always points to the most recent file.
+A `candidates_latest.json` symlink is also updated to always point to the most recent file.
 
 ### Output Schema
 
-Each element in the output array represents one ranked strategy candidate:
+Each ranked candidate is a JSON object with the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output
+### Example Candidate
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
+{
+  "instrument": "USO",
+  "structure": "long_straddle",
+  "expiration": 30,
+  "edge_score": 0.47,
+  "signals": {
+    "tanker_disruption_index": "high",
+    "volatility_gap": "positive",
+    "narrative_velocity": "rising"
   },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive",
-      "supply_shock_probability": "elevated",
-      "sector_dispersion": "high"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
+  "generated_at": "2026-03-15T14:32:00Z"
+}
 ```
 
 ### Reading the Edge Score
 
-| Edge Score Range | Interpretation | Suggested Action |
+The `edge_score` is the primary ranking signal. It is a composite of all contributing derived features, normalised to `[0.0, 1.0]`.
+
+| Edge Score Range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
+| `0.50 – 0.69` | Moderate signal confluence — worth monitoring |
+| `0.30 – 0.49` | Weak confluence — lower conviction, proceed with caution |
+| `< 0.30` | Below threshold — filtered out by default (`MIN_EDGE_SCORE`) |
+
+> Candidates are ordered by `edge_score` descending. Review the `signals` object for every candidate to understand **why** the score was assigned before acting on any recommendation.
+
+### Contributing Signals Reference
+
+The `signals` object may contain any of the following keys, depending on which data layers are active:
+
+| Signal Key | Source Layer | Possible Values |
 |---|---|---|
-| 0.70 – 1.00 | Strong signal confluence | High-priority candidate; review signals carefully |
-| 0.40 – 0.69 | Moderate confluence | Candidate worth monitoring; validate with additional research |
-| 0.10 – 0.39 | Weak confluence | Low-conviction signal; treat as background noise unless a specific thesis supports it |
-| 0.00 – 0.09 | Negligible | Discard |
+| `volatility_gap` | Feature Generation | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | Feature Generation | `contango`, `backwardation`, `flat` |
+| `sector_dispersion` | Feature Generation | `high`, `moderate`, `low` |
+| `insider_conviction_score` | Alternative Signals | `high`, `moderate`, `low` |
+| `narrative_velocity` | Alternative Signals | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | Event Detection | `high`, `moderate`, `low` |
+| `tanker_disruption_index` | Event Detection | `high`, `moderate`, `low` |
+| `eia_inventory_surprise` | Event Detection | `bullish`, `bearish`, `neutral` |
 
-> **Important:** The edge score is a heuristic composite, not a probability of profit. Always perform independent due diligence before placing any trade. The system is **advisory only**.
-
-### Signal Reference
-
-| Signal Key | Description | Source Agent |
-|---|---|---|
-| `volatility_gap` | Realised vs. implied volatility divergence | Feature Generation |
-| `futures_curve_steepness` | Contango / backwardation gradient | Feature Generation |
-| `sector_dispersion` | Spread between energy sub-sector moves | Feature Generation |
-| `insider_conviction_score` | Aggregated insider trading signal | Feature Generation |
-| `narrative_velocity` | Acceleration of energy-related headlines | Feature Generation |
-| `supply_shock_probability` | Modelled probability of a supply disruption | Feature Generation |
-| `tanker_disruption_index` | Shipping-flow anomaly score | Event Detection |
-| `refinery_outage_score` | Refinery utilisation deviation | Event Detection |
-| `geopolitical_intensity` | Geo-event confidence × intensity product | Event Detection |
-
-### Visualisation
-
-The JSON output is compatible with **thinkorswim** or any JSON-capable dashboard. To load the latest candidates directly:
-
-```bash
-cat ./output/ranked_candidates_latest.json | python -m json.tool
-```
-
----
-
-## Troubleshooting
-
-### Common Issues
-
-| Symptom | Likely Cause | Resolution |
-|---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` not loaded or variable missing | Confirm `.env` exists in project root and contains the key; verify `python-dotenv` is installed |
-| `RateLimitError` from Alpha Vantage | Free-tier rate limit exceeded | Increase `DATA_REFRESH_INTERVAL_MINUTES`; consider caching raw responses |
-| Empty `ranked_candidates_*.json` | No candidates exceeded the minimum threshold | Check `LOG_LEVEL=DEBUG` output; verify market data was fetched
+###

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline end-to-end. It assumes you are comfortable with Python, virtual environments, and basic CLI usage.
+> **Version 1.0 • March 2026**
+> This guide walks a developer through installing, configuring, and running the full pipeline end-to-end, and explains how to read and act on its output.
 
 ---
 
@@ -18,50 +18,74 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that surfaces options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical news, and alternative datasets, then produces structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is a four-agent Python pipeline that detects volatility mispricing in oil-related instruments and produces ranked, explainable options trading candidates.
 
 ### What the pipeline does
 
+| Stage | Agent | Input | Output |
+|---|---|---|---|
+| 1 | **Data Ingestion Agent** | Raw API feeds | Unified market state object |
+| 2 | **Event Detection Agent** | Market state + news/geo feeds | Scored supply & geopolitical events |
+| 3 | **Feature Generation Agent** | Market state + event scores | Derived signal set |
+| 4 | **Strategy Evaluation Agent** | Derived signals | Ranked candidate opportunities (JSON) |
+
+Data flows **unidirectionally** through the agents via a shared market state object and a derived features store. No stage writes back to an earlier stage.
+
 ```mermaid
 flowchart LR
-    subgraph Sources["External Data Sources"]
-        A1[Alpha Vantage / MetalpriceAPI\nCrude Prices]
-        A2[yfinance / Polygon.io\nETF & Equity Prices + Options]
-        A3[EIA API\nInventory & Utilization]
-        A4[GDELT / NewsAPI\nNews & Geo Events]
-        A5[SEC EDGAR / Quiver Quant\nInsider Activity]
-        A6[MarineTraffic / VesselFinder\nShipping & Tanker Flows]
-        A7[Reddit / Stocktwits\nNarrative Sentiment]
+    subgraph Feeds["External Feeds"]
+        F1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        F2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        F3[Options Chains\nYahoo Finance / Polygon.io]
+        F4[Supply & Inventory\nEIA API]
+        F5[News & Geo Events\nGDELT / NewsAPI]
+        F6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        F7[Shipping & Logistics\nMarineTraffic / VesselFinder]
+        F8[Narrative & Sentiment\nReddit / Stocktwits]
     end
 
     subgraph Pipeline["Agent Pipeline"]
-        B["① Data Ingestion Agent\nFetch & Normalize"]
-        C["② Event Detection Agent\nSupply & Geo Signals"]
-        D["③ Feature Generation Agent\nDerived Signal Computation"]
-        E["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+        A1["🟦 Data Ingestion Agent\nFetch & Normalize"]
+        A2["🟨 Event Detection Agent\nSupply & Geo Signals"]
+        A3["🟩 Feature Generation Agent\nDerived Signal Computation"]
+        A4["🟥 Strategy Evaluation Agent\nOpportunity Ranking"]
+    end
+
+    subgraph Store["Shared State"]
+        MS[(Market State\nObject)]
+        FS[(Derived\nFeatures Store)]
     end
 
     subgraph Output["Output"]
-        F[Ranked Candidate JSON\nEdge-scored Opportunities]
+        JSON[Ranked Candidates\nJSON]
     end
 
-    Sources --> B
-    B -->|Unified Market State| C
-    C -->|Scored Events| D
-    D -->|Derived Features| E
-    E --> F
+    F1 & F2 & F3 & F4 --> A1
+    F5 --> A2
+    F6 & F7 & F8 --> A3
+
+    A1 -->|writes| MS
+    MS -->|reads| A2
+    A2 -->|scored events| MS
+    MS -->|reads| A3
+    A3 -->|writes| FS
+    FS -->|reads| A4
+    A4 --> JSON
 ```
 
-### In-scope instruments and strategies
+### In-scope instruments (MVP)
 
-| Category | Items |
+| Category | Instruments |
 |---|---|
-| **Crude futures** | Brent Crude, WTI (`CL=F`) |
-| **ETFs** | USO, XLE |
-| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
 
-> **Advisory only.** The system generates recommendations but performs no automated trade execution.
+### In-scope option structures (MVP)
+
+`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
+
+> **Advisory only.** Automated trade execution is out of scope. All output is for informational purposes.
 
 ---
 
@@ -72,30 +96,41 @@ flowchart LR
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| Memory | 2 GB RAM |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS on port 443 |
 | OS | Linux, macOS, or Windows (WSL2 recommended on Windows) |
+| RAM | 2 GB |
+| Disk | 10 GB (for 6–12 months of historical data) |
+| Network | Outbound HTTPS to API endpoints |
 
-### Required accounts and API keys
+### Required tools
 
-All sources are free or free-tier. Obtain credentials before proceeding.
+```bash
+# Verify Python version
+python --version   # must be >= 3.10
 
-| Service | Purpose | Sign-up URL |
+# Verify pip
+pip --version
+
+# Optional but recommended: create an isolated environment
+python -m venv .venv
+source .venv/bin/activate      # Linux / macOS
+# .venv\Scripts\activate       # Windows PowerShell
+```
+
+### API accounts
+
+Obtain free (or free-tier) credentials from the following providers before proceeding. All are zero-cost for MVP usage.
+
+| Provider | Used by | Sign-up URL |
 |---|---|---|
-| Alpha Vantage | Crude spot/futures prices | <https://www.alphavantage.co/support/#api-key> |
-| MetalpriceAPI | Supplemental commodity prices | <https://metalpriceapi.com> |
-| Polygon.io | Options chains (free tier) | <https://polygon.io> |
-| EIA API | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
-| NewsAPI | News & geopolitical events | <https://newsapi.org> |
-| SEC EDGAR | Insider activity (no key required) | <https://efts.sec.gov/LATEST/search-index?q=%22form-type%22:%224%22> |
-| Quiver Quant | Insider conviction scores (optional) | <https://www.quiverquant.com> |
+| Alpha Vantage | Crude prices | https://www.alphavantage.co/support/#api-key |
+| MetalpriceAPI | Crude prices (fallback) | https://metalpriceapi.com |
+| Polygon.io | Options chains | https://polygon.io |
+| EIA API | Supply & inventory | https://www.eia.gov/opendata/ |
+| NewsAPI | News & geo events | https://newsapi.org |
+| Quiver Quant | Insider activity | https://www.quiverquant.com |
+| MarineTraffic | Shipping & logistics | https://www.marinetraffic.com/en/p/api-services |
 
-> **Yahoo Finance / yfinance** and **GDELT** require no API key. **MarineTraffic** and **VesselFinder** offer free tiers; register at their respective sites if you want shipping signals in Phase 3.
-
-### Python dependencies
-
-Install dependencies from the project's `requirements.txt` after cloning (see [Setup & Configuration](#setup--configuration)).
+> `yfinance`, GDELT, SEC EDGAR, Reddit, and Stocktwits do not require API keys for basic access.
 
 ---
 
@@ -108,218 +143,222 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2. Install dependencies
 
 ```bash
-python -m venv .venv
-
-# Linux / macOS
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.venv\Scripts\Activate.ps1
-```
-
-### 3. Install dependencies
-
-```bash
-pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 3. Configure environment variables
 
-Copy the provided template and populate your credentials:
+The pipeline reads all secrets and tuneable parameters from environment variables. The recommended approach is to copy the provided template and edit it in place.
 
 ```bash
 cp .env.example .env
+# then open .env in your editor of choice
 ```
 
-Open `.env` in your editor and fill in each value. The full set of recognised environment variables is listed below.
-
-#### Environment variable reference
+#### Full environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | ✅ | — | API key for MetalpriceAPI commodity feed |
-| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | ✅ | — | API key for EIA inventory/refinery data |
-| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI news/geo event feed |
-| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider signals (Phase 3) |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
-| `DATA_DIR` | ⬜ | `./data` | Local path for storing raw and derived historical data |
-| `OUTPUT_DIR` | ⬜ | `./output` | Directory where ranked candidate JSON files are written |
-| `LOG_LEVEL` | ⬜ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
-| `EIA_REFRESH_SCHEDULE` | ⬜ | `weekly` | Refresh schedule for EIA data (`daily` or `weekly`) |
-| `EDGAR_REFRESH_SCHEDULE` | ⬜ | `daily` | Refresh schedule for SEC EDGAR insider filings |
-| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Number of days of historical data to retain on disk |
-| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`4`); controls which agents are enabled |
-| `INSTRUMENTS` | ⬜ | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to evaluate |
-| `OPTION_STRUCTURES` | ⬜ | `long_straddle,call_spread,put_spread,calendar_spread` | Comma-separated list of eligible option structures |
-| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score `[0.0–1.0]` for a candidate to appear in output |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | No | — | Fallback crude price key (MetalpriceAPI) |
+| `POLYGON_API_KEY` | No | — | Polygon.io key for options chain data |
+| `EIA_API_KEY` | Yes | — | EIA Open Data API key for supply/inventory |
+| `NEWS_API_KEY` | Yes | — | NewsAPI key for news & geopolitical events |
+| `QUIVER_API_KEY` | No | — | Quiver Quant key for insider conviction data |
+| `MARINETRAFFIC_API_KEY` | No | — | MarineTraffic API key for tanker flow data |
+| `DATA_DIR` | No | `./data` | Root directory for persisted market state and historical data |
+| `OUTPUT_DIR` | No | `./output` | Directory where ranked candidate JSON files are written |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for minute-level market data feeds |
+| `OPTIONS_DATA_INTERVAL_HOURS` | No | `24` | Polling cadence for options chain data (daily feeds) |
+| `EIA_INTERVAL_HOURS` | No | `168` | Polling cadence for EIA inventory data (weekly = 168 h) |
+| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting support |
+| `MIN_EDGE_SCORE` | No | `0.20` | Minimum `edge_score` threshold; candidates below this are suppressed |
+| `TARGET_INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to evaluate |
+| `TARGET_STRUCTURES` | No | `long_straddle,call_spread,put_spread,calendar_spread` | Comma-separated list of option structures to evaluate |
+| `TIMEZONE` | No | `UTC` | Timezone for all timestamps in output (`UTC` strongly recommended) |
 
-> **Tip:** Variables marked ⬜ are optional for Phase 1 but may be required by later phases. Leave optional keys blank or commented out if their Phase has not been activated.
-
-#### Minimal `.env` for Phase 1
+#### Example `.env` file
 
 ```dotenv
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-METALPRICE_API_KEY=your_metalprice_key
-POLYGON_API_KEY=your_polygon_key
-EIA_API_KEY=your_eia_key
-NEWS_API_KEY=your_newsapi_key
+# === Required API keys ===
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
 
-# Optional overrides
+# === Optional API keys ===
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
+MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
+
+# === Storage ===
 DATA_DIR=./data
 OUTPUT_DIR=./output
+HISTORY_RETENTION_DAYS=365
+
+# === Pipeline behaviour ===
+MARKET_DATA_INTERVAL_MINUTES=5
+OPTIONS_DATA_INTERVAL_HOURS=24
+EIA_INTERVAL_HOURS=168
+MIN_EDGE_SCORE=0.20
 LOG_LEVEL=INFO
-PIPELINE_PHASE=1
-EDGE_SCORE_THRESHOLD=0.30
+TIMEZONE=UTC
 ```
 
-### 5. Initialise local data storage
+### 4. Initialise the data store
+
+Run the initialisation command once to create the required directory structure and seed the historical data store:
 
 ```bash
 python -m agent init
 ```
 
-This creates the directory structure under `DATA_DIR` and writes empty schema files for the historical store.
+Expected output:
 
 ```
-data/
-├── raw/
-│   ├── prices/
-│   ├── options/
-│   ├── eia/
-│   ├── events/
-│   ├── insider/
-│   └── shipping/
-└── derived/
-    ├── features/
-    └── market_state/
+[INFO] Creating data directory at ./data
+[INFO] Creating output directory at ./output
+[INFO] Historical store initialised (retention: 365 days)
+[INFO] Init complete.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution flow
+### Pipeline phases
 
-```mermaid
-sequenceDiagram
-    participant User
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Local Data Store
-    participant Out as Output (JSON)
+The pipeline ships with support for the four MVP phases. You can run a specific phase or the full stack. Phases build on each other — running Phase 3 implicitly requires Phases 1 and 2 to have run at least once.
 
-    User->>CLI: python -m agent run
-    CLI->>DIA: trigger ingestion
-    DIA->>Store: fetch & persist raw feeds
-    DIA-->>EDA: emit unified market state
-    EDA->>Store: score & persist events
-    EDA-->>FGA: emit scored event list
-    FGA->>Store: compute & persist derived features
-    FGA-->>SEA: emit feature vector
-    SEA->>Out: write ranked candidate JSON
-    SEA-->>CLI: pipeline complete
-    CLI-->>User: exit 0 / log summary
-```
+| Phase flag | Name | What it enables |
+|---|---|---|
+| `--phase 1` | Core Market Signals & Options | Crude/ETF prices, options surface, straddle & spread strategies |
+| `--phase 2` | Supply & Event Augmentation | EIA inventory, GDELT/NewsAPI event detection, event-driven scoring |
+| `--phase 3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, full edge scoring |
+| `--phase 4` | High-Fidelity Enhancements | Reserved for future paid data sources and exotic structures |
 
-### Running once (single-shot)
+### Single run (one-shot)
 
-Execute a full pipeline run against current market data and exit:
+Execute the full pipeline once and write results to `OUTPUT_DIR`:
 
 ```bash
 python -m agent run
 ```
 
-On success the process exits with code `0` and writes one or more candidate files to `OUTPUT_DIR`.
-
-### Running with a specific phase
-
-Override the active phase at the command line without changing `.env`:
+Run only through Phase 2:
 
 ```bash
 python -m agent run --phase 2
 ```
 
-### Running individual agents
-
-Each agent can be executed in isolation for debugging or incremental development:
+Run a single named agent in isolation (useful for debugging):
 
 ```bash
-# Step 1 – ingest and normalize market data
 python -m agent run --agent ingestion
-
-# Step 2 – detect and score supply/geo events
-python -m agent run --agent events
-
-# Step 3 – compute derived features
-python -m agent run --agent features
-
-# Step 4 – evaluate and rank strategies
-python -m agent run --agent strategy
+python -m agent run --agent event_detection
+python -m agent run --agent feature_generation
+python -m agent run --agent strategy_evaluation
 ```
 
-> Agents consume inputs from the shared data store, so they can be run independently as long as upstream outputs are already present on disk.
+### Continuous mode (scheduled polling)
 
-### Scheduled / continuous operation
-
-The pipeline is designed for a minutes-level market data cadence and slower daily/weekly cadences for EIA and EDGAR. Use `cron` (Linux/macOS) or Task Scheduler (Windows) to automate runs.
-
-**Example cron entries:**
-
-```cron
-# Full pipeline every 5 minutes during trading hours (Mon–Fri, 09:00–17:00 ET)
-*/5 9-17 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent run >> logs/pipeline.log 2>&1
-
-# EIA and EDGAR refresh once daily at 06:00
-0 6 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent run --agent ingestion --feeds eia,edgar >> logs/slow_feeds.log 2>&1
-```
-
-### Running inside Docker (optional)
+Run the pipeline continuously, respecting the cadence variables defined in `.env`:
 
 ```bash
-docker build -t energy-options-agent .
+python -m agent run --continuous
+```
 
+In continuous mode the scheduler honours:
+- `MARKET_DATA_INTERVAL_MINUTES` for fast feeds (prices)
+- `OPTIONS_DATA_INTERVAL_HOURS` for options chains
+- `EIA_INTERVAL_HOURS` for supply/inventory data
+
+Stop with `Ctrl+C`; the pipeline completes its current cycle before exiting.
+
+### Running inside Docker (recommended for production)
+
+```bash
+# Build the image
+docker build -t energy-options-agent:latest .
+
+# Run one-shot with your .env file mounted
 docker run --rm \
   --env-file .env \
   -v "$(pwd)/data:/app/data" \
   -v "$(pwd)/output:/app/output" \
-  energy-options-agent python -m agent run
+  energy-options-agent:latest run
+
+# Run in continuous mode
+docker run -d \
+  --name energy-agent \
+  --env-file .env \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/output:/app/output" \
+  energy-options-agent:latest run --continuous
+```
+
+### Typical run sequence (what the pipeline does internally)
+
+```mermaid
+sequenceDiagram
+    participant CLI as CLI / Scheduler
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant Store as Market State / Feature Store
+    participant Out as JSON Output
+
+    CLI->>DIA: trigger run
+    DIA->>Store: fetch raw feeds; write normalised market state
+    DIA-->>CLI: ingestion complete
+
+    CLI->>EDA: trigger run
+    EDA->>Store: read market state; read news/geo feeds
+    EDA->>Store: write scored events (confidence + intensity)
+    EDA-->>CLI: event detection complete
+
+    CLI->>FGA: trigger run
+    FGA->>Store: read market state + scored events
+    FGA->>Store: write derived features\n(vol gap, curve steepness, dispersion,\ninsider score, narrative velocity,\nsupply shock probability)
+    FGA-->>CLI: feature generation complete
+
+    CLI->>SEA: trigger run
+    SEA->>Store: read derived features
+    SEA->>Out: write ranked candidate JSON\n(instrument, structure, expiration,\nedge_score, signals, generated_at)
+    SEA-->>CLI: strategy evaluation complete
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output file location
 
-After each pipeline run, ranked candidates are written to `OUTPUT_DIR` (default `./output`) as timestamped JSON files:
+Each pipeline run produces a timestamped JSON file in `OUTPUT_DIR`:
 
 ```
 output/
-└── candidates_20260315T143002Z.json
+└── candidates_2026-03-15T14:32:00Z.json
 ```
+
+A `latest.json` symlink always points to the most recent run.
 
 ### Output schema
 
-Each file contains a JSON array of candidate objects. Every candidate exposes the following fields:
+Each element in the output array is a **strategy candidate** with the following fields:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Options structure: `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative state |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | `integer` (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signal names to their qualitative levels |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
 ### Example output
 
@@ -335,62 +374,37 @@ Each file contains a JSON array of candidate objects. Every candidate exposes th
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:30:02Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
     "expiration": 21,
-    "edge_score": 0.38,
+    "edge_score": 0.31,
     "signals": {
-      "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "sector_dispersion": "widening"
+      "volatility_gap": "positive",
+      "eia_inventory_draw": "above_average"
     },
-    "generated_at": "2026-03-15T14:30:02Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
 ### Reading the edge score
 
-| Edge Score | Interpretation |
-|---|---|
-| `0.70 – 1.00` | Strong signal confluence; high-conviction candidate |
-| `0.50 – 0.69` | Moderate confluence; worth monitoring closely |
-| `0.30 – 0.49` | Weak but non-trivial signal; treat as low-priority |
-| `< 0.30` | Below threshold; filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
-
-### Understanding contributing signals
-
-The `signals` object explains *why* a candidate was ranked. Common signal keys and their meanings:
-
-| Signal Key | What it measures |
-|---|---|
-| `volatility_gap` | Realized vs. implied volatility divergence |
-| `futures_curve_steepness` | Contango or backwardation in the crude curve |
-| `sector_dispersion` | Spread between energy sub-sector returns |
-| `insider_conviction` | Aggregated insider buying/selling intensity (EDGAR) |
-| `narrative_velocity` | Acceleration of energy-related headlines or social mentions |
-| `supply_shock_probability` | Composite probability of a near-term supply disruption |
-| `tanker_disruption_index` | Shipping-flow anomalies at key chokepoints |
-
-### Visualising output in thinkorswim
-
-The JSON output is compatible with any JSON-capable dashboard. To load into thinkorswim:
-
-1. Point a **thinkScript** custom scan or watchlist import at the `OUTPUT_DIR` path (or a local HTTP server serving the JSON files).
-2. Map `instrument` to the symbol column and `edge_score` to a custom column for sorting.
-3. Use the `signals` map fields as annotation columns for context.
-
----
-
-## Troubleshooting
-
-### Common errors and fixes
-
-| Symptom | Likely Cause | Resolution |
+| `edge_score` range | Interpretation | Suggested action |
 |---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | Missing or unset environment variable | Confirm `.env` is populated and loaded; re-run `source .env` or verify your shell exports the variable |
-| `HTTPError 429 Too Many Requests` | API rate limit exceeded | Increase `MARKET_DATA_INTERVAL_MINUTES`; check free-tier rate limits for the affected source |
-|
+| `0.70 – 1.00` | Strong signal confluence | High-priority candidate; review all contributing signals |
+| `0.40 – 0.69` | Moderate confluence | Candidate warrants further analysis |
+| `0.20 – 0.39` | Weak / marginal signal | Low conviction; monitor only |
+| `< 0.20` | Below threshold | Suppressed by default (`MIN_EDGE_SCORE`) |
+
+> The `edge_score` is a composite heuristic, not a probability of profit. It reflects the degree to which multiple independent signals agree that a mispricing opportunity may exist.
+
+### Reading the signals map
+
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent:
+
+| Signal key | Description |
+|---|---|

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full four-agent pipeline from a clean environment to a ranked list of options trading opportunities.
+> **Version 1.0 • March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline from a clean environment to ranked options candidates.
 
 ---
 
@@ -18,115 +18,82 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**. It is advisory only — no trades are placed automatically.
+The **Energy Options Opportunity Agent** is a four-agent Python pipeline that surfaces volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**.
 
 ### Pipeline Architecture
 
-The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**. Data flows in one direction only.
-
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[EIA Supply Data]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nEDGAR / Quiver Quant]
-        A7[Shipping Data\nMarineTraffic / VesselFinder]
-        A8[Sentiment\nReddit / Stocktwits]
+    subgraph Agents
+        A["🛢️ Data Ingestion Agent\nFetch & Normalize"]
+        B["📡 Event Detection Agent\nSupply & Geo Signals"]
+        C["⚙️ Feature Generation Agent\nDerived Signal Computation"]
+        D["🏆 Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Pipeline
-        B[Data Ingestion Agent\nFetch & Normalize]
-        C[Event Detection Agent\nSupply & Geo Signals]
-        D[Feature Generation Agent\nDerived Signal Computation]
-        E[Strategy Evaluation Agent\nOpportunity Ranking]
-    end
+    RAW["Raw Feeds\n(prices, options chains,\nnews, EIA, EDGAR,\nshipping, sentiment)"]
+    MS["Shared Market\nState Object"]
+    FS["Derived\nFeatures Store"]
+    OUT["Ranked Candidates\n(JSON output)"]
 
-    subgraph Output
-        F[Ranked Candidates\nJSON / Dashboard]
-    end
-
-    A1 & A2 & A3 & A4 --> B
-    A5 --> C
-    A6 & A7 & A8 --> D
-    B --> C
-    C --> D
-    D --> E
-    E --> F
+    RAW --> A
+    A -->|normalised| MS
+    MS --> B
+    B -->|event scores| MS
+    MS --> C
+    C -->|derived signals| FS
+    FS --> D
+    D --> OUT
 ```
 
-### In-Scope Instruments
+Data flows **unidirectionally**: raw feeds → normalised market state → event scores → derived features → ranked strategy candidates. Each agent is independently deployable, so you can update or replace any stage without disrupting the rest of the pipeline.
+
+### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
 ### In-Scope Option Structures (MVP)
 
-| Structure | Enum Value |
-|---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
+`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
 
-> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
+> **Advisory only.** The system produces recommendations; it does **not** execute trades automatically.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### Runtime Requirements
 
-| Requirement | Minimum |
-|---|---|
-| Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 5 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| Requirement | Minimum version | Notes |
+|---|---|---|
+| Python | 3.10+ | Tested on 3.11 |
+| pip | 23+ | or use `pipenv` / `poetry` |
+| Git | 2.x | for cloning the repo |
+| Docker *(optional)* | 24+ | for containerised deployment |
 
-### Required Accounts & API Keys
+### External API Accounts
 
-Register for free-tier accounts at each provider before proceeding. All sources listed below have a free or free-limited tier sufficient for MVP operation.
+Obtain free-tier credentials for each service before configuring the pipeline. All sources listed below have free or limited free tiers.
 
-| Provider | Used By | Sign-up URL | Notes |
-|---|---|---|---|
-| Alpha Vantage or MetalpriceAPI | Data Ingestion | https://www.alphavantage.co / https://metalpriceapi.com | WTI & Brent spot/futures |
-| Polygon.io | Data Ingestion | https://polygon.io | Options chains; free tier is limited |
-| EIA Open Data | Data Ingestion | https://www.eia.gov/opendata | Inventory & refinery data |
-| NewsAPI | Event Detection | https://newsapi.org | Energy headlines |
-| GDELT | Event Detection | https://www.gdeltproject.org | Geopolitical events; no key required |
-| SEC EDGAR | Feature Generation | https://www.sec.gov/developer | Insider activity; no key required |
-| Quiver Quant | Feature Generation | https://www.quiverquant.com | Insider conviction; free tier available |
-| MarineTraffic or VesselFinder | Feature Generation | https://www.marinetraffic.com | Tanker flows; free tier |
-| Reddit (PRAW) | Feature Generation | https://www.reddit.com/prefs/apps | Narrative/sentiment velocity |
+| Service | Used for | Sign-up URL |
+|---|---|---|
+| Alpha Vantage | WTI / Brent spot & futures prices | <https://www.alphavantage.co/support/#api-key> |
+| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required (public) |
+| Polygon.io *(optional)* | Higher-quality options data | <https://polygon.io> |
+| EIA API | Inventory & refinery utilisation | <https://www.eia.gov/opendata/register.php> |
+| GDELT | News & geopolitical events | No key required (public) |
+| NewsAPI | News headlines | <https://newsapi.org/register> |
+| SEC EDGAR | Insider trade filings | No key required (public) |
+| Quiver Quant *(optional)* | Parsed insider conviction data | <https://www.quiverquant.com> |
+| MarineTraffic / VesselFinder | Tanker flow data | Free tier; register at respective sites |
+| Reddit API | Retail sentiment | <https://www.reddit.com/prefs/apps> |
+| Stocktwits | Narrative velocity | <https://api.stocktwits.com/developers/apps/new> |
 
-### Python Dependencies
-
-Install dependencies into a virtual environment:
-
-```bash
-python -m venv .venv
-source .venv/bin/activate        # Windows: .venv\Scripts\activate
-pip install --upgrade pip
-pip install -r requirements.txt
-```
-
-A minimal `requirements.txt` should include:
-
-```text
-yfinance>=0.2
-requests>=2.31
-pandas>=2.0
-numpy>=1.26
-praw>=7.7
-python-dotenv>=1.0
-```
+> **Tip:** Phase 1 (core market signals) only requires **Alpha Vantage** and **yfinance**. You can run a partial pipeline without the remaining keys by setting later-phase features to disabled (see [Setup & Configuration](#setup--configuration)).
 
 ---
 
@@ -139,100 +106,96 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create the Environment File
+### 2. Create a Virtual Environment
 
-The pipeline reads all secrets and tuneable parameters from environment variables. Copy the provided template and fill in your values:
+```bash
+python -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows PowerShell
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+### 4. Configure Environment Variables
+
+Copy the template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and populate each variable described in the table below.
+Open `.env` in your editor and set each variable. The full reference table is below.
 
-### Environment Variables Reference
-
-All variables are loaded at startup. Variables marked **Required** will cause the pipeline to exit immediately if absent. Variables marked **Optional** have defaults that are safe for MVP use.
-
-#### Data Ingestion Agent
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Required* | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Required* | — | API key for MetalpriceAPI crude feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chains |
-| `EIA_API_KEY` | Required | — | API key for EIA supply/inventory data |
-| `PRICE_REFRESH_INTERVAL_SEC` | Optional | `60` | Market price polling cadence in seconds |
-| `EIA_REFRESH_INTERVAL_SEC` | Optional | `86400` | EIA data polling cadence (default: daily) |
-| `HISTORICAL_RETENTION_DAYS` | Optional | `365` | Days of raw history to retain on disk |
+| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for WTI / Brent price feed |
+| `POLYGON_API_KEY` | ⬜ Optional | `""` | Polygon.io key for higher-fidelity options data |
+| `EIA_API_KEY` | ✅ Phase 2 | — | EIA Open Data key for inventory & refinery data |
+| `NEWSAPI_KEY` | ✅ Phase 2 | — | NewsAPI key for headline ingestion |
+| `GDELT_ENABLED` | ⬜ Optional | `true` | Set `false` to skip GDELT event ingestion |
+| `QUIVER_QUANT_API_KEY` | ⬜ Optional | `""` | Quiver Quant key for insider conviction scores |
+| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit API OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit API OAuth client secret |
+| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `STOCKTWITS_API_KEY` | ⬜ Optional | `""` | Stocktwits API key for narrative velocity |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ Optional | `""` | MarineTraffic free-tier key for tanker data |
+| `DATA_RETENTION_DAYS` | ⬜ Optional | `180` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ Optional | `5` | Polling cadence for minute-level market data feeds |
+| `OUTPUT_DIR` | ⬜ Optional | `./output` | Directory where JSON output files are written |
+| `LOG_LEVEL` | ⬜ Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_PHASE` | ⬜ Optional | `1` | Active phase (`1`–`3`); controls which agents & signals are enabled |
 
-> \* Provide at least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY`.
+#### Minimal `.env` for Phase 1
 
-#### Event Detection Agent
+```dotenv
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+PIPELINE_PHASE=1
+OUTPUT_DIR=./output
+LOG_LEVEL=INFO
+```
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `NEWS_API_KEY` | Required | — | API key for NewsAPI energy headlines |
-| `GDELT_ENABLED` | Optional | `true` | Enable GDELT geopolitical feed (no key needed) |
-| `EVENT_CONFIDENCE_THRESHOLD` | Optional | `0.5` | Minimum confidence score to surface an event |
-| `EVENT_INTENSITY_THRESHOLD` | Optional | `0.3` | Minimum intensity score to surface an event |
+#### Full `.env` for Phase 3
 
-#### Feature Generation Agent
+```dotenv
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+EIA_API_KEY=your_eia_key
+NEWSAPI_KEY=your_newsapi_key
+GDELT_ENABLED=true
+QUIVER_QUANT_API_KEY=your_quiver_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_secret
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_API_KEY=your_stocktwits_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+DATA_RETENTION_DAYS=365
+MARKET_DATA_INTERVAL_MINUTES=5
+OUTPUT_DIR=./output
+LOG_LEVEL=INFO
+PIPELINE_PHASE=3
+```
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `QUIVER_API_KEY` | Optional | — | API key for Quiver Quant insider conviction data |
-| `REDDIT_CLIENT_ID` | Optional | — | Reddit PRAW client ID for sentiment velocity |
-| `REDDIT_CLIENT_SECRET` | Optional | — | Reddit PRAW client secret |
-| `REDDIT_USER_AGENT` | Optional | `energy-agent/1.0` | Reddit PRAW user agent string |
-| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
-| `VESSEL_FINDER_API_KEY` | Optional | — | Alternative tanker data source key |
+### 5. Initialise the Data Store
 
-#### Strategy Evaluation Agent
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `MIN_EDGE_SCORE` | Optional | `0.30` | Minimum edge score for a candidate to appear in output |
-| `MAX_CANDIDATES` | Optional | `20` | Maximum number of ranked candidates to emit per run |
-| `DEFAULT_EXPIRATION_DAYS` | Optional | `30` | Default target expiration when not overridden by signal |
-
-#### Output & Storage
-
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `OUTPUT_DIR` | Optional | `./output` | Directory where JSON output files are written |
-| `DATA_STORE_DIR` | Optional | `./data` | Directory for historical raw and derived data |
-| `LOG_LEVEL` | Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-
-### 3. Verify Configuration
-
-Run the built-in config check before your first full run:
+Run the initialisation script to create the local SQLite database and required directory structure:
 
 ```bash
-python -m agent.cli check-config
+python -m agent.init_store
 ```
 
-Expected output when all required variables are present:
+Expected output:
 
 ```
-[OK] Data Ingestion Agent     — all required keys present
-[OK] Event Detection Agent    — all required keys present
-[OK] Feature Generation Agent — optional keys: QUIVER_API_KEY missing (non-fatal)
-[OK] Strategy Evaluation Agent
-[OK] Output directories       — ./output, ./data created
-Configuration check passed.
+[INFO] Creating data directory: ./data
+[INFO] Initialising historical store (retention: 180 days)
+[INFO] Store initialised successfully.
 ```
-
-Missing optional keys produce `[WARN]` lines and are non-fatal. Missing required keys produce `[FAIL]` and abort the check.
-
-### 4. Initialize the Data Store
-
-Create the on-disk historical store and run an initial backfill:
-
-```bash
-python -m agent.cli init-store --backfill-days 30
-```
-
-This fetches up to 30 days of historical price, options, and inventory data. Use `--backfill-days 365` to build a full year of history for backtesting purposes (takes longer and consumes more API quota).
 
 ---
 
@@ -243,179 +206,187 @@ This fetches up to 30 days of historical price, options, and inventory data. Use
 ```mermaid
 sequenceDiagram
     participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Data Store
-    participant Out as JSON Output
+    participant DI as Data Ingestion Agent
+    participant ED as Event Detection Agent
+    participant FG as Feature Generation Agent
+    participant SE as Strategy Evaluation Agent
+    participant FS as File System (JSON)
 
-    CLI->>DIA: run(instruments, refresh_interval)
-    DIA->>Store: write market_state object
-    DIA-->>EDA: market_state ready signal
+    CLI->>DI: run ingestion
+    DI-->>DI: fetch prices, ETFs, options chains
+    DI-->>CLI: market state object ready
 
-    EDA->>Store: read market_state
-    EDA->>EDA: score events (confidence, intensity)
-    EDA->>Store: write event_scores
-    EDA-->>FGA: events ready signal
+    CLI->>ED: run event detection
+    ED-->>ED: scan GDELT / NewsAPI / EIA
+    ED-->>CLI: event scores appended to market state
 
-    FGA->>Store: read market_state + event_scores
-    FGA->>FGA: compute derived signals
-    FGA->>Store: write features_store
-    FGA-->>SEA: features ready signal
+    CLI->>FG: run feature generation
+    FG-->>FG: compute vol gaps, curve steepness, dispersion, etc.
+    FG-->>CLI: derived features store updated
 
-    SEA->>Store: read features_store
-    SEA->>SEA: evaluate & rank candidates
-    SEA->>Out: write ranked_candidates.json
-    SEA-->>CLI: pipeline complete
+    CLI->>SE: run strategy evaluation
+    SE-->>SE: score & rank candidate structures
+    SE->>FS: write candidates_<timestamp>.json
+    SE-->>CLI: pipeline complete
 ```
 
-### Single Run (One-Shot)
-
-Execute the full four-agent pipeline once and write results to `./output`:
+### Running the Full Pipeline (Single Execution)
 
 ```bash
-python -m agent.cli run
+python -m agent.pipeline run
 ```
 
-To override the output directory for this run:
-
-```bash
-python -m agent.cli run --output-dir /tmp/eo-results
-```
-
-### Continuous Mode
-
-Run the pipeline on a repeating cadence driven by `PRICE_REFRESH_INTERVAL_SEC`:
-
-```bash
-python -m agent.cli run --continuous
-```
-
-Press `Ctrl+C` to stop gracefully. The pipeline will finish the current cycle before exiting.
+This executes all four agents in sequence and writes a timestamped JSON file to `OUTPUT_DIR`.
 
 ### Running Individual Agents
 
-Each agent can be executed in isolation for development or debugging:
+You can invoke any agent in isolation for development or debugging:
 
 ```bash
 # Data Ingestion only
-python -m agent.cli run --agent ingestion
+python -m agent.pipeline run --stage ingest
 
-# Event Detection only (reads existing market_state from store)
-python -m agent.cli run --agent event-detection
+# Event Detection only
+python -m agent.pipeline run --stage events
 
 # Feature Generation only
-python -m agent.cli run --agent feature-generation
+python -m agent.pipeline run --stage features
 
 # Strategy Evaluation only
-python -m agent.cli run --agent strategy-evaluation
+python -m agent.pipeline run --stage evaluate
 ```
 
-### Selecting MVP Phase
+### Scheduling Continuous Execution
 
-The pipeline respects the phased rollout defined in the system design. Use `--phase` to limit which data sources and signals are active:
+For production use, run the pipeline on a recurring schedule. The market data layer refreshes on a **minutes-level cadence**; slower feeds (EIA, EDGAR) update **daily or weekly**.
 
-| Flag | Phase | What Is Active |
-|---|---|---|
-| `--phase 1` | Core Market Signals | Crude benchmarks, USO/XLE prices, IV surface, long straddles & spreads |
-| `--phase 2` | Supply & Event Augmentation | Phase 1 + EIA data, GDELT/NewsAPI event detection, supply disruption index |
-| `--phase 3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider data, Reddit/Stocktwits sentiment, shipping data |
-| `--phase 4` | High-Fidelity Enhancements | Phase 3 + OPIS pricing, exotic structures (when implemented) |
-
-```bash
-# Run Phase 2 pipeline
-python -m agent.cli run --phase 2
-```
-
-The default is `--phase 3` (all currently implemented signals).
-
-### Scheduled Execution (cron example)
-
-To run the pipeline every 5 minutes via cron:
+#### Using cron (Linux / macOS)
 
 ```bash
 crontab -e
 ```
 
-Add the following line (adjust paths as needed):
+Add the following entries:
 
 ```cron
-*/5 * * * * /home/user/energy-options-agent/.venv/bin/python \
-    -m agent.cli run \
-    --output-dir /home/user/energy-options-agent/output \
-    >> /home/user/energy-options-agent/logs/pipeline.log 2>&1
+# Full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
+*/5 9-17 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run >> logs/pipeline.log 2>&1
+
+# EIA/EDGAR slow-feed refresh — daily at 06:00
+0 6 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run --stage ingest --feeds slow >> logs/slow_ingest.log 2>&1
 ```
+
+#### Using Docker
+
+```bash
+# Build the image
+docker build -t energy-options-agent:1.0 .
+
+# Run a single pipeline execution
+docker run --rm --env-file .env energy-options-agent:1.0
+
+# Run continuously with a 5-minute internal loop
+docker run -d --env-file .env \
+  -v "$(pwd)/output:/app/output" \
+  -v "$(pwd)/data:/app/data" \
+  energy-options-agent:1.0 --loop --interval 300
+```
+
+### Useful CLI Flags
+
+| Flag | Description |
+|---|---|
+| `--stage <name>` | Run a single agent stage: `ingest`, `events`, `features`, `evaluate` |
+| `--feeds slow` | Restrict ingestion to daily/weekly feeds (EIA, EDGAR) only |
+| `--dry-run` | Execute pipeline without writing output files |
+| `--loop` | Run continuously (Docker / daemon mode) |
+| `--interval <seconds>` | Polling interval when `--loop` is active (default: `300`) |
+| `--log-level DEBUG` | Override `LOG_LEVEL` for this run |
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output Location
 
-Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
+Each pipeline run writes a file to `OUTPUT_DIR` (default `./output`):
 
 ```
 output/
-└── ranked_candidates_20260315T142301Z.json
+└── candidates_2026-03-15T14:32:07Z.json
 ```
 
-A symlink `output/latest.json` always points to the most recent file.
+The latest run is also symlinked as `output/candidates_latest.json`.
 
 ### Output Schema
 
-Each element in the output array is a **strategy candidate**:
+Each file contains a JSON array of strategy candidates, one object per ranked opportunity.
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | enum string | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | integer (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | float `[0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signals and their assessed levels |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output File
+### Example Output
 
 ```json
-{
-  "generated_at": "2026-03-15T14:23:01Z",
-  "phase": 3,
-  "candidate_count": 4,
-  "candidates": [
-    {
-      "instrument": "USO",
-      "structure": "long_straddle",
-      "expiration": 30,
-      "edge_score": 0.72,
-      "signals": {
-        "tanker_disruption_index": "high",
-        "volatility_gap": "positive",
-        "narrative_velocity": "rising",
-        "supply_shock_probability": "elevated"
-      },
-      "generated_at": "2026-03-15T14:23:01Z"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
     },
-    {
-      "instrument": "XLE",
-      "structure": "call_spread",
-      "expiration": 21,
-      "edge_score": 0.51,
-      "signals": {
-        "volatility_gap": "positive",
-        "sector_dispersion": "high",
-        "insider_conviction": "bullish"
-      },
-      "generated_at": "2026-03-15T14:23:01Z"
+    "generated_at": "2026-03-15T14:32:07Z"
+  },
+  {
+    "instrument": "XOM",
+    "structure": "call_spread",
+    "expiration": 45,
+    "edge_score": 0.31,
+    "signals": {
+      "volatility_gap": "positive",
+      "insider_conviction": "elevated",
+      "futures_curve_steepness": "backwardated"
     },
-    {
-      "instrument": "CL=F",
-      "structure": "put_spread",
-      "expiration": 14,
-      "edge_score": 0.44,
-      "signals": {
-        "futures_curve_steepness": "contango_widening",
-        "eia_inventory_surprise": "bearish",
-        "narrative_velocity": "stable"
-      },
-      "generated_at": "2026
+    "generated_at": "2026-03-15T14:32:07Z"
+  }
+]
+```
+
+### Reading the Edge Score
+
+| `edge_score` range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
+| `0.40 – 0.69` | Moderate confluence — worth monitoring |
+| `0.20 – 0.39` | Weak signal — low conviction; use with caution |
+| `0.00 – 0.19` | Minimal signal — typically filtered from default output |
+
+> The edge score is a composite heuristic and **does not constitute financial advice**. Always apply independent judgement and risk management before acting on any candidate.
+
+### Signal Reference
+
+The `signals` object can contain any of the following keys, populated by the Feature Generation Agent:
+
+| Signal key | Source agent | What it measures |
+|---|---|---|
+| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Feature Generation | Contango / backwardation in the crude futures curve |
+| `sector_dispersion` | Feature Generation | Cross-sector correlation breakdown |
+| `insider_conviction` | Feature Generation | Weighted score of recent executive trades (EDGAR) |
+| `narrative_velocity` | Feature Generation | Headline acceleration from Reddit / Stocktwits / news |
+| `supply_shock_probability` | Feature Generation | Modelled probability of near-term supply disruption |
+| `tanker_disruption_index` | Event Detection | Shipping flow anomalies (MarineTraffic / VesselFinder) |
+| `refinery_utilization` | Event Detection | EIA refinery utilisation delta |
+| `geopolitical_intensity` | Event Detection | GDELT/NewsAPI event confidence × intensity score |
+
+### Consuming Output in thinkorsw

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline from a clean environment to ranked options candidates.
+> **Version 1.0 · March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline end-to-end. It assumes you are comfortable with Python, the command line, and environment variables, but have not worked with this project before.
 
 ---
 
@@ -18,375 +18,344 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a four-agent Python pipeline that surfaces volatility mispricing in oil-related instruments and ranks candidate options strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It is advisory only — no orders are placed automatically.
 
-### Pipeline Architecture
+### What the pipeline does
+
+The pipeline runs four loosely coupled agents in sequence, each writing results to a shared state that the next agent consumes:
 
 ```mermaid
 flowchart LR
-    subgraph Agents
-        A["🛢️ Data Ingestion Agent\nFetch & Normalize"]
-        B["📡 Event Detection Agent\nSupply & Geo Signals"]
-        C["⚙️ Feature Generation Agent\nDerived Signal Computation"]
-        D["🏆 Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Ingestion["① Data Ingestion Agent"]
+        A1[Crude prices\nWTI · Brent]
+        A2[ETF / Equity prices\nUSO · XLE · XOM · CVX]
+        A3[Options chains\nstrike · expiry · IV · volume]
     end
 
-    RAW["Raw Feeds\n(prices, options chains,\nnews, EIA, EDGAR,\nshipping, sentiment)"]
-    MS["Shared Market\nState Object"]
-    FS["Derived\nFeatures Store"]
-    OUT["Ranked Candidates\n(JSON output)"]
+    subgraph Events["② Event Detection Agent"]
+        B1[News & geo feeds\nGDELT · NewsAPI]
+        B2[Supply signals\nEIA · shipping]
+        B3[Confidence &\nintensity scoring]
+    end
 
-    RAW --> A
-    A -->|normalised| MS
-    MS --> B
-    B -->|event scores| MS
-    MS --> C
-    C -->|derived signals| FS
-    FS --> D
-    D --> OUT
+    subgraph Features["③ Feature Generation Agent"]
+        C1[Volatility gap\nrealised vs implied]
+        C2[Futures curve\nsteepness]
+        C3[Supply shock\nprobability]
+        C4[Narrative velocity\ninsider conviction]
+    end
+
+    subgraph Strategy["④ Strategy Evaluation Agent"]
+        D1[Evaluate eligible\nstructures]
+        D2[Compute edge score\n0.0 – 1.0]
+        D3[Rank &\nexplain candidates]
+    end
+
+    Ingestion -->|market state object| Events
+    Events    -->|scored events| Features
+    Features  -->|derived features store| Strategy
+    Strategy  -->|JSON output| E[(candidates.json)]
 ```
 
-Data flows **unidirectionally**: raw feeds → normalised market state → event scores → derived features → ranked strategy candidates. Each agent is independently deployable, so you can update or replace any stage without disrupting the rest of the pipeline.
+### In-scope instruments & option structures
 
-### In-Scope Instruments (MVP)
-
-| Category | Instruments |
+| Category | Items |
 |---|---|
 | Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
+| Option structures | Long straddles, call/put spreads, calendar spreads |
 
-### In-Scope Option Structures (MVP)
-
-`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
-
-> **Advisory only.** The system produces recommendations; it does **not** execute trades automatically.
+> **Out of scope for MVP:** exotic/multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### Runtime Requirements
+### System requirements
 
-| Requirement | Minimum version | Notes |
+| Requirement | Minimum |
+|---|---|
+| Python | 3.10 or later |
+| Operating system | Linux, macOS, or Windows (WSL recommended) |
+| Memory | 2 GB RAM |
+| Storage | 5 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS on port 443 |
+
+### Required accounts & API keys
+
+All data sources used in the MVP are free or have a free tier. Obtain credentials before running the pipeline.
+
+| Data source | What it provides | Sign-up URL |
 |---|---|---|
-| Python | 3.10+ | Tested on 3.11 |
-| pip | 23+ | or use `pipenv` / `poetry` |
-| Git | 2.x | for cloning the repo |
-| Docker *(optional)* | 24+ | for containerised deployment |
-
-### External API Accounts
-
-Obtain free-tier credentials for each service before configuring the pipeline. All sources listed below have free or limited free tiers.
-
-| Service | Used for | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | WTI / Brent spot & futures prices | <https://www.alphavantage.co/support/#api-key> |
-| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required (public) |
-| Polygon.io *(optional)* | Higher-quality options data | <https://polygon.io> |
-| EIA API | Inventory & refinery utilisation | <https://www.eia.gov/opendata/register.php> |
-| GDELT | News & geopolitical events | No key required (public) |
-| NewsAPI | News headlines | <https://newsapi.org/register> |
-| SEC EDGAR | Insider trade filings | No key required (public) |
-| Quiver Quant *(optional)* | Parsed insider conviction data | <https://www.quiverquant.com> |
-| MarineTraffic / VesselFinder | Tanker flow data | Free tier; register at respective sites |
-| Reddit API | Retail sentiment | <https://www.reddit.com/prefs/apps> |
-| Stocktwits | Narrative velocity | <https://api.stocktwits.com/developers/apps/new> |
-
-> **Tip:** Phase 1 (core market signals) only requires **Alpha Vantage** and **yfinance**. You can run a partial pipeline without the remaining keys by setting later-phase features to disabled (see [Setup & Configuration](#setup--configuration)).
+| Alpha Vantage | WTI / Brent spot & futures prices | https://www.alphavantage.co/support/#api-key |
+| Yahoo Finance (`yfinance`) | ETF, equity, and options chain data | *(no key required)* |
+| Polygon.io | Options chain supplement (free tier) | https://polygon.io/dashboard/signup |
+| EIA API | Weekly inventory & refinery utilisation | https://www.eia.gov/opendata/register.php |
+| GDELT | News & geopolitical event stream | *(no key required — HTTP download)* |
+| NewsAPI | Headline news feed | https://newsapi.org/register |
+| SEC EDGAR | Insider trading filings | *(no key required)* |
+| Quiver Quant | Structured insider data (free tier) | https://www.quiverquant.com/signup/ |
+| MarineTraffic | Tanker flow data (free tier) | https://www.marinetraffic.com/en/p/register |
+| Reddit API (`praw`) | Retail sentiment & narrative velocity | https://www.reddit.com/prefs/apps |
+| Stocktwits | Retail sentiment stream | https://api.stocktwits.com/developers/apps/new |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows PowerShell
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.\.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the template and fill in your credentials:
+Copy the provided template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set each variable. The full reference table is below.
+Open `.env` in your editor and supply values for every variable in the table below.
 
-#### Environment Variable Reference
+#### Environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for WTI / Brent price feed |
-| `POLYGON_API_KEY` | ⬜ Optional | `""` | Polygon.io key for higher-fidelity options data |
-| `EIA_API_KEY` | ✅ Phase 2 | — | EIA Open Data key for inventory & refinery data |
-| `NEWSAPI_KEY` | ✅ Phase 2 | — | NewsAPI key for headline ingestion |
-| `GDELT_ENABLED` | ⬜ Optional | `true` | Set `false` to skip GDELT event ingestion |
-| `QUIVER_QUANT_API_KEY` | ⬜ Optional | `""` | Quiver Quant key for insider conviction scores |
-| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit API OAuth client ID |
-| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit API OAuth client secret |
-| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `STOCKTWITS_API_KEY` | ⬜ Optional | `""` | Stocktwits API key for narrative velocity |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ Optional | `""` | MarineTraffic free-tier key for tanker data |
-| `DATA_RETENTION_DAYS` | ⬜ Optional | `180` | Days of historical data to retain (180–365 recommended) |
-| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ Optional | `5` | Polling cadence for minute-level market data feeds |
-| `OUTPUT_DIR` | ⬜ Optional | `./output` | Directory where JSON output files are written |
-| `LOG_LEVEL` | ⬜ Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_PHASE` | ⬜ Optional | `1` | Active phase (`1`–`3`); controls which agents & signals are enabled |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for WTI / Brent crude price feeds |
+| `POLYGON_API_KEY` | ✅ | — | Polygon.io key for supplemental options chain data |
+| `EIA_API_KEY` | ✅ | — | EIA Open Data key for inventory & refinery utilisation |
+| `NEWS_API_KEY` | ✅ | — | NewsAPI key for headline energy news |
+| `QUIVER_QUANT_API_KEY` | ⬜ | — | Quiver Quant key for structured insider activity (Phase 3) |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | MarineTraffic key for tanker flow data (Phase 3) |
+| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit OAuth client ID for PRAW (Phase 3) |
+| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit OAuth client secret for PRAW (Phase 3) |
+| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | User-agent string sent with Reddit requests |
+| `STOCKTWITS_ACCESS_TOKEN` | ⬜ | — | Stocktwits bearer token for sentiment feed (Phase 3) |
+| `DATA_DIR` | ✅ | `./data` | Root directory for raw and derived data storage |
+| `OUTPUT_DIR` | ✅ | `./output` | Directory where ranked candidates JSON is written |
+| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `HISTORY_DAYS` | ⬜ | `365` | Days of historical data to retain (recommended: 180–365) |
+| `PRICE_REFRESH_MINUTES` | ⬜ | `5` | Cadence (minutes) for market data refresh during a run |
+| `SLOW_FEED_SCHEDULE` | ⬜ | `daily` | Refresh schedule for EIA / EDGAR feeds (`daily` or `weekly`) |
+| `PIPELINE_PHASE` | ⬜ | `1` | MVP phase to activate (`1`, `2`, or `3`); controls which agents and signals are enabled |
+
+> **Required (✅)** variables must be set before any agent will run. Optional (⬜) variables unlock Phase 2 / Phase 3 signals; the pipeline runs in a reduced-signal mode without them.
 
 #### Minimal `.env` for Phase 1
 
 ```dotenv
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-PIPELINE_PHASE=1
-OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-```
-
-#### Full `.env` for Phase 3
-
-```dotenv
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+POLYGON_API_KEY=your_polygon_key
 EIA_API_KEY=your_eia_key
-NEWSAPI_KEY=your_newsapi_key
-GDELT_ENABLED=true
-QUIVER_QUANT_API_KEY=your_quiver_key
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_secret
-REDDIT_USER_AGENT=energy-agent/1.0
-STOCKTWITS_API_KEY=your_stocktwits_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-DATA_RETENTION_DAYS=365
-MARKET_DATA_INTERVAL_MINUTES=5
+NEWS_API_KEY=your_newsapi_key
+
+DATA_DIR=./data
 OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-PIPELINE_PHASE=3
+PIPELINE_PHASE=1
 ```
 
-### 5. Initialise the Data Store
-
-Run the initialisation script to create the local SQLite database and required directory structure:
+### 5. Initialise the data directory
 
 ```bash
-python -m agent.init_store
+python -m agent.cli init
 ```
 
-Expected output:
-
-```
-[INFO] Creating data directory: ./data
-[INFO] Initialising historical store (retention: 180 days)
-[INFO] Store initialised successfully.
-```
+This creates the `DATA_DIR` and `OUTPUT_DIR` folder structure and writes a `config.json` derived from your `.env`.
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Execution Flow
+### Pipeline execution modes
+
+| Mode | Command | When to use |
+|---|---|---|
+| Full pipeline (all agents, once) | `python -m agent.cli run` | On-demand analysis |
+| Single agent | `python -m agent.cli run --agent <name>` | Debug or incremental re-run |
+| Continuous / scheduled | `python -m agent.cli run --loop` | Live monitoring |
+| Dry run (no output written) | `python -m agent.cli run --dry-run` | Validate config without side effects |
+
+### Run the full pipeline once
+
+```bash
+python -m agent.cli run
+```
+
+Expected console output:
+
+```
+[2026-03-15 09:00:01 UTC] INFO  pipeline      Starting full pipeline run (phase=1)
+[2026-03-15 09:00:02 UTC] INFO  ingestion     Fetching WTI spot price ... OK (104.32)
+[2026-03-15 09:00:03 UTC] INFO  ingestion     Fetching Brent spot price ... OK (107.81)
+[2026-03-15 09:00:05 UTC] INFO  ingestion     Fetching options chain: USO ... OK (312 contracts)
+[2026-03-15 09:00:08 UTC] INFO  events        Scanning GDELT feed ... 4 energy events detected
+[2026-03-15 09:00:09 UTC] INFO  events        Scanning NewsAPI feed ... 2 supply disruption events
+[2026-03-15 09:00:10 UTC] INFO  features      Computing volatility gap (USO) ... +0.083
+[2026-03-15 09:00:11 UTC] INFO  features      Computing futures curve steepness (WTI) ... contango +1.4%
+[2026-03-15 09:00:13 UTC] INFO  strategy      Evaluating long_straddle on USO (30d) ... edge_score=0.47
+[2026-03-15 09:00:14 UTC] INFO  strategy      Evaluating call_spread on XLE (45d) ... edge_score=0.31
+[2026-03-15 09:00:15 UTC] INFO  pipeline      Run complete. 5 candidates written to ./output/candidates.json
+```
+
+### Run a single agent
+
+Useful when you want to re-run only one stage — for example, after receiving an EIA data update — without re-fetching market prices.
+
+```bash
+# Agent names: ingestion | events | features | strategy
+python -m agent.cli run --agent strategy
+```
+
+### Run continuously with automatic refresh
+
+```bash
+python -m agent.cli run --loop --interval 300   # refresh every 5 minutes
+```
+
+Press `Ctrl+C` to stop. The pipeline tolerates delayed or missing upstream data; individual feed failures are logged as warnings and the run continues with the most recent cached data.
+
+### Activate Phase 2 or Phase 3 signals
+
+Set `PIPELINE_PHASE` in your `.env` (or pass it inline) to unlock additional signal layers:
+
+```bash
+# Phase 2: adds EIA supply signals and GDELT/NewsAPI event-driven edge scoring
+PIPELINE_PHASE=2 python -m agent.cli run
+
+# Phase 3: additionally adds insider conviction, narrative velocity, and shipping data
+PIPELINE_PHASE=3 python -m agent.cli run
+```
+
+> Phase 4 features (OPIS pricing, exotic structures, automated execution) are not yet implemented and are reserved for future releases.
+
+### Agent data-flow sequence
 
 ```mermaid
 sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DI as Data Ingestion Agent
-    participant ED as Event Detection Agent
-    participant FG as Feature Generation Agent
-    participant SE as Strategy Evaluation Agent
-    participant FS as File System (JSON)
+    participant CLI as CLI (agent.cli run)
+    participant IA  as Data Ingestion Agent
+    participant EA  as Event Detection Agent
+    participant FA  as Feature Generation Agent
+    participant SA  as Strategy Evaluation Agent
+    participant FS  as Filesystem (data/ & output/)
 
-    CLI->>DI: run ingestion
-    DI-->>DI: fetch prices, ETFs, options chains
-    DI-->>CLI: market state object ready
+    CLI->>IA: start_ingestion(config)
+    IA-->>FS: write market_state.json
+    IA-->>CLI: ingestion complete
 
-    CLI->>ED: run event detection
-    ED-->>ED: scan GDELT / NewsAPI / EIA
-    ED-->>CLI: event scores appended to market state
+    CLI->>EA: start_event_detection(market_state)
+    EA-->>FS: write scored_events.json
+    EA-->>CLI: event detection complete
 
-    CLI->>FG: run feature generation
-    FG-->>FG: compute vol gaps, curve steepness, dispersion, etc.
-    FG-->>CLI: derived features store updated
+    CLI->>FA: start_feature_generation(market_state, scored_events)
+    FA-->>FS: write derived_features.json
+    FA-->>CLI: feature generation complete
 
-    CLI->>SE: run strategy evaluation
-    SE-->>SE: score & rank candidate structures
-    SE->>FS: write candidates_<timestamp>.json
-    SE-->>CLI: pipeline complete
+    CLI->>SA: start_strategy_evaluation(derived_features)
+    SA-->>FS: write candidates.json
+    SA-->>CLI: strategy evaluation complete
+
+    CLI-->>CLI: print summary & exit
 ```
-
-### Running the Full Pipeline (Single Execution)
-
-```bash
-python -m agent.pipeline run
-```
-
-This executes all four agents in sequence and writes a timestamped JSON file to `OUTPUT_DIR`.
-
-### Running Individual Agents
-
-You can invoke any agent in isolation for development or debugging:
-
-```bash
-# Data Ingestion only
-python -m agent.pipeline run --stage ingest
-
-# Event Detection only
-python -m agent.pipeline run --stage events
-
-# Feature Generation only
-python -m agent.pipeline run --stage features
-
-# Strategy Evaluation only
-python -m agent.pipeline run --stage evaluate
-```
-
-### Scheduling Continuous Execution
-
-For production use, run the pipeline on a recurring schedule. The market data layer refreshes on a **minutes-level cadence**; slower feeds (EIA, EDGAR) update **daily or weekly**.
-
-#### Using cron (Linux / macOS)
-
-```bash
-crontab -e
-```
-
-Add the following entries:
-
-```cron
-# Full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
-*/5 9-17 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run >> logs/pipeline.log 2>&1
-
-# EIA/EDGAR slow-feed refresh — daily at 06:00
-0 6 * * 1-5 cd /path/to/energy-options-agent && .venv/bin/python -m agent.pipeline run --stage ingest --feeds slow >> logs/slow_ingest.log 2>&1
-```
-
-#### Using Docker
-
-```bash
-# Build the image
-docker build -t energy-options-agent:1.0 .
-
-# Run a single pipeline execution
-docker run --rm --env-file .env energy-options-agent:1.0
-
-# Run continuously with a 5-minute internal loop
-docker run -d --env-file .env \
-  -v "$(pwd)/output:/app/output" \
-  -v "$(pwd)/data:/app/data" \
-  energy-options-agent:1.0 --loop --interval 300
-```
-
-### Useful CLI Flags
-
-| Flag | Description |
-|---|---|
-| `--stage <name>` | Run a single agent stage: `ingest`, `events`, `features`, `evaluate` |
-| `--feeds slow` | Restrict ingestion to daily/weekly feeds (EIA, EDGAR) only |
-| `--dry-run` | Execute pipeline without writing output files |
-| `--loop` | Run continuously (Docker / daemon mode) |
-| `--interval <seconds>` | Polling interval when `--loop` is active (default: `300`) |
-| `--log-level DEBUG` | Override `LOG_LEVEL` for this run |
 
 ---
 
 ## Interpreting the Output
 
-### Output Location
-
-Each pipeline run writes a file to `OUTPUT_DIR` (default `./output`):
+### Output file location
 
 ```
 output/
-└── candidates_2026-03-15T14:32:07Z.json
+└── candidates.json          ← ranked list of strategy candidates (latest run)
+└── candidates_<timestamp>.json   ← timestamped archive of each run
 ```
 
-The latest run is also symlinked as `output/candidates_latest.json`.
+### Output schema
 
-### Output Schema
-
-Each file contains a JSON array of strategy candidates, one object per ranked opportunity.
+Each element in the `candidates` array conforms to the following schema:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
+| `instrument` | `string` | Target instrument — e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | Options structure: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
 | `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current values |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output
+### Example output
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
+{
+  "run_id": "2026-03-15T09:00:15Z",
+  "phase": 1,
+  "candidates": [
+    {
+      "instrument": "USO",
+      "structure": "long_straddle",
+      "expiration": 30,
+      "edge_score": 0.47,
+      "signals": {
+        "tanker_disruption_index": "high",
+        "volatility_gap": "positive",
+        "narrative_velocity": "rising"
+      },
+      "generated_at": "2026-03-15T09:00:13Z"
     },
-    "generated_at": "2026-03-15T14:32:07Z"
-  },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive",
-      "insider_conviction": "elevated",
-      "futures_curve_steepness": "backwardated"
-    },
-    "generated_at": "2026-03-15T14:32:07Z"
-  }
-]
+    {
+      "instrument": "XLE",
+      "structure": "call_spread",
+      "expiration": 45,
+      "edge_score": 0.31,
+      "signals": {
+        "volatility_gap": "positive",
+        "futures_curve_steepness": "contango"
+      },
+      "generated_at": "2026-03-15T09:00:14Z"
+    }
+  ]
+}
 ```
 
-### Reading the Edge Score
+### Reading the edge score
 
-| `edge_score` range | Interpretation |
-|---|---|
-| `0.70 – 1.00` | Strong signal confluence — high-priority candidate |
-| `0.40 – 0.69` | Moderate confluence — worth monitoring |
-| `0.20 – 0.39` | Weak signal — low conviction; use with caution |
-| `0.00 – 0.19` | Minimal signal — typically filtered from default output |
-
-> The edge score is a composite heuristic and **does not constitute financial advice**. Always apply independent judgement and risk management before acting on any candidate.
-
-### Signal Reference
-
-The `signals` object can contain any of the following keys, populated by the Feature Generation Agent:
-
-| Signal key | Source agent | What it measures |
+| Edge score range | Interpretation | Suggested action |
 |---|---|---|
-| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence |
-| `futures_curve_steepness` | Feature Generation | Contango / backwardation in the crude futures curve |
-| `sector_dispersion` | Feature Generation | Cross-sector correlation breakdown |
-| `insider_conviction` | Feature Generation | Weighted score of recent executive trades (EDGAR) |
-| `narrative_velocity` | Feature Generation | Headline acceleration from Reddit / Stocktwits / news |
-| `supply_shock_probability` | Feature Generation | Modelled probability of near-term supply disruption |
-| `tanker_disruption_index` | Event Detection | Shipping flow anomalies (MarineTraffic / VesselFinder) |
-| `refinery_utilization` | Event Detection | EIA refinery utilisation delta |
-| `geopolitical_intensity` | Event Detection | GDELT/NewsAPI event confidence × intensity score |
+| `0.70 – 1.00` | Strong signal confluence | High-priority review; examine all contributing signals |
+| `0.45 – 0.69` | Moderate confluence | Worth investigating alongside your own analysis |
+| `0.20 – 0.44` | Weak / noisy signal | Low confidence; treat as background information |
+| `0.00 – 0.19` | Negligible edge | Typically noise; not actionable on its own |
 
-### Consuming Output in thinkorsw
+> The edge score reflects signal confluence only. It is **not** a probability of profit and does **not** account for bid/ask spreads, liquidity, or position sizing. The system is **advisory only** — no trades are placed automatically.
+
+### Reading the signals map
+
+Each key in the `signals` object corresponds to a derived feature. Common keys and their meanings:
+
+| Signal key | Possible values | What it means |
+|---|---|---|
+| `volatility_gap` | `positive`, `negative`, `neutral` | Realised vol is above (`positive`) or below implied vol |
+| `futures_curve_steepness` | `contango`, `backwardation

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> Advisory only. The system produces ranked strategy candidates; it does **not** execute trades.
+> **Version 1.0 · March 2026**
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
 
 ---
 
@@ -18,394 +18,405 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a four-stage Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
 
-### Pipeline at a Glance
+### What the pipeline does
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Crude Prices\nWTI · Brent]
-        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
-        A3[Options Chains\nStrike · IV · Volume]
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping & Logistics\nMarineTraffic / VesselFinder]
+        A8[Narrative & Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[News & Geo Feeds\nGDELT · NewsAPI]
-        B2[Supply / Inventory\nEIA API]
-        B3[Shipping Signals\nMarineTraffic]
-        B4[Confidence &\nIntensity Scoring]
+    subgraph Pipeline
+        direction TB
+        B1["① Data Ingestion Agent\nFetch & Normalize"]
+        B2["② Event Detection Agent\nSupply & Geo Signals"]
+        B3["③ Feature Generation Agent\nDerived Signal Computation"]
+        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs Implied]
-        C2[Futures Curve\nSteepness]
-        C3[Sector Dispersion]
-        C4[Insider Conviction]
-        C5[Narrative Velocity]
-        C6[Supply Shock\nProbability]
+    subgraph Output
+        C1[Ranked Candidates\nJSON / Dashboard]
     end
 
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Eligible Structures\nStraddle · Spreads]
-        D2[Edge Score\nComputation]
-        D3[Ranked Candidates\nJSON Output]
-    end
-
-    MarketState[(Shared\nMarket State)]
-    FeaturesStore[(Derived\nFeatures Store)]
-
-    Ingestion --> MarketState
-    Events --> MarketState
-    MarketState --> Features
-    Features --> FeaturesStore
-    FeaturesStore --> Strategy
-    Strategy --> D3
+    Inputs --> B1
+    B1 -->|Unified Market State| B2
+    B2 -->|Scored Events| B3
+    B3 -->|Derived Features| B4
+    B4 --> C1
 ```
 
-### In-Scope Instruments & Structures (MVP)
+### In-scope instruments
 
-| Category | Items |
+| Category | Instruments |
 |---|---|
-| **Crude Futures** | Brent Crude, WTI |
-| **ETFs** | USO, XLE |
-| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option Structures** | Long straddles, call / put spreads, calendar spreads |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-Automated execution, exotic multi-legged strategies, and regional refined product pricing (OPIS) are **out of scope** for the current release.
+### In-scope option structures (MVP)
+
+| Structure | Enum value |
+|---|---|
+| Long straddle | `long_straddle` |
+| Call spread | `call_spread` |
+| Put spread | `put_spread` |
+| Calendar spread | `calendar_spread` |
+
+> **Advisory only.** Automated trade execution is explicitly out of scope. All output is for informational and analytical purposes.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| **Python** | 3.10+ |
-| **Operating System** | Linux, macOS, or Windows (WSL recommended) |
-| **RAM** | 2 GB |
-| **Disk** | 5 GB (12-month data retention target) |
-| **Network** | Outbound HTTPS to public APIs |
+| Python | 3.10+ |
+| RAM | 2 GB |
+| Disk | 10 GB (for 6–12 months of historical data) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Deployment target | Local machine, single VM, or container |
 
-### Required Tools
+### Required Python packages
+
+Install dependencies from the project root:
 
 ```bash
-# Verify Python version
-python --version   # must be >= 3.10
-
-# Verify pip
-pip --version
-
-# Optional but recommended: virtual environment tooling
-python -m venv --help
+pip install -r requirements.txt
 ```
 
-### External API Accounts
+Key dependencies include:
 
-Register for free-tier access at each provider before configuring the pipeline:
+```text
+yfinance
+requests
+pandas
+numpy
+python-dotenv
+schedule
+```
 
-| Data Layer | Provider | Free Tier? | Sign-up URL |
+### External API accounts
+
+Obtain free-tier credentials for each data source before configuring the pipeline.
+
+| Service | URL | Cost | Used for |
 |---|---|---|---|
-| Crude Prices | Alpha Vantage | ✅ Free | https://www.alphavantage.co/support/#api-key |
-| ETF / Equity Prices | yfinance (Yahoo Finance) | ✅ Free | No registration required |
-| Options Data | Polygon.io | ✅ Free / Limited | https://polygon.io/dashboard/signup |
-| Supply & Inventory | EIA API | ✅ Free | https://www.eia.gov/opendata/register.php |
-| News & Geo Events | NewsAPI | ✅ Free | https://newsapi.org/register |
-| News & Geo Events | GDELT | ✅ Free | No registration required |
-| Insider Activity | SEC EDGAR | ✅ Free | No registration required |
-| Insider Activity | Quiver Quant | ⚠️ Free / Limited | https://www.quiverquant.com/signup |
-| Shipping / Logistics | MarineTraffic | ✅ Free tier | https://www.marinetraffic.com/en/register |
-| Narrative / Sentiment | Reddit API | ✅ Free | https://www.reddit.com/wiki/api |
+| Alpha Vantage | https://www.alphavantage.co | Free | WTI / Brent spot and futures |
+| EIA API | https://www.eia.gov/opendata | Free | Inventory and refinery utilization |
+| NewsAPI | https://newsapi.org | Free tier | News and geopolitical events |
+| GDELT | https://www.gdeltproject.org | Free | Geopolitical event stream |
+| Polygon.io | https://polygon.io | Free/Limited | Options chains |
+| SEC EDGAR | https://www.sec.gov/developer | Free | Insider filing data |
+| Quiver Quant | https://www.quiverquant.com | Free/Limited | Parsed insider trades |
+| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flow data |
+
+> **Tip:** `yfinance` (Yahoo Finance) requires no API key and is used as the primary fallback for equity, ETF, and options chain data.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create a virtual environment
 
 ```bash
 python -m venv .venv
-
-# Linux / macOS
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.\.venv\Scripts\Activate.ps1
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
-pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Create the environment file
 
-Copy the provided template and populate your API keys:
+Copy the provided template and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in each value. The full set of recognised variables is documented in the table below.
+Then open `.env` in your editor and fill in each value:
 
-#### Environment Variable Reference
+```dotenv
+# .env — Energy Options Opportunity Agent
+
+# ── Data Ingestion ────────────────────────────────────────────
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+EIA_API_KEY=your_eia_key
+POLYGON_API_KEY=your_polygon_key
+
+# ── Event Detection ───────────────────────────────────────────
+NEWS_API_KEY=your_newsapi_key
+
+# ── Alternative / Contextual Signals ─────────────────────────
+QUIVER_QUANT_API_KEY=your_quiver_quant_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+
+# ── Output ────────────────────────────────────────────────────
+OUTPUT_DIR=./output
+OUTPUT_FORMAT=json
+
+# ── Scheduling ────────────────────────────────────────────────
+MARKET_DATA_INTERVAL_MINUTES=5
+SLOW_FEED_INTERVAL_HOURS=24
+
+# ── Data Retention ───────────────────────────────────────────
+RETENTION_DAYS=365
+```
+
+### Environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for crude price feeds (WTI, Brent spot/futures) |
-| `POLYGON_API_KEY` | ✅ | — | API key for options chain data (strike, expiry, IV, volume) |
-| `EIA_API_KEY` | ✅ | — | API key for EIA inventory and refinery utilisation data |
-| `NEWSAPI_KEY` | ✅ | — | API key for energy news and geopolitical event headlines |
-| `REDDIT_CLIENT_ID` | ⚠️ Phase 3 | — | Reddit OAuth client ID for sentiment / narrative velocity |
-| `REDDIT_CLIENT_SECRET` | ⚠️ Phase 3 | — | Reddit OAuth client secret |
-| `REDDIT_USER_AGENT` | ⚠️ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `QUIVER_API_KEY` | ⚠️ Phase 3 | — | Quiver Quant key for insider conviction scores |
-| `MARINETRAFFIC_API_KEY` | ⚠️ Phase 3 | — | MarineTraffic key for tanker flow signals |
-| `DATA_DIR` | ❌ | `./data` | Root directory for persisted raw and derived data |
-| `OUTPUT_DIR` | ❌ | `./output` | Directory where ranked candidate JSON files are written |
-| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Polling cadence for minute-level market data feeds |
-| `HISTORY_RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain for backtesting |
-| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum edge score for a candidate to appear in output |
-| `MAX_CANDIDATES` | ❌ | `20` | Maximum number of ranked candidates written per run |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for WTI and Brent crude prices |
+| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery data |
+| `POLYGON_API_KEY` | No | — | API key for options chain data (falls back to yfinance) |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical and energy news |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for parsed SEC insider trade data |
+| `MARINE_TRAFFIC_API_KEY` | No | — | API key for tanker flow and shipping data |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
+| `OUTPUT_FORMAT` | No | `json` | Output format; currently `json` is supported |
+| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for market data (prices, options) |
+| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Polling cadence for slow feeds (EIA, EDGAR) |
+| `RETENTION_DAYS` | No | `365` | Number of days of historical data to retain on disk |
 
-> **Tip — Variables marked ⚠️ Phase 3** are only needed once you enable Phase 3 alternative signals. The pipeline runs without them in Phases 1 and 2.
+> **Optional keys:** If `POLYGON_API_KEY`, `QUIVER_QUANT_API_KEY`, or `MARINE_TRAFFIC_API_KEY` are absent, the pipeline will fall back to available free sources or skip those signals gracefully. The pipeline will not fail due to a missing optional key.
 
-#### Example `.env`
+### 5. Verify the setup
 
-```dotenv
-# === Core API Keys ===
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=your_polygon_key_here
-EIA_API_KEY=your_eia_key_here
-NEWSAPI_KEY=your_newsapi_key_here
-
-# === Phase 3 (Alternative Signals) ===
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=energy-agent/1.0
-QUIVER_API_KEY=your_quiver_key_here
-MARINETRAFFIC_API_KEY=your_marinetraffic_key_here
-
-# === Storage & Output ===
-DATA_DIR=./data
-OUTPUT_DIR=./output
-HISTORY_RETENTION_DAYS=365
-
-# === Pipeline Behaviour ===
-LOG_LEVEL=INFO
-MARKET_DATA_INTERVAL_MINUTES=5
-EDGE_SCORE_THRESHOLD=0.30
-MAX_CANDIDATES=20
-```
-
-### 5. Initialise Storage
-
-Create the local data and output directories and seed the historical data store:
+Run the built-in configuration check before starting the pipeline:
 
 ```bash
-python -m agent init
+python -m agent check-config
 ```
 
 Expected output:
 
 ```
-[INFO] Creating data directory at ./data
-[INFO] Creating output directory at ./output
-[INFO] Storage initialised successfully.
+[OK] Alpha Vantage         reachable
+[OK] EIA API               reachable
+[OK] NewsAPI               reachable
+[OK] yfinance              available (no key required)
+[WARN] Polygon.io          key not set — falling back to yfinance for options
+[WARN] MarineTraffic       key not set — shipping signals disabled
+[OK] Output directory      ./output exists
+Configuration check complete. 2 warning(s), 0 error(s).
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Phases
+### Pipeline execution sequence
 
-The system ships with four progressive phases. Activate only the phases for which you have configured the required data sources.
+```mermaid
+sequenceDiagram
+    participant CLI as CLI / Scheduler
+    participant DI as ① Data Ingestion Agent
+    participant ED as ② Event Detection Agent
+    participant FG as ③ Feature Generation Agent
+    participant SE as ④ Strategy Evaluation Agent
+    participant FS as Filesystem / Output
 
-| Phase | Name | Key Data Sources Added |
-|---|---|---|
-| **1** | Core Market Signals & Options | Alpha Vantage, yfinance, Polygon.io |
-| **2** | Supply & Event Augmentation | EIA API, GDELT, NewsAPI |
-| **3** | Alternative / Contextual Signals | EDGAR, Quiver, MarineTraffic, Reddit |
-| **4** | High-Fidelity Enhancements | OPIS (paid), exotic structures, execution API |
+    CLI->>DI: trigger run
+    DI->>DI: fetch crude prices, ETF/equity, options chains
+    DI->>DI: normalize → unified market state object
+    DI->>ED: market state
+    ED->>ED: scan news, GDELT, shipping feeds
+    ED->>ED: score events (confidence + intensity)
+    ED->>FG: market state + scored events
+    FG->>FG: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock probability
+    FG->>SE: derived features store
+    SE->>SE: evaluate eligible option structures\nagainst computed signals
+    SE->>SE: generate edge scores, attach signal references
+    SE->>FS: write ranked candidates (JSON)
+    FS-->>CLI: run complete — candidates available in ./output
+```
 
-### Single Run (Ad-hoc)
+### Run once (manual)
 
-Execute a full pipeline pass and write results to `OUTPUT_DIR`:
+Execute a single end-to-end pipeline run:
 
 ```bash
 python -m agent run
 ```
 
-To restrict to a specific phase:
+This triggers all four agents in sequence and writes the output to `OUTPUT_DIR`.
+
+### Run on a schedule (continuous mode)
+
+Start the pipeline in continuous mode. Market data is polled at the cadence set by `MARKET_DATA_INTERVAL_MINUTES`; slow feeds (EIA, EDGAR) refresh at `SLOW_FEED_INTERVAL_HOURS`:
 
 ```bash
-# Phase 1 only (market data + options surface)
-python -m agent run --phase 1
-
-# Phases 1 and 2 (adds supply & event signals)
-python -m agent run --phase 2
+python -m agent run --continuous
 ```
 
-To override the edge score threshold for a single run:
+### Run a specific agent only
+
+Each agent can be executed independently, which is useful during development or when debugging a single stage:
 
 ```bash
-python -m agent run --edge-threshold 0.25
+# Run only the Data Ingestion Agent
+python -m agent run --agent ingestion
+
+# Run only the Event Detection Agent
+python -m agent run --agent events
+
+# Run only the Feature Generation Agent
+python -m agent run --agent features
+
+# Run only the Strategy Evaluation Agent
+python -m agent run --agent strategy
 ```
 
-### Scheduled / Continuous Mode
+> **Dependency note:** Running `features` or `strategy` in isolation requires a valid market state object and event scores to already exist in the derived features store from a prior run of the upstream agents.
 
-Run the pipeline on its configured polling cadence (default: every 5 minutes for market data; daily for EIA/EDGAR):
+### Run with Docker
+
+A `Dockerfile` and `docker-compose.yml` are provided for containerized deployment on a single VM:
 
 ```bash
-python -m agent start
+# Build the image
+docker build -t energy-options-agent .
+
+# Run once
+docker run --env-file .env -v $(pwd)/output:/app/output energy-options-agent
+
+# Run continuously via docker-compose
+docker-compose up -d
 ```
 
-Stop the scheduler gracefully:
+### CLI reference
 
-```bash
-python -m agent stop
-```
-
-### Dry Run (No Output Written)
-
-Validate configuration and data source connectivity without persisting any results:
-
-```bash
-python -m agent run --dry-run
-```
-
-### Individual Agent Execution
-
-Each agent can be invoked independently for development or debugging:
-
-```bash
-# Data Ingestion Agent only
-python -m agent.ingestion
-
-# Event Detection Agent only
-python -m agent.events
-
-# Feature Generation Agent only
-python -m agent.features
-
-# Strategy Evaluation Agent only
-python -m agent.strategy
-```
-
-### Confirming a Successful Run
-
-A successful full-pipeline run produces console output similar to:
-
-```
-[INFO] [ingestion]  Market state refreshed — 6 instruments, 4 options chains loaded.
-[INFO] [events]     3 events detected (max intensity: high, avg confidence: 0.71).
-[INFO] [features]   Derived 6 signal dimensions across 6 instruments.
-[INFO] [strategy]   12 candidates evaluated; 5 above edge threshold (0.30).
-[INFO] [output]     Results written to ./output/candidates_2026-03-15T14:32:00Z.json
-```
+| Command | Description |
+|---|---|
+| `python -m agent check-config` | Validate configuration and API connectivity |
+| `python -m agent run` | Execute one full pipeline run |
+| `python -m agent run --continuous` | Run pipeline on a repeating schedule |
+| `python -m agent run --agent <name>` | Run a single agent (`ingestion`, `events`, `features`, `strategy`) |
+| `python -m agent status` | Show last run timestamp and candidate count |
+| `python -m agent clean --older-than <days>` | Purge output files older than `<days>` days |
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output location
 
-Each run writes a timestamped JSON file to `OUTPUT_DIR`:
+After each run, one or more JSON files are written to `OUTPUT_DIR` (default: `./output`):
 
 ```
 ./output/
 └── candidates_2026-03-15T14:32:00Z.json
 ```
 
-### Output Schema
+### Output schema
 
-Each ranked candidate is a JSON object with the following fields:
+Each file contains an array of strategy candidate objects:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument — e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Target expiration in **calendar days** from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | `object` | Map of contributing signals and their qualitative states |
+| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current state |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output File
+### Example output
 
 ```json
-{
-  "generated_at": "2026-03-15T14:32:00Z",
-  "candidates": [
-    {
-      "instrument": "USO",
-      "structure": "long_straddle",
-      "expiration": 30,
-      "edge_score": 0.47,
-      "signals": {
-        "tanker_disruption_index": "high",
-        "volatility_gap": "positive",
-        "narrative_velocity": "rising"
-      },
-      "generated_at": "2026-03-15T14:32:00Z"
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity": "rising"
     },
-    {
-      "instrument": "XLE",
-      "structure": "call_spread",
-      "expiration": 21,
-      "edge_score": 0.38,
-      "signals": {
-        "supply_shock_probability": "elevated",
-        "volatility_gap": "positive",
-        "sector_dispersion": "high"
-      },
-      "generated_at": "2026-03-15T14:32:00Z"
-    }
-  ]
-}
+    "generated_at": "2026-03-15T14:32:00Z"
+  },
+  {
+    "instrument": "XOM",
+    "structure": "call_spread",
+    "expiration": 45,
+    "edge_score": 0.31,
+    "signals": {
+      "volatility_gap": "positive",
+      "supply_shock_probability": "elevated",
+      "insider_conviction_score": "moderate"
+    },
+    "generated_at": "2026-03-15T14:32:00Z"
+  }
+]
 ```
 
-### Reading the Edge Score
+### Reading the edge score
 
-| Edge Score Range | Interpretation | Suggested Action |
+The `edge_score` is a composite float between `0.0` and `1.0` reflecting the degree of signal confluence across all active layers.
+
+| Edge score range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong confluence — multiple independent signals agree |
+| `0.40 – 0.69` | Moderate confluence — worth monitoring; verify signals manually |
+| `0.00 – 0.39` | Weak confluence — low signal agreement; treat with caution |
+
+> **Important:** The edge score is a heuristic ranking tool, not a probability of profit. It indicates the relative strength of signal alignment, not a forecast of price direction or options premium outcome.
+
+### Reading the signals map
+
+The `signals` object provides the explainability layer for each candidate. Each key is a derived feature; each value describes its current state.
+
+| Signal key | Description |
+|---|---|
+| `volatility_gap` | Relationship between realized and implied volatility (`positive` = IV underprices realized vol) |
+| `futures_curve_steepness` | Degree of contango or backwardation in the crude futures curve |
+| `sector_dispersion` | Cross-instrument divergence within energy equities and ETFs |
+| `insider_conviction_score` | Aggregated signal from recent SEC EDGAR insider filings |
+| `narrative_velocity` | Rate of headline acceleration from news and social feeds |
+| `supply_shock_probability` | Derived probability of a near-term supply disruption event |
+| `tanker_disruption_index` | Signal derived from shipping and logistics flow anomalies |
+
+### Consuming the output in thinkorswim
+
+The JSON output is compatible with any thinkorswim thinkScript import tool or third-party JSON-to-watchlist utility. Export the `instrument` and `structure` fields to build a prioritized watchlist sorted descending by `edge_score`.
+
+---
+
+## Troubleshooting
+
+### General diagnostic steps
+
+1. Run `python -m agent check-config` to confirm all reachable APIs and environment variables.
+2. Check the log file at `./logs/agent.log` for timestamped error messages.
+3. Confirm your virtual environment is activated and dependencies are installed.
+
+### Common issues
+
+| Symptom | Likely cause | Resolution |
 |---|---|---|
-| `0.00 – 0.29` | Weak or noisy signal confluence | Below default threshold; not emitted unless threshold is lowered |
-| `0.30 – 0.49` | Moderate opportunity; signals partially aligned | Review contributing signals before acting |
-| `0.50 – 0.74` | Strong confluence across multiple signal layers | High-priority review candidate |
-| `0.75 – 1.00` | Very strong confluence; rare under normal conditions | Immediate review warranted |
-
-### Signal Reference
-
-The `signals` object contains zero or more of the following keys:
-
-| Signal Key | Source Agent | What It Measures |
-|---|---|---|
-| `volatility_gap` | Feature Generation | Divergence between realised and implied volatility |
-| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the futures curve |
-| `sector_dispersion` | Feature Generation | Cross-sector price divergence within energy equities |
-| `insider_conviction_score` | Feature Generation | Aggregated executive trade activity (EDGAR / Quiver) |
-| `narrative_velocity` | Feature Generation | Acceleration of energy-related headlines and social sentiment |
-| `supply_shock_probability` | Feature Generation | Composite probability of near-term supply disruption |
-| `tanker_disruption_index` | Event Detection | Shipping flow anomalies at key tanker chokepoints |
-| `refinery_outage_signal` | Event Detection | Detected refinery capacity reduction events |
-| `geopolitical_event_score` | Event Detection | Confidence-weighted intensity of geopolitical events |
-| `eia_inventory_delta` | Data Ingestion | Week-on-week EIA crude inventory change |
-
-### Downstream Consumption
-
-The JSON output is compatible with:
-
-- **thinkorswim** — import via the platform's scripting or watchlist JSON import.
-- **Any JSON-capable dashboard** — pipe the output file directly into Grafana, Streamlit, or a custom web view.
-- **Backtesting harness** — retained historical output files (up to 12 months) can be replayed against realised price moves to validate edge
+| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` file not loaded or key missing | Confirm `.env` exists in the project root and the variable is set; ensure `python-

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
+> Advisory system only. No automated trade execution occurs at any point in the pipeline.
 
 ---
 
@@ -18,333 +18,347 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
-### What the pipeline does
+### Pipeline Architecture
+
+The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
     subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping & Logistics\nMarineTraffic / VesselFinder]
-        A8[Narrative & Sentiment\nReddit / Stocktwits]
+        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
+        A2([ETF & Equity Prices\nyfinance])
+        A3([Options Chains\nYahoo / Polygon.io])
+        A4([Supply / Inventory\nEIA API])
+        A5([News & Geo Events\nGDELT / NewsAPI])
+        A6([Insider Activity\nSEC EDGAR / Quiver])
+        A7([Shipping\nMarineTraffic])
+        A8([Sentiment\nReddit / Stocktwits])
     end
 
-    subgraph Pipeline
+    subgraph Pipeline["Four-Agent Pipeline"]
         direction TB
-        B1["① Data Ingestion Agent\nFetch & Normalize"]
-        B2["② Event Detection Agent\nSupply & Geo Signals"]
-        B3["③ Feature Generation Agent\nDerived Signal Computation"]
-        B4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+        B["🟦 Data Ingestion Agent\nFetch & Normalize\n→ Market State Object"]
+        C["🟨 Event Detection Agent\nSupply & Geo Signals\n→ Scored Events"]
+        D["🟩 Feature Generation Agent\nDerived Signal Computation\n→ Features Store"]
+        E["🟥 Strategy Evaluation Agent\nOpportunity Ranking\n→ Ranked Candidates"]
+        B --> C --> D --> E
     end
 
     subgraph Output
-        C1[Ranked Candidates\nJSON / Dashboard]
+        F([JSON Candidates\nedge_score · signals\nexpiration · structure])
     end
 
-    Inputs --> B1
-    B1 -->|Unified Market State| B2
-    B2 -->|Scored Events| B3
-    B3 -->|Derived Features| B4
-    B4 --> C1
+    Inputs --> B
+    E --> Output
 ```
 
-### In-scope instruments
+### In-Scope Instruments
 
 | Category | Instruments |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-scope option structures (MVP)
+### In-Scope Option Structures (MVP)
 
-| Structure | Enum value |
+| Structure | Enum Value |
 |---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
 
-> **Advisory only.** Automated trade execution is explicitly out of scope. All output is for informational and analytical purposes.
+> **Out of scope (MVP):** exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10+ |
+| OS | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| Deployment target | Local machine, single VM, or container |
+| Disk | 5 GB (6–12 months of historical data) |
+| Network | Outbound HTTPS to external APIs |
 
-### Required Python packages
+### Python Dependencies
 
-Install dependencies from the project root:
+Install all dependencies from the project root:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Key dependencies include:
+Key packages the pipeline relies on include:
 
-```text
-yfinance
-requests
-pandas
-numpy
-python-dotenv
-schedule
-```
+| Package | Purpose |
+|---|---|
+| `yfinance` | ETF, equity, and options chain data |
+| `requests` | HTTP calls to EIA, Alpha Vantage, GDELT, NewsAPI |
+| `pandas` / `numpy` | Data normalization and feature computation |
+| `pydantic` | Market state object and output schema validation |
+| `schedule` or `apscheduler` | Cadence-based refresh scheduling |
 
-### External API accounts
+### API Accounts
 
-Obtain free-tier credentials for each data source before configuring the pipeline.
+You must obtain API keys (all free or freemium) before running the pipeline:
 
-| Service | URL | Cost | Used for |
-|---|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co | Free | WTI / Brent spot and futures |
-| EIA API | https://www.eia.gov/opendata | Free | Inventory and refinery utilization |
-| NewsAPI | https://newsapi.org | Free tier | News and geopolitical events |
-| GDELT | https://www.gdeltproject.org | Free | Geopolitical event stream |
-| Polygon.io | https://polygon.io | Free/Limited | Options chains |
-| SEC EDGAR | https://www.sec.gov/developer | Free | Insider filing data |
-| Quiver Quant | https://www.quiverquant.com | Free/Limited | Parsed insider trades |
-| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flow data |
-
-> **Tip:** `yfinance` (Yahoo Finance) requires no API key and is used as the primary fallback for equity, ETF, and options chain data.
+| Service | Registration URL | Tier Needed |
+|---|---|---|
+| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free |
+| MetalpriceAPI | https://metalpriceapi.com | Free |
+| Polygon.io | https://polygon.io | Free / Limited |
+| EIA API | https://www.eia.gov/opendata/ | Free |
+| NewsAPI | https://newsapi.org | Free |
+| GDELT | No key required (public dataset) | — |
+| SEC EDGAR | No key required (public dataset) | — |
+| Quiver Quant | https://www.quiverquant.com | Free / Limited |
+| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Free tier |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a virtual environment
+### 2. Create a Virtual Environment
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows
+# .venv\Scripts\activate.bat     # Windows CMD
+# .venv\Scripts\Activate.ps1     # Windows PowerShell
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Create the environment file
+### 4. Configure Environment Variables
 
-Copy the provided template and populate it with your credentials:
+Copy the example environment file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and fill in each value:
+Open `.env` in your editor and set each value. The full set of supported environment variables is listed below.
 
-```dotenv
-# .env — Energy Options Opportunity Agent
-
-# ── Data Ingestion ────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-EIA_API_KEY=your_eia_key
-POLYGON_API_KEY=your_polygon_key
-
-# ── Event Detection ───────────────────────────────────────────
-NEWS_API_KEY=your_newsapi_key
-
-# ── Alternative / Contextual Signals ─────────────────────────
-QUIVER_QUANT_API_KEY=your_quiver_quant_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-
-# ── Output ────────────────────────────────────────────────────
-OUTPUT_DIR=./output
-OUTPUT_FORMAT=json
-
-# ── Scheduling ────────────────────────────────────────────────
-MARKET_DATA_INTERVAL_MINUTES=5
-SLOW_FEED_INTERVAL_HOURS=24
-
-# ── Data Retention ───────────────────────────────────────────
-RETENTION_DAYS=365
-```
-
-### Environment variable reference
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for WTI and Brent crude prices |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery data |
-| `POLYGON_API_KEY` | No | — | API key for options chain data (falls back to yfinance) |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical and energy news |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for parsed SEC insider trade data |
-| `MARINE_TRAFFIC_API_KEY` | No | — | API key for tanker flow and shipping data |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Yes | — | API key for MetalpriceAPI (Brent/WTI spot) |
+| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery utilization |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy news |
+| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
+| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flow data |
 | `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `OUTPUT_FORMAT` | No | `json` | Output format; currently `json` is supported |
-| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for market data (prices, options) |
-| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Polling cadence for slow feeds (EIA, EDGAR) |
-| `RETENTION_DAYS` | No | `365` | Number of days of historical data to retain on disk |
+| `DATA_STORE_DIR` | No | `./data` | Root directory for raw and derived historical data |
+| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Refresh cadence in minutes for market price feeds |
+| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Refresh cadence in hours for EIA and EDGAR feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_PHASE` | No | `1` | Active MVP phase (`1`–`4`); gates which agents are enabled |
+| `MIN_EDGE_SCORE` | No | `0.20` | Minimum edge score threshold for emitting a candidate |
+| `MAX_CANDIDATES` | No | `10` | Maximum number of ranked candidates per pipeline run |
 
-> **Optional keys:** If `POLYGON_API_KEY`, `QUIVER_QUANT_API_KEY`, or `MARINE_TRAFFIC_API_KEY` are absent, the pipeline will fall back to available free sources or skip those signals gracefully. The pipeline will not fail due to a missing optional key.
+> **Tip:** Variables marked **No** under *Required* are optional. The pipeline degrades gracefully when optional data sources are unavailable — it will log a warning and continue rather than halting.
 
-### 5. Verify the setup
+#### Example `.env`
 
-Run the built-in configuration check before starting the pipeline:
+```dotenv
+# --- Required API Keys ---
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+METALPRICE_API_KEY=YOUR_MP_KEY_HERE
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWS_API_KEY_HERE
+
+# --- Optional API Keys ---
+POLYGON_API_KEY=
+QUIVER_QUANT_API_KEY=
+MARINETRAFFIC_API_KEY=
+
+# --- Pipeline Behaviour ---
+PIPELINE_PHASE=1
+MIN_EDGE_SCORE=0.20
+MAX_CANDIDATES=10
+MARKET_DATA_INTERVAL_MIN=5
+SLOW_FEED_INTERVAL_HOURS=24
+
+# --- Storage ---
+OUTPUT_DIR=./output
+DATA_STORE_DIR=./data
+RETENTION_DAYS=365
+
+# --- Observability ---
+LOG_LEVEL=INFO
+```
+
+### 5. Initialise the Data Store
+
+Run the one-time initialisation script to create the required directory structure and seed the historical data store:
 
 ```bash
-python -m agent check-config
+python -m agent.cli init
 ```
 
 Expected output:
 
 ```
-[OK] Alpha Vantage         reachable
-[OK] EIA API               reachable
-[OK] NewsAPI               reachable
-[OK] yfinance              available (no key required)
-[WARN] Polygon.io          key not set — falling back to yfinance for options
-[WARN] MarineTraffic       key not set — shipping signals disabled
-[OK] Output directory      ./output exists
-Configuration check complete. 2 warning(s), 0 error(s).
+[INFO] Creating data store at ./data ...
+[INFO] Creating output directory at ./output ...
+[INFO] Initialisation complete. Run `python -m agent.cli run` to start the pipeline.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution sequence
+### Pipeline Data Flow (Sequence)
 
 ```mermaid
 sequenceDiagram
+    autonumber
     participant CLI as CLI / Scheduler
-    participant DI as ① Data Ingestion Agent
-    participant ED as ② Event Detection Agent
-    participant FG as ③ Feature Generation Agent
-    participant SE as ④ Strategy Evaluation Agent
-    participant FS as Filesystem / Output
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant FS as File System (JSON Output)
 
-    CLI->>DI: trigger run
-    DI->>DI: fetch crude prices, ETF/equity, options chains
-    DI->>DI: normalize → unified market state object
-    DI->>ED: market state
-    ED->>ED: scan news, GDELT, shipping feeds
-    ED->>ED: score events (confidence + intensity)
-    ED->>FG: market state + scored events
-    FG->>FG: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock probability
-    FG->>SE: derived features store
-    SE->>SE: evaluate eligible option structures\nagainst computed signals
-    SE->>SE: generate edge scores, attach signal references
-    SE->>FS: write ranked candidates (JSON)
-    FS-->>CLI: run complete — candidates available in ./output
+    CLI->>DIA: trigger run()
+    DIA->>DIA: fetch crude, ETF, equity prices
+    DIA->>DIA: fetch options chains
+    DIA->>DIA: normalize → MarketStateObject
+    DIA-->>EDA: MarketStateObject
+
+    EDA->>EDA: scan GDELT / NewsAPI
+    EDA->>EDA: score supply disruptions, outages, chokepoints
+    EDA-->>FGA: MarketStateObject + ScoredEvents
+
+    FGA->>FGA: compute volatility gaps (realized vs. implied)
+    FGA->>FGA: compute curve steepness, dispersion, insider scores
+    FGA->>FGA: compute narrative velocity, supply shock probability
+    FGA-->>SEA: FeaturesStore
+
+    SEA->>SEA: evaluate eligible option structures
+    SEA->>SEA: compute edge scores
+    SEA->>SEA: rank candidates, attach signal references
+    SEA-->>FS: write ranked_candidates_<timestamp>.json
 ```
 
-### Run once (manual)
+### Single Run (One-Shot)
 
-Execute a single end-to-end pipeline run:
+Execute the full pipeline once and write output to `OUTPUT_DIR`:
 
 ```bash
-python -m agent run
+python -m agent.cli run
 ```
 
-This triggers all four agents in sequence and writes the output to `OUTPUT_DIR`.
-
-### Run on a schedule (continuous mode)
-
-Start the pipeline in continuous mode. Market data is polled at the cadence set by `MARKET_DATA_INTERVAL_MINUTES`; slow feeds (EIA, EDGAR) refresh at `SLOW_FEED_INTERVAL_HOURS`:
+To override the active phase without editing `.env`:
 
 ```bash
-python -m agent run --continuous
+python -m agent.cli run --phase 2
 ```
 
-### Run a specific agent only
-
-Each agent can be executed independently, which is useful during development or when debugging a single stage:
+To lower the minimum edge score for a broader candidate set:
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent run --agent ingestion
-
-# Run only the Event Detection Agent
-python -m agent run --agent events
-
-# Run only the Feature Generation Agent
-python -m agent run --agent features
-
-# Run only the Strategy Evaluation Agent
-python -m agent run --agent strategy
+python -m agent.cli run --min-edge-score 0.10
 ```
 
-> **Dependency note:** Running `features` or `strategy` in isolation requires a valid market state object and event scores to already exist in the derived features store from a prior run of the upstream agents.
+### Continuous Mode (Scheduled)
 
-### Run with Docker
+Run the pipeline on a recurring cadence driven by `MARKET_DATA_INTERVAL_MIN`:
 
-A `Dockerfile` and `docker-compose.yml` are provided for containerized deployment on a single VM:
+```bash
+python -m agent.cli run --continuous
+```
+
+The scheduler will:
+- Refresh market price feeds every `MARKET_DATA_INTERVAL_MIN` minutes.
+- Refresh slow feeds (EIA, EDGAR) every `SLOW_FEED_INTERVAL_HOURS` hours.
+- Append a new output file per cycle to `OUTPUT_DIR`.
+
+Stop the process with `Ctrl+C`.
+
+### Running Individual Agents
+
+Each agent can be run in isolation for development or debugging:
+
+```bash
+# Data Ingestion only
+python -m agent.cli run --agent ingestion
+
+# Event Detection only (requires a prior ingestion snapshot)
+python -m agent.cli run --agent event-detection
+
+# Feature Generation only
+python -m agent.cli run --agent feature-generation
+
+# Strategy Evaluation only
+python -m agent.cli run --agent strategy-evaluation
+```
+
+### Running in Docker
+
+A minimal container target is provided for cloud or server deployment:
 
 ```bash
 # Build the image
-docker build -t energy-options-agent .
+docker build -t energy-options-agent:latest .
 
-# Run once
-docker run --env-file .env -v $(pwd)/output:/app/output energy-options-agent
-
-# Run continuously via docker-compose
-docker-compose up -d
+# Run with your local .env file
+docker run --env-file .env \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  energy-options-agent:latest
 ```
-
-### CLI reference
-
-| Command | Description |
-|---|---|
-| `python -m agent check-config` | Validate configuration and API connectivity |
-| `python -m agent run` | Execute one full pipeline run |
-| `python -m agent run --continuous` | Run pipeline on a repeating schedule |
-| `python -m agent run --agent <name>` | Run a single agent (`ingestion`, `events`, `features`, `strategy`) |
-| `python -m agent status` | Show last run timestamp and candidate count |
-| `python -m agent clean --older-than <days>` | Purge output files older than `<days>` days |
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output File Location
 
-After each run, one or more JSON files are written to `OUTPUT_DIR` (default: `./output`):
+Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
-./output/
-└── candidates_2026-03-15T14:32:00Z.json
+output/
+└── ranked_candidates_2026-03-15T14:05:00Z.json
 ```
 
-### Output schema
+### Output Schema
 
-Each file contains an array of strategy candidate objects:
+Each file contains an array of candidate objects. The fields are:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
 | `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
 | `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current state |
+| `signals` | `object` | Map of contributing signals and their qualitative levels |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output
+### Example Output
 
 ```json
 [
@@ -358,65 +372,59 @@ Each file contains an array of strategy candidate objects:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:05:00Z"
   },
   {
-    "instrument": "XOM",
+    "instrument": "XLE",
     "structure": "call_spread",
     "expiration": 45,
     "edge_score": 0.31,
     "signals": {
-      "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "insider_conviction_score": "moderate"
+      "volatility_gap": "positive",
+      "sector_dispersion": "widening"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:05:00Z"
   }
 ]
 ```
 
-### Reading the edge score
+### Reading the Edge Score
 
-The `edge_score` is a composite float between `0.0` and `1.0` reflecting the degree of signal confluence across all active layers.
-
-| Edge score range | Interpretation |
+| Edge Score Range | Interpretation |
 |---|---|
-| `0.70 – 1.00` | Strong confluence — multiple independent signals agree |
-| `0.40 – 0.69` | Moderate confluence — worth monitoring; verify signals manually |
-| `0.00 – 0.39` | Weak confluence — low signal agreement; treat with caution |
+| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
+| `0.40 – 0.69` | Moderate confluence — worthy of further review |
+| `0.20 – 0.39` | Weak signal — monitor rather than act |
+| `< 0.20` | Below threshold — suppressed by default (`MIN_EDGE_SCORE`) |
 
-> **Important:** The edge score is a heuristic ranking tool, not a probability of profit. It indicates the relative strength of signal alignment, not a forecast of price direction or options premium outcome.
+> **Important:** The edge score is an advisory signal, not a trade recommendation. The system does not execute trades and does not account for individual risk tolerance, position sizing, or transaction costs.
 
-### Reading the signals map
+### Signal Reference
 
-The `signals` object provides the explainability layer for each candidate. Each key is a derived feature; each value describes its current state.
+The `signals` map reports the state of each contributing derived feature at the time of evaluation:
 
-| Signal key | Description |
+| Signal Key | What It Measures |
 |---|---|
-| `volatility_gap` | Relationship between realized and implied volatility (`positive` = IV underprices realized vol) |
-| `futures_curve_steepness` | Degree of contango or backwardation in the crude futures curve |
-| `sector_dispersion` | Cross-instrument divergence within energy equities and ETFs |
-| `insider_conviction_score` | Aggregated signal from recent SEC EDGAR insider filings |
-| `narrative_velocity` | Rate of headline acceleration from news and social feeds |
-| `supply_shock_probability` | Derived probability of a near-term supply disruption event |
-| `tanker_disruption_index` | Signal derived from shipping and logistics flow anomalies |
+| `volatility_gap` | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Contango or backwardation steepness |
+| `sector_dispersion` | Cross-instrument spread within the energy sector |
+| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
+| `narrative_velocity` | Headline acceleration from GDELT / NewsAPI / Reddit |
+| `supply_shock_probability` | Probability of near-term supply disruption |
+| `tanker_disruption_index` | Shipping flow anomaly from MarineTraffic |
 
-### Consuming the output in thinkorswim
+### Using the Output with thinkorswim
 
-The JSON output is compatible with any thinkorswim thinkScript import tool or third-party JSON-to-watchlist utility. Export the `instrument` and `structure` fields to build a prioritized watchlist sorted descending by `edge_score`.
+The JSON output is compatible with any thinkorswim thinkScript study or third-party dashboard that can consume a JSON file. Load `ranked_candidates_<timestamp>.json` from your `OUTPUT_DIR` into your visualization layer. Candidates are pre-sorted by `edge_score` descending.
 
 ---
 
 ## Troubleshooting
 
-### General diagnostic steps
+### Common Issues
 
-1. Run `python -m agent check-config` to confirm all reachable APIs and environment variables.
-2. Check the log file at `./logs/agent.log` for timestamped error messages.
-3. Confirm your virtual environment is activated and dependencies are installed.
-
-### Common issues
-
-| Symptom | Likely cause | Resolution |
+| Symptom | Likely Cause | Resolution |
 |---|---|---|
-| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` file not loaded or key missing | Confirm `.env` exists in the project root and the variable is set; ensure `python-
+| `KeyError: ALPHA_VANTAGE_API_KEY` | Environment variable not set | Verify `.env` is populated and loaded; re-run `source .venv/bin/activate` |
+| `WARNING: options chain unavailable for XOM` | Polygon.io

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting. It assumes you are comfortable with Python and command-line tools but are new to this project.
+> **Version 1.0 • March 2026**
+> Advisory only. The system produces ranked strategy candidates; it does **not** execute trades.
 
 ---
 
@@ -18,121 +18,118 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that detects options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical news, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a four-stage Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
-### What the pipeline does
-
-| Stage | Agent | What happens |
-|---|---|---|
-| 1 | **Data Ingestion Agent** | Fetches and normalises crude prices, ETF/equity data, and options chains into a unified market state object |
-| 2 | **Event Detection Agent** | Monitors news and geopolitical feeds; scores supply disruptions, refinery outages, and tanker chokepoints |
-| 3 | **Feature Generation Agent** | Computes volatility gaps, futures curve steepness, sector dispersion, insider conviction, narrative velocity, and supply shock probability |
-| 4 | **Strategy Evaluation Agent** | Ranks candidate option structures (long straddles, call/put spreads, calendar spreads) by edge score with full signal attribution |
-
-### Pipeline data flow
+### Pipeline at a Glance
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        A3[Options Chains\nPolygon.io / Yahoo Finance]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping Data\nMarineTraffic / VesselFinder]
-        A8[Sentiment\nReddit / Stocktwits]
+    subgraph Ingestion["① Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nStrike · IV · Volume]
     end
 
-    subgraph Pipeline
-        B[Data Ingestion Agent\nFetch & Normalise]
-        C[Event Detection Agent\nSupply & Geo Signals]
-        D[Feature Generation Agent\nDerived Signal Computation]
-        E[Strategy Evaluation Agent\nOpportunity Ranking]
+    subgraph Events["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT · NewsAPI]
+        B2[Supply / Inventory\nEIA API]
+        B3[Shipping Signals\nMarineTraffic]
+        B4[Confidence &\nIntensity Scoring]
     end
 
-    subgraph Output
-        F[Ranked Candidates\nJSON / Dashboard]
+    subgraph Features["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs Implied]
+        C2[Futures Curve\nSteepness]
+        C3[Sector Dispersion]
+        C4[Insider Conviction]
+        C5[Narrative Velocity]
+        C6[Supply Shock\nProbability]
     end
 
-    A1 & A2 & A3 & A4 --> B
-    A5 --> C
-    A6 & A7 & A8 --> D
-    B -->|market state object| C
-    C -->|scored events| D
-    D -->|derived features store| E
-    E --> F
+    subgraph Strategy["④ Strategy Evaluation Agent"]
+        D1[Eligible Structures\nStraddle · Spreads]
+        D2[Edge Score\nComputation]
+        D3[Ranked Candidates\nJSON Output]
+    end
+
+    MarketState[(Shared\nMarket State)]
+    FeaturesStore[(Derived\nFeatures Store)]
+
+    Ingestion --> MarketState
+    Events --> MarketState
+    MarketState --> Features
+    Features --> FeaturesStore
+    FeaturesStore --> Strategy
+    Strategy --> D3
 ```
 
-### In-scope instruments and structures
+### In-Scope Instruments & Structures (MVP)
 
-**Instruments:** Brent Crude, WTI (`CL=F`), USO, XLE, XOM, CVX
+| Category | Items |
+|---|---|
+| **Crude Futures** | Brent Crude, WTI |
+| **ETFs** | USO, XLE |
+| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option Structures** | Long straddles, call / put spreads, calendar spreads |
 
-**Option structures (MVP):** `long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
-
-> **Advisory only.** The pipeline produces ranked recommendations. Automated trade execution is explicitly out of scope for the MVP.
+Automated execution, exotic multi-legged strategies, and regional refined product pricing (OPIS) are **out of scope** for the current release.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
-| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
-| Python | 3.10 or later |
-| Disk space | ~5 GB (for 6–12 months of historical data) |
-| Memory | 2 GB RAM |
-| Deployment target | Local machine, single VM, or single container |
+| **Python** | 3.10+ |
+| **Operating System** | Linux, macOS, or Windows (WSL recommended) |
+| **RAM** | 2 GB |
+| **Disk** | 5 GB (12-month data retention target) |
+| **Network** | Outbound HTTPS to public APIs |
 
-### External accounts and API keys
+### Required Tools
 
-All required data sources are free or offer a free tier. Obtain credentials before proceeding.
+```bash
+# Verify Python version
+python --version   # must be >= 3.10
 
-| Source | Purpose | Where to register |
-|---|---|---|
-| Alpha Vantage | WTI / Brent spot and futures prices | <https://www.alphavantage.co/support/#api-key> |
-| MetalpriceAPI | Commodity price fallback | <https://metalpriceapi.com> |
-| Polygon.io | Options chains (strike, expiry, IV, volume) | <https://polygon.io> |
-| EIA API | Weekly inventory and refinery utilisation | <https://www.eia.gov/opendata/> |
-| NewsAPI | News and geopolitical event feed | <https://newsapi.org> |
-| GDELT | Geopolitical event data | No key required (public dataset) |
-| SEC EDGAR | Insider trade filings | No key required (public dataset) |
-| Quiver Quant | Structured insider activity | <https://www.quiverquant.com> |
-| MarineTraffic | Tanker flow data (free tier) | <https://www.marinetraffic.com/en/online-services/plans> |
-| Reddit API | Retail sentiment (PRAW) | <https://www.reddit.com/prefs/apps> |
-| Stocktwits | Narrative / sentiment velocity | <https://api.stocktwits.com/developers/apps/new> |
+# Verify pip
+pip --version
 
-> **Tip:** Yahoo Finance / `yfinance` requires no API key and is used for ETF and equity prices as well as an options-data fallback.
-
-### Python dependencies
-
-The project uses a `requirements.txt` file. Core dependencies include:
-
-```
-yfinance
-requests
-pandas
-numpy
-python-dotenv
-schedule
+# Optional but recommended: virtual environment tooling
+python -m venv --help
 ```
 
-Install them after cloning the repository (see [Setup & Configuration](#setup--configuration)).
+### External API Accounts
+
+Register for free-tier access at each provider before configuring the pipeline:
+
+| Data Layer | Provider | Free Tier? | Sign-up URL |
+|---|---|---|---|
+| Crude Prices | Alpha Vantage | ✅ Free | https://www.alphavantage.co/support/#api-key |
+| ETF / Equity Prices | yfinance (Yahoo Finance) | ✅ Free | No registration required |
+| Options Data | Polygon.io | ✅ Free / Limited | https://polygon.io/dashboard/signup |
+| Supply & Inventory | EIA API | ✅ Free | https://www.eia.gov/opendata/register.php |
+| News & Geo Events | NewsAPI | ✅ Free | https://newsapi.org/register |
+| News & Geo Events | GDELT | ✅ Free | No registration required |
+| Insider Activity | SEC EDGAR | ✅ Free | No registration required |
+| Insider Activity | Quiver Quant | ⚠️ Free / Limited | https://www.quiverquant.com/signup |
+| Shipping / Logistics | MarineTraffic | ✅ Free tier | https://www.marinetraffic.com/en/register |
+| Narrative / Sentiment | Reddit API | ✅ Free | https://www.reddit.com/wiki/api |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
 python -m venv .venv
@@ -141,244 +138,274 @@ python -m venv .venv
 source .venv/bin/activate
 
 # Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 4. Configure Environment Variables
 
-Copy the sample environment file and populate it with your credentials:
+Copy the provided template and populate your API keys:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value marked `REQUIRED`.
+Open `.env` in your editor and fill in each value. The full set of recognised variables is documented in the table below.
 
-#### Full environment variable reference
+#### Environment Variable Reference
 
-| Variable | Required | Description | Example value |
+| Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | Crude price feed (WTI, Brent) | `ABC123XYZ` |
-| `METALPRICE_API_KEY` | Optional | Fallback commodity price feed | `def456uvw` |
-| `POLYGON_API_KEY` | ✅ | Options chains (strike, expiry, IV, volume) | `ghi789rst` |
-| `EIA_API_KEY` | ✅ | Weekly supply / inventory data | `jkl012mno` |
-| `NEWS_API_KEY` | ✅ | News and geopolitical events | `pqr345stu` |
-| `QUIVER_QUANT_API_KEY` | Optional | Structured insider activity data | `vwx678yza` |
-| `MARINETRAFFIC_API_KEY` | Optional | Tanker flow / shipping logistics | `bcd901efg` |
-| `REDDIT_CLIENT_ID` | Optional | Reddit PRAW app client ID | `hij234klm` |
-| `REDDIT_CLIENT_SECRET` | Optional | Reddit PRAW app client secret | `nop567qrs` |
-| `REDDIT_USER_AGENT` | Optional | Reddit PRAW user agent string | `energy-agent/1.0` |
-| `STOCKTWITS_API_KEY` | Optional | Stocktwits sentiment feed | `tuv890wxy` |
-| `DATA_DIR` | ✅ | Path for persisted historical data | `./data` |
-| `OUTPUT_DIR` | ✅ | Path for JSON output files | `./output` |
-| `LOG_LEVEL` | Optional | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) | `INFO` |
-| `MARKET_DATA_INTERVAL_MINUTES` | Optional | Refresh cadence for market data | `5` |
-| `HISTORY_RETENTION_DAYS` | Optional | Days of historical data to retain | `365` |
-| `EDGE_SCORE_THRESHOLD` | Optional | Minimum edge score to include in output | `0.20` |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for crude price feeds (WTI, Brent spot/futures) |
+| `POLYGON_API_KEY` | ✅ | — | API key for options chain data (strike, expiry, IV, volume) |
+| `EIA_API_KEY` | ✅ | — | API key for EIA inventory and refinery utilisation data |
+| `NEWSAPI_KEY` | ✅ | — | API key for energy news and geopolitical event headlines |
+| `REDDIT_CLIENT_ID` | ⚠️ Phase 3 | — | Reddit OAuth client ID for sentiment / narrative velocity |
+| `REDDIT_CLIENT_SECRET` | ⚠️ Phase 3 | — | Reddit OAuth client secret |
+| `REDDIT_USER_AGENT` | ⚠️ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `QUIVER_API_KEY` | ⚠️ Phase 3 | — | Quiver Quant key for insider conviction scores |
+| `MARINETRAFFIC_API_KEY` | ⚠️ Phase 3 | — | MarineTraffic key for tanker flow signals |
+| `DATA_DIR` | ❌ | `./data` | Root directory for persisted raw and derived data |
+| `OUTPUT_DIR` | ❌ | `./output` | Directory where ranked candidate JSON files are written |
+| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Polling cadence for minute-level market data feeds |
+| `HISTORY_RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain for backtesting |
+| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum edge score for a candidate to appear in output |
+| `MAX_CANDIDATES` | ❌ | `20` | Maximum number of ranked candidates written per run |
 
-> **Optional vs. required:** Variables marked Optional correspond to Phase 2–3 data sources. The pipeline tolerates missing or delayed data without failing (see [Non-Functional Requirements](#non-functional-requirements-summary)). If a key is absent, the corresponding agent module is skipped and a warning is logged.
+> **Tip — Variables marked ⚠️ Phase 3** are only needed once you enable Phase 3 alternative signals. The pipeline runs without them in Phases 1 and 2.
 
-### 5. Initialise the data directory
+#### Example `.env`
 
-```bash
-python -m agent.init_storage
+```dotenv
+# === Core API Keys ===
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
+POLYGON_API_KEY=your_polygon_key_here
+EIA_API_KEY=your_eia_key_here
+NEWSAPI_KEY=your_newsapi_key_here
+
+# === Phase 3 (Alternative Signals) ===
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-agent/1.0
+QUIVER_API_KEY=your_quiver_key_here
+MARINETRAFFIC_API_KEY=your_marinetraffic_key_here
+
+# === Storage & Output ===
+DATA_DIR=./data
+OUTPUT_DIR=./output
+HISTORY_RETENTION_DAYS=365
+
+# === Pipeline Behaviour ===
+LOG_LEVEL=INFO
+MARKET_DATA_INTERVAL_MINUTES=5
+EDGE_SCORE_THRESHOLD=0.30
+MAX_CANDIDATES=20
 ```
 
-This creates the `DATA_DIR` and `OUTPUT_DIR` folder structure and verifies write permissions before the first run.
+### 5. Initialise Storage
 
-### 6. Verify connectivity
-
-Run the connectivity check to confirm that each configured API key is valid and reachable:
+Create the local data and output directories and seed the historical data store:
 
 ```bash
-python -m agent.check_feeds
+python -m agent init
 ```
 
 Expected output:
 
 ```
-[OK]  Alpha Vantage      — crude prices reachable
-[OK]  Polygon.io         — options chain reachable
-[OK]  EIA API            — inventory feed reachable
-[OK]  NewsAPI            — news feed reachable
-[SKIP] MarineTraffic     — key not configured, module disabled
-[SKIP] Reddit            — key not configured, module disabled
+[INFO] Creating data directory at ./data
+[INFO] Creating output directory at ./output
+[INFO] Storage initialised successfully.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution modes
+### Pipeline Phases
 
-| Mode | Command | Use case |
+The system ships with four progressive phases. Activate only the phases for which you have configured the required data sources.
+
+| Phase | Name | Key Data Sources Added |
 |---|---|---|
-| Single run | `python -m agent.run --once` | Ad-hoc evaluation; runs all four agents once and exits |
-| Scheduled loop | `python -m agent.run` | Continuous operation; market data refreshed on the configured minute cadence |
-| Individual agent | `python -m agent.<agent_module>` | Development and debugging of a single stage |
+| **1** | Core Market Signals & Options | Alpha Vantage, yfinance, Polygon.io |
+| **2** | Supply & Event Augmentation | EIA API, GDELT, NewsAPI |
+| **3** | Alternative / Contextual Signals | EDGAR, Quiver, MarineTraffic, Reddit |
+| **4** | High-Fidelity Enhancements | OPIS (paid), exotic structures, execution API |
 
-### Single run (recommended for first-time users)
+### Single Run (Ad-hoc)
 
-```bash
-python -m agent.run --once
-```
-
-The pipeline executes the four agents in sequence:
-
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant FS as File System (OUTPUT_DIR)
-
-    CLI->>DIA: trigger run
-    DIA->>DIA: fetch crude, ETF, equity, options data
-    DIA-->>EDA: market state object
-    EDA->>EDA: scan news & geo feeds; score events
-    EDA-->>FGA: scored events + market state
-    FGA->>FGA: compute volatility gaps, curve steepness,\ndispersion, insider conviction,\nnarrative velocity, shock probability
-    FGA-->>SEA: derived features store
-    SEA->>SEA: evaluate long straddles, spreads,\ncalendar spreads; rank by edge score
-    SEA-->>FS: write ranked_candidates_<timestamp>.json
-    FS-->>CLI: run complete; exit 0
-```
-
-### Scheduled continuous run
+Execute a full pipeline pass and write results to `OUTPUT_DIR`:
 
 ```bash
-python -m agent.run
+python -m agent run
 ```
 
-- Market data (crude, ETF, equity, options) refreshes every `MARKET_DATA_INTERVAL_MINUTES` minutes.
-- Slower feeds (EIA, EDGAR) refresh on a daily or weekly schedule automatically.
-- Press `Ctrl+C` to stop. In-progress runs complete before the process exits.
-
-### Running individual agents
-
-Useful when iterating on a single stage without re-fetching all data:
+To restrict to a specific phase:
 
 ```bash
-# Re-run only the Feature Generation Agent against cached market state
-python -m agent.feature_generation
+# Phase 1 only (market data + options surface)
+python -m agent run --phase 1
 
-# Re-run only the Strategy Evaluation Agent against existing derived features
-python -m agent.strategy_evaluation
+# Phases 1 and 2 (adds supply & event signals)
+python -m agent run --phase 2
 ```
 
-### Useful CLI flags
-
-| Flag | Description |
-|---|---|
-| `--once` | Execute a single pipeline pass then exit |
-| `--dry-run` | Run the full pipeline but do not write output files |
-| `--log-level DEBUG` | Override `LOG_LEVEL` for this invocation |
-| `--output-dir <path>` | Override `OUTPUT_DIR` for this invocation |
-| `--min-edge <float>` | Override `EDGE_SCORE_THRESHOLD` for this invocation |
-
-Example combining flags:
+To override the edge score threshold for a single run:
 
 ```bash
-python -m agent.run --once --log-level DEBUG --min-edge 0.30
+python -m agent run --edge-threshold 0.25
+```
+
+### Scheduled / Continuous Mode
+
+Run the pipeline on its configured polling cadence (default: every 5 minutes for market data; daily for EIA/EDGAR):
+
+```bash
+python -m agent start
+```
+
+Stop the scheduler gracefully:
+
+```bash
+python -m agent stop
+```
+
+### Dry Run (No Output Written)
+
+Validate configuration and data source connectivity without persisting any results:
+
+```bash
+python -m agent run --dry-run
+```
+
+### Individual Agent Execution
+
+Each agent can be invoked independently for development or debugging:
+
+```bash
+# Data Ingestion Agent only
+python -m agent.ingestion
+
+# Event Detection Agent only
+python -m agent.events
+
+# Feature Generation Agent only
+python -m agent.features
+
+# Strategy Evaluation Agent only
+python -m agent.strategy
+```
+
+### Confirming a Successful Run
+
+A successful full-pipeline run produces console output similar to:
+
+```
+[INFO] [ingestion]  Market state refreshed — 6 instruments, 4 options chains loaded.
+[INFO] [events]     3 events detected (max intensity: high, avg confidence: 0.71).
+[INFO] [features]   Derived 6 signal dimensions across 6 instruments.
+[INFO] [strategy]   12 candidates evaluated; 5 above edge threshold (0.30).
+[INFO] [output]     Results written to ./output/candidates_2026-03-15T14:32:00Z.json
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output File Location
 
-After each pipeline run, one JSON file is written to `OUTPUT_DIR`:
+Each run writes a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
-output/
-└── ranked_candidates_2026-03-15T14:32:00Z.json
+./output/
+└── candidates_2026-03-15T14:32:00Z.json
 ```
 
-The filename encodes the UTC timestamp of the evaluation run.
+### Output Schema
 
-### Output schema
-
-Each file contains a top-level array of strategy candidate objects.
+Each ranked candidate is a JSON object with the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument — e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | enum | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | integer (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signals and their qualitative values |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument — e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in **calendar days** from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
+| `signals` | `object` | Map of contributing signals and their qualitative states |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output
+### Example Output File
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
+{
+  "generated_at": "2026-03-15T14:32:00Z",
+  "candidates": [
+    {
+      "instrument": "USO",
+      "structure": "long_straddle",
+      "expiration": 30,
+      "edge_score": 0.47,
+      "signals": {
+        "tanker_disruption_index": "high",
+        "volatility_gap": "positive",
+        "narrative_velocity": "rising"
+      },
+      "generated_at": "2026-03-15T14:32:00Z"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
-  },
-  {
-    "instrument": "XLE",
-    "structure": "call_spread",
-    "expiration": 21,
-    "edge_score": 0.34,
-    "signals": {
-      "volatility_gap": "positive",
-      "supply_shock_probability": "elevated",
-      "sector_dispersion": "high"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
+    {
+      "instrument": "XLE",
+      "structure": "call_spread",
+      "expiration": 21,
+      "edge_score": 0.38,
+      "signals": {
+        "supply_shock_probability": "elevated",
+        "volatility_gap": "positive",
+        "sector_dispersion": "high"
+      },
+      "generated_at": "2026-03-15T14:32:00Z"
+    }
+  ]
+}
 ```
 
-### Reading the edge score
+### Reading the Edge Score
 
-| Edge score range | Interpretation |
-|---|---|
-| 0.60 – 1.00 | Strong signal confluence — multiple independent signals aligned |
-| 0.40 – 0.59 | Moderate confluence — worth reviewing contributing signals |
-| 0.20 – 0.39 | Weak signal — marginal opportunity, high uncertainty |
-| 0.00 – 0.19 | Below threshold — filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
+| Edge Score Range | Interpretation | Suggested Action |
+|---|---|---|
+| `0.00 – 0.29` | Weak or noisy signal confluence | Below default threshold; not emitted unless threshold is lowered |
+| `0.30 – 0.49` | Moderate opportunity; signals partially aligned | Review contributing signals before acting |
+| `0.50 – 0.74` | Strong confluence across multiple signal layers | High-priority review candidate |
+| `0.75 – 1.00` | Very strong confluence; rare under normal conditions | Immediate review warranted |
 
-> The edge score is a heuristic composite in the MVP. It is designed to be explainable, not predictive in a statistically rigorous sense. Always review the `signals` map before acting on a candidate.
+### Signal Reference
 
-### Reading the signals map
+The `signals` object contains zero or more of the following keys:
 
-| Signal key | What it measures |
-|---|---|
-| `volatility_gap` | Spread between realised and implied volatility; `positive` = IV underprices expected moves |
-| `futures_curve_steepness` | Contango / backwardation regime of the crude futures curve |
-| `sector_dispersion` | Cross-sector correlation breakdown indicating idiosyncratic energy moves |
-| `insider_conviction_score` | Aggregated executive trade activity (EDGAR / Quiver Quant) |
-| `narrative_velocity` | Acceleration of headline volume on the instrument (Reddit / Stocktwits / NewsAPI) |
-| `supply_shock_probability` | Composite probability of a near-term supply disruption |
-| `tanker_disruption_index` | Shipping flow anomalies at key chokepoints |
+| Signal Key | Source Agent | What It Measures |
+|---|---|---|
+| `volatility_gap` | Feature Generation | Divergence between realised and implied volatility |
+| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the futures curve |
+| `sector_dispersion` | Feature Generation | Cross-sector price divergence within energy equities |
+| `insider_conviction_score` | Feature Generation | Aggregated executive trade activity (EDGAR / Quiver) |
+| `narrative_velocity` | Feature Generation | Acceleration of energy-related headlines and social sentiment |
+| `supply_shock_probability` | Feature Generation | Composite probability of near-term supply disruption |
+| `tanker_disruption_index` | Event Detection | Shipping flow anomalies at key tanker chokepoints |
+| `refinery_outage_signal` | Event Detection | Detected refinery capacity reduction events |
+| `geopolitical_event_score` | Event Detection | Confidence-weighted intensity of geopolitical events |
+| `eia_inventory_delta` | Data Ingestion | Week-on-week EIA crude inventory change |
 
-### Consuming output downstream
+### Downstream Consumption
 
-The JSON format is compatible with any JSON-capable dashboard. To load candidates into a thinkorswim-compatible watchlist, pipe the output through the provided helper:
+The JSON output is compatible with:
 
-```bash
-python -m agent.export_tos --input output/ranked_candidates_2026-03-15T14:32:00Z.json
-```
-
-This writes a `.csv`
+- **thinkorswim** — import via the platform's scripting or watchlist JSON import.
+- **Any JSON-capable dashboard** — pipe the output file directly into Grafana, Streamlit, or a custom web view.
+- **Backtesting harness** — retained historical output files (up to 12 months) can be replayed against realised price moves to validate edge

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full four-agent pipeline end-to-end, and explains how to interpret the ranked output it produces.
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting. It assumes you are comfortable with Python and command-line tools but are new to this project.
 
 ---
 
@@ -18,353 +18,308 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that detects options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical news, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
-The system is **advisory only** — it does not execute trades.
+### What the pipeline does
 
-### Pipeline Architecture
+| Stage | Agent | What happens |
+|---|---|---|
+| 1 | **Data Ingestion Agent** | Fetches and normalises crude prices, ETF/equity data, and options chains into a unified market state object |
+| 2 | **Event Detection Agent** | Monitors news and geopolitical feeds; scores supply disruptions, refinery outages, and tanker chokepoints |
+| 3 | **Feature Generation Agent** | Computes volatility gaps, futures curve steepness, sector dispersion, insider conviction, narrative velocity, and supply shock probability |
+| 4 | **Strategy Evaluation Agent** | Ranks candidate option structures (long straddles, call/put spreads, calendar spreads) by edge score with full signal attribution |
 
-Data flows unidirectionally through four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**.
+### Pipeline data flow
 
 ```mermaid
 flowchart LR
-    subgraph Sources["External Data Sources"]
-        S1["Crude Prices\n(Alpha Vantage / MetalpriceAPI)"]
-        S2["ETF / Equity Prices\n(Yahoo Finance / yfinance)"]
-        S3["Options Chains\n(Yahoo Finance / Polygon.io)"]
-        S4["Supply & Inventory\n(EIA API)"]
-        S5["News & Geo Events\n(GDELT / NewsAPI)"]
-        S6["Insider Activity\n(SEC EDGAR / Quiver Quant)"]
-        S7["Shipping / Logistics\n(MarineTraffic / VesselFinder)"]
-        S8["Narrative / Sentiment\n(Reddit / Stocktwits)"]
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        A3[Options Chains\nPolygon.io / Yahoo Finance]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping Data\nMarineTraffic / VesselFinder]
+        A8[Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Agent1["① Data Ingestion Agent"]
-        A1["Fetch & Normalize\n→ Market State Object"]
+    subgraph Pipeline
+        B[Data Ingestion Agent\nFetch & Normalise]
+        C[Event Detection Agent\nSupply & Geo Signals]
+        D[Feature Generation Agent\nDerived Signal Computation]
+        E[Strategy Evaluation Agent\nOpportunity Ranking]
     end
 
-    subgraph Agent2["② Event Detection Agent"]
-        A2["Supply & Geo Signals\n→ Confidence / Intensity Scores"]
+    subgraph Output
+        F[Ranked Candidates\nJSON / Dashboard]
     end
 
-    subgraph Agent3["③ Feature Generation Agent"]
-        A3["Derived Signal Computation\n→ Features Store"]
-    end
-
-    subgraph Agent4["④ Strategy Evaluation Agent"]
-        A4["Opportunity Ranking\n→ Edge-Scored Candidates"]
-    end
-
-    OUT["JSON Output\n(ranked candidates)"]
-
-    Sources --> Agent1
-    Agent1 --> Agent2
-    Agent2 --> Agent3
-    Agent3 --> Agent4
-    Agent4 --> OUT
+    A1 & A2 & A3 & A4 --> B
+    A5 --> C
+    A6 & A7 & A8 --> D
+    B -->|market state object| C
+    C -->|scored events| D
+    D -->|derived features store| E
+    E --> F
 ```
 
-### In-Scope Instruments
+### In-scope instruments and structures
 
-| Category | Instruments |
-|---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+**Instruments:** Brent Crude, WTI (`CL=F`), USO, XLE, XOM, CVX
 
-### In-Scope Option Structures (MVP)
+**Option structures (MVP):** `long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
 
-| Structure | Enum value |
-|---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
-
-> **Out of scope for MVP:** exotic / multi-legged structures, regional refined product pricing (OPIS), and automated trade execution.
+> **Advisory only.** The pipeline produces ranked recommendations. Automated trade execution is explicitly out of scope for the MVP.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
+| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 5 GB (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| Disk space | ~5 GB (for 6–12 months of historical data) |
+| Memory | 2 GB RAM |
+| Deployment target | Local machine, single VM, or single container |
 
-### Required Tools
+### External accounts and API keys
 
-```bash
-# Verify Python version
-python --version   # must be >= 3.10
+All required data sources are free or offer a free tier. Obtain credentials before proceeding.
 
-# Verify pip
-pip --version
+| Source | Purpose | Where to register |
+|---|---|---|
+| Alpha Vantage | WTI / Brent spot and futures prices | <https://www.alphavantage.co/support/#api-key> |
+| MetalpriceAPI | Commodity price fallback | <https://metalpriceapi.com> |
+| Polygon.io | Options chains (strike, expiry, IV, volume) | <https://polygon.io> |
+| EIA API | Weekly inventory and refinery utilisation | <https://www.eia.gov/opendata/> |
+| NewsAPI | News and geopolitical event feed | <https://newsapi.org> |
+| GDELT | Geopolitical event data | No key required (public dataset) |
+| SEC EDGAR | Insider trade filings | No key required (public dataset) |
+| Quiver Quant | Structured insider activity | <https://www.quiverquant.com> |
+| MarineTraffic | Tanker flow data (free tier) | <https://www.marinetraffic.com/en/online-services/plans> |
+| Reddit API | Retail sentiment (PRAW) | <https://www.reddit.com/prefs/apps> |
+| Stocktwits | Narrative / sentiment velocity | <https://api.stocktwits.com/developers/apps/new> |
 
-# (Optional but recommended) Verify Docker if running containerised
-docker --version
+> **Tip:** Yahoo Finance / `yfinance` requires no API key and is used for ETF and equity prices as well as an options-data fallback.
+
+### Python dependencies
+
+The project uses a `requirements.txt` file. Core dependencies include:
+
+```
+yfinance
+requests
+pandas
+numpy
+python-dotenv
+schedule
 ```
 
-### API Accounts
-
-You will need free-tier (or limited) accounts for the following services before configuring the pipeline:
-
-| Service | Purpose | Tier needed | Sign-up URL |
-|---|---|---|---|
-| Alpha Vantage | WTI / Brent spot & futures | Free | https://www.alphavantage.co |
-| Polygon.io | Options chains (strike, expiry, IV, volume) | Free / Limited | https://polygon.io |
-| EIA API | Inventory & refinery utilization | Free | https://www.eia.gov/opendata |
-| NewsAPI | News & geopolitical events | Free | https://newsapi.org |
-| GDELT | Geopolitical event stream | Free | https://www.gdeltproject.org |
-| SEC EDGAR | Insider activity | Free | https://efts.sec.gov/LATEST/search-index |
-| Quiver Quant | Insider activity (supplemental) | Free / Limited | https://www.quiverquant.com |
-| MarineTraffic | Tanker / shipping flows | Free tier | https://www.marinetraffic.com |
-| Reddit API | Narrative / sentiment | Free | https://www.reddit.com/dev/api |
-| Stocktwits | Narrative / sentiment | Free | https://api.stocktwits.com |
-
-> `yfinance` (Yahoo Finance) does not require an API key. GDELT is publicly accessible without registration.
+Install them after cloning the repository (see [Setup & Configuration](#setup--configuration)).
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows PowerShell
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the provided template and populate it with your credentials:
+Copy the sample environment file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value. The table below documents all recognised environment variables.
+Open `.env` in your editor and fill in every value marked `REQUIRED`.
 
-#### Environment Variables Reference
+#### Full environment variable reference
 
-| Variable | Required | Default | Description |
+| Variable | Required | Description | Example value |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for crude price feeds (WTI, Brent) |
-| `POLYGON_API_KEY` | Yes | — | API key for options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA supply / inventory data |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI news & geo events |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider data (Phase 3) |
-| `MARINE_TRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flows (Phase 3) |
-| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth client ID (Phase 3) |
-| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth client secret (Phase 3) |
-| `STOCKTWITS_ACCESS_TOKEN` | No | — | Stocktwits API access token (Phase 3) |
-| `DATA_STORE_PATH` | No | `./data` | Local path for persisted raw and derived data |
-| `OUTPUT_PATH` | No | `./output` | Directory where JSON candidate files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_REFRESH_INTERVAL` | No | `60` | Minutes-level polling interval (seconds) for market data |
-| `HISTORICAL_RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
-| `PHASE` | No | `1` | Active MVP phase: `1`, `2`, or `3` (controls which agents are enabled) |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | Crude price feed (WTI, Brent) | `ABC123XYZ` |
+| `METALPRICE_API_KEY` | Optional | Fallback commodity price feed | `def456uvw` |
+| `POLYGON_API_KEY` | ✅ | Options chains (strike, expiry, IV, volume) | `ghi789rst` |
+| `EIA_API_KEY` | ✅ | Weekly supply / inventory data | `jkl012mno` |
+| `NEWS_API_KEY` | ✅ | News and geopolitical events | `pqr345stu` |
+| `QUIVER_QUANT_API_KEY` | Optional | Structured insider activity data | `vwx678yza` |
+| `MARINETRAFFIC_API_KEY` | Optional | Tanker flow / shipping logistics | `bcd901efg` |
+| `REDDIT_CLIENT_ID` | Optional | Reddit PRAW app client ID | `hij234klm` |
+| `REDDIT_CLIENT_SECRET` | Optional | Reddit PRAW app client secret | `nop567qrs` |
+| `REDDIT_USER_AGENT` | Optional | Reddit PRAW user agent string | `energy-agent/1.0` |
+| `STOCKTWITS_API_KEY` | Optional | Stocktwits sentiment feed | `tuv890wxy` |
+| `DATA_DIR` | ✅ | Path for persisted historical data | `./data` |
+| `OUTPUT_DIR` | ✅ | Path for JSON output files | `./output` |
+| `LOG_LEVEL` | Optional | Logging verbosity (`DEBUG`, `INFO`, `WARNING`) | `INFO` |
+| `MARKET_DATA_INTERVAL_MINUTES` | Optional | Refresh cadence for market data | `5` |
+| `HISTORY_RETENTION_DAYS` | Optional | Days of historical data to retain | `365` |
+| `EDGE_SCORE_THRESHOLD` | Optional | Minimum edge score to include in output | `0.20` |
 
-> Variables marked **No** are only required when running the corresponding MVP phase. The pipeline will log a warning and skip that data source if a key is absent, without failing.
+> **Optional vs. required:** Variables marked Optional correspond to Phase 2–3 data sources. The pipeline tolerates missing or delayed data without failing (see [Non-Functional Requirements](#non-functional-requirements-summary)). If a key is absent, the corresponding agent module is skipped and a warning is logged.
 
-#### Example `.env`
-
-```dotenv
-# --- Required ---
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# --- Phase 3 (optional) ---
-QUIVER_QUANT_API_KEY=
-MARINE_TRAFFIC_API_KEY=
-REDDIT_CLIENT_ID=
-REDDIT_CLIENT_SECRET=
-STOCKTWITS_ACCESS_TOKEN=
-
-# --- Pipeline settings ---
-DATA_STORE_PATH=./data
-OUTPUT_PATH=./output
-LOG_LEVEL=INFO
-MARKET_DATA_REFRESH_INTERVAL=60
-HISTORICAL_RETENTION_DAYS=365
-PHASE=1
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation script to create the local directory structure and seed the historical data store:
+### 5. Initialise the data directory
 
 ```bash
-python -m agent.init_store
+python -m agent.init_storage
+```
+
+This creates the `DATA_DIR` and `OUTPUT_DIR` folder structure and verifies write permissions before the first run.
+
+### 6. Verify connectivity
+
+Run the connectivity check to confirm that each configured API key is valid and reachable:
+
+```bash
+python -m agent.check_feeds
 ```
 
 Expected output:
 
 ```
-[INFO] Data store initialised at ./data
-[INFO] Output directory created at ./output
-[INFO] Historical retention set to 365 days
+[OK]  Alpha Vantage      — crude prices reachable
+[OK]  Polygon.io         — options chain reachable
+[OK]  EIA API            — inventory feed reachable
+[OK]  NewsAPI            — news feed reachable
+[SKIP] MarineTraffic     — key not configured, module disabled
+[SKIP] Reddit            — key not configured, module disabled
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Execution Sequence
+### Pipeline execution modes
+
+| Mode | Command | Use case |
+|---|---|---|
+| Single run | `python -m agent.run --once` | Ad-hoc evaluation; runs all four agents once and exits |
+| Scheduled loop | `python -m agent.run` | Continuous operation; market data refreshed on the configured minute cadence |
+| Individual agent | `python -m agent.<agent_module>` | Development and debugging of a single stage |
+
+### Single run (recommended for first-time users)
+
+```bash
+python -m agent.run --once
+```
+
+The pipeline executes the four agents in sequence:
 
 ```mermaid
 sequenceDiagram
-    participant User
     participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant Store as Data Store
-    participant Out as JSON Output
+    participant FS as File System (OUTPUT_DIR)
 
-    User->>CLI: python -m agent.run
-    CLI->>DIA: start ingestion cycle
-    DIA->>Store: write market state object
-    DIA-->>CLI: ingestion complete
-    CLI->>EDA: start event detection
-    EDA->>Store: read market state
-    EDA->>Store: write scored events
-    EDA-->>CLI: event detection complete
-    CLI->>FGA: start feature generation
-    FGA->>Store: read market state + events
-    FGA->>Store: write derived features
-    FGA-->>CLI: features ready
-    CLI->>SEA: start strategy evaluation
-    SEA->>Store: read all features
-    SEA->>Out: write ranked candidates
-    SEA-->>CLI: evaluation complete
-    CLI-->>User: pipeline run finished
+    CLI->>DIA: trigger run
+    DIA->>DIA: fetch crude, ETF, equity, options data
+    DIA-->>EDA: market state object
+    EDA->>EDA: scan news & geo feeds; score events
+    EDA-->>FGA: scored events + market state
+    FGA->>FGA: compute volatility gaps, curve steepness,\ndispersion, insider conviction,\nnarrative velocity, shock probability
+    FGA-->>SEA: derived features store
+    SEA->>SEA: evaluate long straddles, spreads,\ncalendar spreads; rank by edge score
+    SEA-->>FS: write ranked_candidates_<timestamp>.json
+    FS-->>CLI: run complete; exit 0
 ```
 
-### Running a Single Full Pipeline Pass
-
-Execute all four agents in sequence for one evaluation cycle:
+### Scheduled continuous run
 
 ```bash
 python -m agent.run
 ```
 
-This command:
-1. Runs the **Data Ingestion Agent** — fetches and normalises all configured feeds.
-2. Runs the **Event Detection Agent** — scores supply and geopolitical events.
-3. Runs the **Feature Generation Agent** — computes all derived signals.
-4. Runs the **Strategy Evaluation Agent** — ranks candidate opportunities.
+- Market data (crude, ETF, equity, options) refreshes every `MARKET_DATA_INTERVAL_MINUTES` minutes.
+- Slower feeds (EIA, EDGAR) refresh on a daily or weekly schedule automatically.
+- Press `Ctrl+C` to stop. In-progress runs complete before the process exits.
 
-Output is written to `$OUTPUT_PATH/candidates_<ISO8601_timestamp>.json`.
+### Running individual agents
 
-### Running in Continuous Mode
-
-To run the pipeline on a recurring cadence (respecting `MARKET_DATA_REFRESH_INTERVAL`):
+Useful when iterating on a single stage without re-fetching all data:
 
 ```bash
-python -m agent.run --continuous
+# Re-run only the Feature Generation Agent against cached market state
+python -m agent.feature_generation
+
+# Re-run only the Strategy Evaluation Agent against existing derived features
+python -m agent.strategy_evaluation
 ```
 
-The pipeline will loop indefinitely, sleeping between cycles. Press `Ctrl+C` to stop gracefully.
+### Useful CLI flags
 
-### Running Individual Agents
-
-Each agent can be invoked independently for debugging or incremental development:
-
-```bash
-# Data Ingestion Agent only
-python -m agent.ingestion
-
-# Event Detection Agent only (requires a valid market state in the store)
-python -m agent.events
-
-# Feature Generation Agent only (requires market state + events)
-python -m agent.features
-
-# Strategy Evaluation Agent only (requires features store to be populated)
-python -m agent.strategy
-```
-
-### Running with Docker
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run a single pass, mounting local data and output directories
-docker run --rm \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest
-
-# Run in continuous mode
-docker run --rm \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest --continuous
-```
-
-### Selecting the Active MVP Phase
-
-Set `PHASE` in `.env` to control which data sources and scoring layers are active:
-
-| `PHASE` value | Active capabilities |
+| Flag | Description |
 |---|---|
-| `1` | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
-| `2` | Phase 1 + EIA inventory/refinery data, GDELT/NewsAPI event detection, supply disruption indices |
-| `3` | Phase 2 + insider trades (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic), full edge scoring |
+| `--once` | Execute a single pipeline pass then exit |
+| `--dry-run` | Run the full pipeline but do not write output files |
+| `--log-level DEBUG` | Override `LOG_LEVEL` for this invocation |
+| `--output-dir <path>` | Override `OUTPUT_DIR` for this invocation |
+| `--min-edge <float>` | Override `EDGE_SCORE_THRESHOLD` for this invocation |
+
+Example combining flags:
+
+```bash
+python -m agent.run --once --log-level DEBUG --min-edge 0.30
+```
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output location
 
-Each pipeline run writes one JSON file to `$OUTPUT_PATH`:
+After each pipeline run, one JSON file is written to `OUTPUT_DIR`:
 
 ```
-./output/candidates_2026-03-15T14:32:00Z.json
+output/
+└── ranked_candidates_2026-03-15T14:32:00Z.json
 ```
 
-### Output Schema
+The filename encodes the UTC timestamp of the evaluation run.
 
-Each file contains a JSON array of **strategy candidate objects**. Every candidate has the following fields:
+### Output schema
+
+Each file contains a top-level array of strategy candidate objects.
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Option structure: `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current values |
+| `instrument` | string | Target instrument — e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | integer (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signals and their qualitative values |
 | `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example Output
+### Example output
 
 ```json
 [
@@ -383,37 +338,47 @@ Each file contains a JSON array of **strategy candidate objects**. Every candida
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
+    "expiration": 21,
+    "edge_score": 0.34,
     "signals": {
       "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "sector_dispersion": "widening"
+      "sector_dispersion": "high"
     },
     "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading the Edge Score
+### Reading the edge score
 
-| `edge_score` range | Suggested interpretation |
+| Edge score range | Interpretation |
 |---|---|
-| 0.70 – 1.00 | Strong signal confluence — worth close review |
-| 0.45 – 0.69 | Moderate confluence — monitor for confirmation |
-| 0.20 – 0.44 | Weak signal — low priority |
-| 0.00 – 0.19 | Minimal confluence — likely noise |
+| 0.60 – 1.00 | Strong signal confluence — multiple independent signals aligned |
+| 0.40 – 0.59 | Moderate confluence — worth reviewing contributing signals |
+| 0.20 – 0.39 | Weak signal — marginal opportunity, high uncertainty |
+| 0.00 – 0.19 | Below threshold — filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
 
-> The edge score is a composite heuristic, not a probability of profit. Always validate candidates against your own market view before acting.
+> The edge score is a heuristic composite in the MVP. It is designed to be explainable, not predictive in a statistically rigorous sense. Always review the `signals` map before acting on a candidate.
 
-### Signal Keys Reference
+### Reading the signals map
 
-| Signal key | Source agent | What it measures |
-|---|---|---|
-| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence (positive = IV underpriced) |
-| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the crude futures curve |
-| `sector_dispersion` | Feature Generation | Price divergence across energy equities and ETFs |
-| `insider_conviction_score` | Feature Generation | Aggregated insider buying/selling intensity (EDGAR/Quiver) |
-| `narrative_velocity` | Feature Generation | Rate of acceleration in energy-related headlines and retail posts |
-| `supply_shock_probability` | Feature Generation | Composite probability of an imminent supply disruption |
-| `tanker_disruption_index` | Event Detection | Severity of detected tanker route or
+| Signal key | What it measures |
+|---|---|
+| `volatility_gap` | Spread between realised and implied volatility; `positive` = IV underprices expected moves |
+| `futures_curve_steepness` | Contango / backwardation regime of the crude futures curve |
+| `sector_dispersion` | Cross-sector correlation breakdown indicating idiosyncratic energy moves |
+| `insider_conviction_score` | Aggregated executive trade activity (EDGAR / Quiver Quant) |
+| `narrative_velocity` | Acceleration of headline volume on the instrument (Reddit / Stocktwits / NewsAPI) |
+| `supply_shock_probability` | Composite probability of a near-term supply disruption |
+| `tanker_disruption_index` | Shipping flow anomalies at key chokepoints |
+
+### Consuming output downstream
+
+The JSON format is compatible with any JSON-capable dashboard. To load candidates into a thinkorswim-compatible watchlist, pipe the output through the provided helper:
+
+```bash
+python -m agent.export_tos --input output/ranked_candidates_2026-03-15T14:32:00Z.json
+```
+
+This writes a `.csv`

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full Energy Options Opportunity Agent pipeline from the command line.
+> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting the structured output it produces.
 
 ---
 
@@ -18,322 +18,232 @@
 
 ## Overview
 
-The Energy Options Opportunity Agent is a modular, autonomous Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical events, and alternative datasets, then produces **structured, ranked candidate options strategies**.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
 
-The system is composed of **four loosely coupled agents** that execute in a fixed, unidirectional sequence:
+The system is **advisory only** — it makes no trades. Output is a JSON-compatible list of candidate strategies, each carrying an `edge_score` and a map of the signals that contributed to it.
+
+### Four-Agent Pipeline
+
+Data flows unidirectionally through four loosely coupled agents that share a common market state object and a derived features store.
 
 ```mermaid
 flowchart LR
-    subgraph Pipeline
-        direction LR
-        A["🛢️ Data Ingestion Agent\n─────────────────\nFetch & Normalize\ncrude prices, ETFs,\nequities, options chains"]
-        B["📡 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nNews, disruptions,\nchokepoints, scores"]
-        C["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol gaps, curve steepness,\nnarrative velocity, etc."]
-        D["📊 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge scores, structures,\nexplainability signals"]
+    subgraph Ingestion ["① Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nStrike · Expiry · IV · Volume]
     end
 
-    RAW["Raw Feeds\n(prices, news,\nEIA, EDGAR,\nshipping)"]
-    OUT["Ranked Candidates\n(JSON output)"]
+    subgraph Events ["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT · NewsAPI]
+        B2[Supply / Inventory\nEIA API]
+        B3[Shipping\nMarineTraffic]
+        B4[Confidence & Intensity\nScoring]
+    end
 
-    RAW --> A --> B --> C --> D --> OUT
+    subgraph Features ["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealized vs Implied]
+        C2[Futures Curve Steepness]
+        C3[Sector Dispersion]
+        C4[Insider Conviction Score]
+        C5[Narrative Velocity]
+        C6[Supply Shock Probability]
+    end
 
-    style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
-    style B fill:#1e3a5f,color:#fff,stroke:#4a90d9
-    style C fill:#1e3a5f,color:#fff,stroke:#4a90d9
-    style D fill:#1e3a5f,color:#fff,stroke:#4a90d9
-    style RAW fill:#2d2d2d,color:#ccc,stroke:#666
-    style OUT fill:#1a4731,color:#fff,stroke:#2ecc71
+    subgraph Strategy ["④ Strategy Evaluation Agent"]
+        D1[Evaluate Eligible Structures\nStraddles · Spreads · Calendars]
+        D2[Compute Edge Scores]
+        D3[Ranked JSON Output]
+    end
+
+    Ingestion -->|Market State Object| Events
+    Events    -->|Scored Events| Features
+    Features  -->|Derived Signals| Strategy
+    Strategy  -->|candidates.json| Output[(Downstream\nDashboard /\nthinkorswim)]
 ```
 
-Each agent communicates through a **shared market state object** and a **derived features store**. Agents are independently deployable, so you can update or re-run any single stage without disrupting the rest of the pipeline.
+### In-Scope Instruments & Structures
 
-### In-scope instruments (MVP)
-
-| Category | Instruments |
+| Category | Items |
 |---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI |
 | ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
-
-### In-scope option structures (MVP)
-
-| Structure | Enum value |
-|---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
-
-> **Advisory only.** The system does not execute trades. All output is informational.
+| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
+| Option structures (MVP) | Long straddle, call spread, put spread, calendar spread |
 
 ---
 
 ## Prerequisites
 
-Before running the pipeline, ensure the following are in place.
-
-### System requirements
-
-| Requirement | Minimum |
+| Requirement | Minimum version / notes |
 |---|---|
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| pip | 23+ (ships with Python 3.10+) |
+| Git | Any recent version |
+| Operating system | Linux, macOS, or Windows (WSL2 recommended on Windows) |
+| Hardware | Single modest VM or laptop; no GPU required |
+| API keys | See [Setup & Configuration](#setup--configuration) |
 
-### Python dependencies
-
-Install dependencies from the project root:
+Install Python dependencies into a virtual environment:
 
 ```bash
+git clone https://github.com/your-org/energy-options-agent.git
+cd energy-options-agent
+
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
-
-Key packages the pipeline depends on include:
-
-| Package | Purpose |
-|---|---|
-| `yfinance` | ETF and equity price data (Yahoo Finance) |
-| `requests` | HTTP calls to Alpha Vantage, EIA, GDELT, EDGAR, NewsAPI |
-| `pandas` / `numpy` | Data normalization and feature computation |
-| `pydantic` | Market state and output schema validation |
-| `schedule` | Cadenced refresh loops |
-| `python-dotenv` | Loading environment variables from `.env` |
-
-### API accounts
-
-All required data sources are **free or low-cost**. Register for API keys before proceeding.
-
-| Source | Sign-up URL | Cost | Used by |
-|---|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free | Crude prices |
-| NewsAPI | https://newsapi.org/register | Free tier | News & geo events |
-| Polygon.io | https://polygon.io | Free/Limited | Options chains |
-| EIA API | https://www.eia.gov/opendata/ | Free | Supply/inventory data |
-| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider activity |
-| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider conviction |
-| MarineTraffic | https://www.marinetraffic.com/en/online-services/plans | Free tier | Tanker/shipping flows |
-
-> **Note:** `yfinance`, GDELT, Reddit (`praw`), and Stocktwits do not require API keys for basic access.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
-
-```bash
-git clone https://github.com/your-org/energy-options-agent.git
-cd energy-options-agent
-```
-
-### 2. Create and activate a virtual environment
-
-```bash
-python -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows
-```
-
-### 3. Install dependencies
-
-```bash
-pip install -r requirements.txt
-```
-
-### 4. Configure environment variables
-
-Copy the provided template and populate your credentials:
+All runtime behaviour is controlled through environment variables. Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in the values described in the table below.
+Then open `.env` in your editor.
 
-#### Environment variable reference
+### Environment Variables
 
-| Variable | Required | Description | Example |
+| Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | API key for crude price feeds (WTI, Brent) | `ABC123XYZ` |
-| `NEWSAPI_KEY` | ✅ | API key for news and geopolitical event feeds | `abc123def456` |
-| `POLYGON_API_KEY` | ✅ | API key for options chain data (strike, expiry, IV, volume) | `abc123...` |
-| `EIA_API_KEY` | ✅ | API key for EIA inventory and refinery utilization feeds | `abc123...` |
-| `QUIVER_QUANT_API_KEY` | ⬜ | API key for insider trade conviction scores (optional in Phase 1) | `qv_abc123` |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ | API key for tanker and shipping flow data (optional in Phase 1–2) | `mt_abc123` |
-| `OUTPUT_DIR` | ✅ | Directory where ranked candidate JSON files are written | `./output` |
-| `HISTORICAL_DATA_DIR` | ✅ | Directory for persisted raw and derived historical data | `./data/historical` |
-| `HISTORICAL_RETENTION_DAYS` | ⬜ | Days of historical data to retain (default: `365`) | `180` |
-| `MARKET_DATA_REFRESH_INTERVAL_SECONDS` | ⬜ | Refresh cadence for real-time price feeds (default: `60`) | `120` |
-| `LOG_LEVEL` | ⬜ | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`) | `DEBUG` |
-| `PIPELINE_PHASE` | ⬜ | Active MVP phase: `1`, `2`, `3` (default: `1`) | `2` |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed (WTI, Brent) |
+| `POLYGON_API_KEY` | No | — | Polygon.io key for options chain data (falls back to yfinance if unset) |
+| `NEWS_API_KEY` | No | — | NewsAPI.org key for headline ingestion |
+| `EIA_API_KEY` | Yes | — | U.S. Energy Information Administration API key (free, register at eia.gov) |
+| `MARINE_TRAFFIC_API_KEY` | No | — | MarineTraffic API key for tanker flow data (free tier supported) |
+| `QUIVER_QUANT_API_KEY` | No | — | Quiver Quantitative key for insider trade data |
+| `DATA_DIR` | No | `./data` | Directory for raw and derived historical data storage |
+| `OUTPUT_DIR` | No | `./output` | Directory where ranked `candidates.json` files are written |
+| `LOG_LEVEL` | No | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `MARKET_REFRESH_INTERVAL_SECONDS` | No | `60` | Cadence for market data polling (minutes-level recommended) |
+| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory/refinery data polling |
+| `HISTORY_RETENTION_DAYS` | No | `365` | Days of raw and derived data to retain for backtesting (180–365 recommended) |
+| `GDELT_ENABLED` | No | `true` | Set to `false` to disable GDELT geo-event ingestion |
+| `REDDIT_ENABLED` | No | `true` | Set to `false` to disable Reddit/Stocktwits sentiment ingestion |
+| `EDGE_SCORE_THRESHOLD` | No | `0.20` | Candidates with an edge score below this value are omitted from output |
+| `MAX_EXPIRATION_DAYS` | No | `90` | Maximum days-to-expiration considered when evaluating structures |
 
-A minimal `.env` for Phase 1 looks like this:
+> **Tip:** Variables marked *No* under Required are optional for MVP Phase 1. You can run a functional pipeline with only `ALPHA_VANTAGE_API_KEY` and `EIA_API_KEY` set.
 
-```dotenv
-ALPHA_VANTAGE_API_KEY=your_key_here
-NEWSAPI_KEY=your_key_here
-POLYGON_API_KEY=your_key_here
-EIA_API_KEY=your_key_here
+### Verifying Data-Source Connectivity
 
-OUTPUT_DIR=./output
-HISTORICAL_DATA_DIR=./data/historical
-LOG_LEVEL=INFO
-PIPELINE_PHASE=1
-```
-
-### 5. Initialise data directories
+Run the built-in connectivity check before your first full pipeline run:
 
 ```bash
-mkdir -p ./output ./data/historical
+python -m agent check-sources
 ```
 
-### 6. Verify configuration
-
-Run the built-in configuration check before the first full pipeline run:
-
-```bash
-python -m agent check-config
-```
-
-Expected output on success:
+Expected output when all configured sources are reachable:
 
 ```
-[✓] ALPHA_VANTAGE_API_KEY — reachable
-[✓] NEWSAPI_KEY — reachable
-[✓] POLYGON_API_KEY — reachable
-[✓] EIA_API_KEY — reachable
-[✓] OUTPUT_DIR — writable
-[✓] HISTORICAL_DATA_DIR — writable
-Configuration OK. Pipeline phase: 1
+[OK]  alpha_vantage       — crude prices (WTI, Brent)
+[OK]  yfinance            — ETF/equity prices (USO, XLE, XOM, CVX)
+[OK]  yfinance            — options chains (fallback active)
+[OK]  eia                 — supply/inventory data
+[SKIP] polygon            — POLYGON_API_KEY not set; using yfinance fallback
+[SKIP] marine_traffic     — MARINE_TRAFFIC_API_KEY not set
+[SKIP] quiver_quant       — QUIVER_QUANT_API_KEY not set
+[OK]  gdelt               — geo/news events
+[OK]  reddit              — narrative sentiment
 ```
+
+`[SKIP]` entries are non-fatal; those signal layers will be absent from edge score computation but will not stop the pipeline.
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline execution flow
+### Full Pipeline (All Four Agents)
 
-The four agents execute in strict sequence. Data flows unidirectionally — the output of each stage is the input of the next:
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant CLI as CLI / Scheduler
-    participant DI as Data Ingestion Agent
-    participant ED as Event Detection Agent
-    participant FG as Feature Generation Agent
-    participant SE as Strategy Evaluation Agent
-    participant FS as Features Store
-    participant OUT as JSON Output
-
-    CLI->>DI: Trigger run
-    DI->>DI: Fetch crude prices, ETFs,\nequities, options chains
-    DI->>FS: Write unified market state object
-    DI->>ED: Handoff (market state ready)
-
-    ED->>FS: Read market state
-    ED->>ED: Monitor news/geo feeds;\nassign confidence + intensity scores
-    ED->>FS: Write detected events
-
-    FG->>FS: Read market state + events
-    FG->>FG: Compute vol gaps, curve steepness,\nsector dispersion, narrative velocity,\ninsider conviction, supply shock prob
-    FG->>FS: Write derived features
-
-    SE->>FS: Read all derived features
-    SE->>SE: Evaluate eligible option structures;\ncompute edge scores;\nattach contributing signals
-    SE->>OUT: Write ranked candidates (JSON)
-    OUT-->>CLI: Return results
-```
-
-### Run modes
-
-#### Single run (one-shot)
-
-Executes the full four-agent pipeline once and writes results to `OUTPUT_DIR`.
+The standard entry point runs all agents in sequence and writes ranked candidates to `$OUTPUT_DIR`.
 
 ```bash
 python -m agent run
 ```
 
-#### Continuous mode (scheduled)
-
-Runs the pipeline on a repeating cadence. Market data is refreshed at the interval defined by `MARKET_DATA_REFRESH_INTERVAL_SECONDS`; slower feeds (EIA, EDGAR) refresh daily or weekly automatically.
+To override configuration inline without editing `.env`:
 
 ```bash
-python -m agent run --continuous
+EDGE_SCORE_THRESHOLD=0.30 python -m agent run
 ```
 
-#### Run a single agent in isolation
+### Run a Single Agent
 
-Each agent can be invoked independently for debugging or incremental updates. The agent reads from and writes to the shared features store.
+Each agent can be invoked independently for testing or incremental development.
 
 ```bash
-# Re-run only the Data Ingestion Agent
+# Agent 1 — fetch and normalise market data only
 python -m agent run --agent ingestion
 
-# Re-run only the Event Detection Agent
-python -m agent run --agent event-detection
+# Agent 2 — event detection (requires market state from Agent 1)
+python -m agent run --agent events
 
-# Re-run only the Feature Generation Agent
-python -m agent run --agent feature-generation
+# Agent 3 — feature generation (requires market state + scored events)
+python -m agent run --agent features
 
-# Re-run only the Strategy Evaluation Agent
-python -m agent run --agent strategy-evaluation
+# Agent 4 — strategy evaluation and ranking (requires derived features)
+python -m agent run --agent strategy
 ```
 
-#### Run a specific MVP phase
+### Scheduled / Continuous Mode
 
-Override the configured phase at runtime:
+To keep the pipeline running on its configured refresh cadence, use the `--loop` flag:
 
 ```bash
-python -m agent run --phase 2
+python -m agent run --loop
 ```
 
-| Phase | Name | What is active |
-|---|---|---|
-| `1` | Core Market Signals & Options | Crude benchmarks, USO/XLE prices, options surface analysis, long straddles and call/put spreads |
-| `2` | Supply & Event Augmentation | Phase 1 + EIA inventory, refinery utilization, GDELT/NewsAPI event detection, supply disruption indices |
-| `3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider trades, Reddit/Stocktwits narrative velocity, MarineTraffic shipping data, full cross-sector correlation |
+In loop mode the pipeline respects `MARKET_REFRESH_INTERVAL_SECONDS` for price/options data and `EIA_REFRESH_INTERVAL_HOURS` for slower supply feeds. Press `Ctrl+C` to stop gracefully.
 
-#### Common flags
+For production-style scheduling, use cron or a process supervisor:
 
-| Flag | Description |
-|---|---|
-| `--phase <1\|2\|3>` | Override active MVP phase |
-| `--continuous` | Run pipeline on a repeating schedule |
-| `--agent <name>` | Run a single named agent only |
-| `--output-dir <path>` | Override `OUTPUT_DIR` for this run |
-| `--log-level <level>` | Override `LOG_LEVEL` for this run |
-| `--dry-run` | Execute all pipeline logic but do not write output files |
+```cron
+# crontab example — run every 5 minutes during trading hours (UTC)
+*/5 13-21 * * 1-5 cd /opt/energy-options-agent && .venv/bin/python -m agent run >> logs/pipeline.log 2>&1
+```
+
+### Verbose / Debug Run
+
+```bash
+LOG_LEVEL=DEBUG python -m agent run
+```
+
+### Output Location
+
+After each successful run a timestamped file is written to `$OUTPUT_DIR`:
+
+```
+output/
+└── candidates_2026-03-15T14:32:00Z.json
+```
+
+The most recent run is also symlinked as `output/candidates_latest.json`.
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output Schema
 
-Each pipeline run writes one JSON file to `OUTPUT_DIR`, named with a UTC timestamp:
-
-```
-./output/candidates_2026-03-15T14:30:00Z.json
-```
-
-The file contains an array of **strategy candidate objects**, ranked in descending order of `edge_score`.
-
-### Output schema
+Each element in the output array represents one ranked strategy candidate.
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | `object` | Map of contributing signals and their states, for explainability |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument ticker, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | One of `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher = stronger signal confluence |
+| `signals` | `object` | Key/value map of contributing signals and their assessed states |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output file
+### Example Output
 
 ```json
 [
@@ -347,7 +257,7 @@ The file contains an array of **strategy candidate objects**, ranked in descendi
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:30:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   },
   {
     "instrument": "XLE",
@@ -355,37 +265,98 @@ The file contains an array of **strategy candidate objects**, ranked in descendi
     "expiration": 45,
     "edge_score": 0.31,
     "signals": {
-      "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
+      "volatility_gap": "positive",
       "sector_dispersion": "widening"
     },
-    "generated_at": "2026-03-15T14:30:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Understanding `edge_score`
+### Reading the Edge Score
 
-The `edge_score` is a composite float in the range `[0.0, 1.0]` that reflects the degree to which multiple independent signals align to suggest a mispricing opportunity.
-
-| Score range | Interpretation |
+| Edge Score Range | Interpretation |
 |---|---|
-| `0.00 – 0.20` | Weak or single-signal confluence; low conviction |
-| `0.21 – 0.40` | Moderate confluence; worth monitoring |
-| `0.41 – 0.60` | Strong multi-signal alignment; primary candidates for review |
-| `0.61 – 1.00` | Very strong confluence; highest-priority candidates |
+| `0.00 – 0.19` | Weak confluence; filtered out by default (`EDGE_SCORE_THRESHOLD`) |
+| `0.20 – 0.39` | Moderate signal alignment; worth monitoring |
+| `0.40 – 0.59` | Strong signal confluence; primary candidates for further review |
+| `0.60 – 1.00` | Very strong confluence; highest priority for manual analysis |
 
-> **Important:** `edge_score` reflects signal alignment, not a prediction of profitability. All output is advisory. No automated trade execution occurs.
+> **Important:** A high `edge_score` reflects signal confluence, not a guaranteed profitable trade. Always apply your own risk assessment before entering any position.
 
-### Understanding the `signals` map
+### Signal Reference
 
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Common signal keys and their possible states are listed below.
+| Signal Key | What it Measures |
+|---|---|
+| `volatility_gap` | Spread between realized and implied volatility; `positive` means IV is low relative to realized vol |
+| `futures_curve_steepness` | Degree of contango or backwardation in the WTI/Brent curve |
+| `sector_dispersion` | Divergence between energy sub-sectors (e.g. XOM vs. XLE) |
+| `insider_conviction_score` | Aggregated intensity of recent insider buying/selling activity |
+| `narrative_velocity` | Acceleration of energy-related headlines and social mentions |
+| `supply_shock_probability` | Model probability of a near-term supply disruption event |
+| `tanker_disruption_index` | Shipping anomaly score derived from AIS/MarineTraffic data |
 
-| Signal key | Possible states | Source agent |
+### Consuming Output in thinkorswim or a Dashboard
+
+The JSON output is self-contained and can be loaded directly into any JSON-capable tool. For thinkorswim, import `candidates_latest.json` via the platform's **Scan** or custom scripting interface, mapping `instrument` → watchlist symbol and `edge_score` → sort column.
+
+---
+
+## Troubleshooting
+
+### Pipeline Fails to Start
+
+| Symptom | Likely Cause | Fix |
 |---|---|---|
-| `volatility_gap` | `positive`, `negative`, `neutral` | Feature Generation |
-| `futures_curve_steepness` | `steep`, `flat`, `inverted` | Feature Generation |
-| `sector_dispersion` | `widening`, `narrowing`, `stable` | Feature Generation |
-| `insider_conviction_score` | `high`, `moderate`, `low` | Feature Generation |
-| `narrative_velocity` | `rising`, `stable`, `falling` | Feature Generation |
-| `supply_shock_probability` | `elevated`,
+| `KeyError: ALPHA_VANTAGE_API_KEY` | Missing required env var | Ensure `.env` is populated and the shell has loaded it (`source .env` or use a tool like `direnv`) |
+| `ModuleNotFoundError` | Dependencies not installed | Confirm the virtual environment is active and `pip install -r requirements.txt` completed without errors |
+| `Permission denied: ./data` | `DATA_DIR` not writable | `mkdir -p data output && chmod 755 data output` |
+
+### Data Source Errors
+
+| Symptom | Likely Cause | Fix |
+|---|---|---|
+| `[WARN] alpha_vantage: rate limit exceeded` | Free-tier API limit hit | Increase `MARKET_REFRESH_INTERVAL_SECONDS` to `300` (5 min) or obtain a paid key |
+| `[WARN] eia: HTTP 403` | Invalid or expired EIA key | Regenerate key at [eia.gov/opendata](https://www.eia.gov/opendata/) |
+| `[WARN] yfinance: no options data for XOM` | Options chain temporarily unavailable | The pipeline tolerates missing data; the affected instrument is skipped for that run and retried on the next cycle |
+| `[WARN] gdelt: timeout` | GDELT endpoint unreachable | Set `GDELT_ENABLED=false` temporarily; geo-event signals will be absent but pipeline will continue |
+
+### Output is Empty or All Candidates Filtered
+
+```bash
+# Check what was generated before threshold filtering
+LOG_LEVEL=DEBUG python -m agent run --agent strategy
+```
+
+If the debug log shows candidates being discarded, your `EDGE_SCORE_THRESHOLD` may be too high for current market conditions.
+
+```bash
+# Lower the threshold for a single exploratory run
+EDGE_SCORE_THRESHOLD=0.10 python -m agent run
+```
+
+### Stale Output Timestamps
+
+If `generated_at` in the output is not advancing, the pipeline may be writing to a cached state. Clear the derived features store and re-run:
+
+```bash
+python -m agent clear-cache --features
+python -m agent run
+```
+
+> **Note:** `--features` clears only the derived signals cache. Raw historical price data in `$DATA_DIR` is not affected.
+
+### Data Retention and Storage Growth
+
+Historical raw and derived data defaults to 365 days (`HISTORY_RETENTION_DAYS`). If disk space is a concern, reduce this value:
+
+```bash
+HISTORY_RETENTION_DAYS=180 python -m agent run
+```
+
+The pipeline automatically purges records older than `HISTORY_RETENTION_DAYS` at the start of each run. A minimum of 180 days is recommended to support meaningful volatility and curve calculations.
+
+---
+
+> **Disclaimer:** The Energy Options Opportunity Agent is an informational tool only. It does not execute trades and does not constitute financial advice. All output should be reviewed by a qualified individual before any trading decision is made.

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> Advisory only. The system surfaces ranked options candidates; it does **not** execute trades.
+> Advisory only. The system surfaces ranked options opportunities; it does **not** place trades automatically.
 
 ---
 
@@ -18,45 +18,36 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and surfaces ranked options trading candidates. It is designed for a single developer running on local hardware or a low-cost cloud VM.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil-market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
 
 The pipeline is composed of four loosely coupled agents that execute in sequence:
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["1 · Data Ingestion Agent"]
-        A1[Crude Prices\nWTI · Brent]
-        A2[ETF / Equity\nUSO · XLE · XOM · CVX]
-        A3[Options Chains\nIV · Strike · Volume]
-    end
+    A([Raw Feeds]) --> B[Data Ingestion Agent\nFetch & Normalize]
+    B -->|Market State Object| C[Event Detection Agent\nSupply & Geo Signals]
+    C -->|Scored Events| D[Feature Generation Agent\nDerived Signal Computation]
+    D -->|Feature Store| E[Strategy Evaluation Agent\nOpportunity Ranking]
+    E --> F([JSON Output\nRanked Candidates])
 
-    subgraph Events["2 · Event Detection Agent"]
-        B1[News & Geo\nGDELT · NewsAPI]
-        B2[Supply / Inventory\nEIA API]
-        B3[Shipping\nMarineTraffic]
-        B4[Confidence &\nIntensity Scores]
-    end
-
-    subgraph Features["3 · Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs Implied]
-        C2[Futures Curve\nSteepness]
-        C3[Supply Shock\nProbability]
-        C4[Narrative Velocity\nInsider Conviction]
-    end
-
-    subgraph Strategy["4 · Strategy Evaluation Agent"]
-        D1[Eligible Structures\nStraddle · Spreads]
-        D2[Edge Score\n0.0 – 1.0]
-        D3[Ranked Candidates\nJSON Output]
-    end
-
-    Ingestion -->|market state object| Events
-    Events    -->|scored events| Features
-    Features  -->|derived signals| Strategy
-    Strategy  -->|candidates.json| Output[(Output\nJSON / Dashboard)]
+    style A fill:#f5f5f5,stroke:#999
+    style F fill:#f5f5f5,stroke:#999
+    style B fill:#dbeafe,stroke:#3b82f6
+    style C fill:#fef9c3,stroke:#ca8a04
+    style D fill:#dcfce7,stroke:#16a34a
+    style E fill:#fce7f3,stroke:#db2777
 ```
 
-### In-scope instruments
+| Agent | Role | Key Output |
+|---|---|---|
+| **Data Ingestion Agent** | Fetch & normalize prices, ETF/equity data, and options chains | Unified market state object |
+| **Event Detection Agent** | Monitor news and geopolitical feeds; score supply disruptions | Confidence- and intensity-scored event list |
+| **Feature Generation Agent** | Compute volatility gaps, curve steepness, narrative velocity, etc. | Derived features store |
+| **Strategy Evaluation Agent** | Evaluate eligible structures; rank by edge score | JSON array of ranked strategy candidates |
+
+Data flows **unidirectionally** through the agents. Each agent can be deployed and updated independently without disrupting the rest of the pipeline.
+
+### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
@@ -64,73 +55,71 @@ flowchart LR
 | ETFs | USO, XLE |
 | Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-scope option structures (MVP)
+### In-Scope Option Structures (MVP)
 
-| Structure | Enum value |
-|---|---|
-| Long straddle | `long_straddle` |
-| Call spread | `call_spread` |
-| Put spread | `put_spread` |
-| Calendar spread | `calendar_spread` |
-
-> **Out of scope (Phase 4 / future):** exotic or multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
+- Long straddles
+- Call / put spreads
+- Calendar spreads
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10 or later |
-| Operating system | Linux, macOS, or Windows (WSL recommended) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 5 GB free (6–12 months of historical data) |
-| Network | Outbound HTTPS to API endpoints |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to data provider endpoints |
 
-### Required tools
+### Required Tools
 
 ```bash
 # Verify Python version
-python --version          # must be >= 3.10
+python --version   # must be >= 3.10
 
 # Verify pip
 pip --version
 
-# Verify git
-git --version
+# (Recommended) Verify that venv is available
+python -m venv --help
 ```
 
-### API accounts
+### API Keys & Accounts
 
-The following free or freemium accounts are required. Register before proceeding.
+You must obtain credentials for the following services before running the pipeline. All tiers listed are **free or low-cost**.
 
-| Service | Used by | Tier needed | Sign-up URL |
+| Service | Used By | Sign-Up URL | Notes |
 |---|---|---|---|
-| Alpha Vantage | Data Ingestion (crude prices) | Free | https://www.alphavantage.co |
-| Yahoo Finance / yfinance | Data Ingestion (ETF, equity, options) | Free (no key needed) | — |
-| Polygon.io | Data Ingestion (options chains, fallback) | Free / Limited | https://polygon.io |
-| EIA API | Event Detection (supply / inventory) | Free | https://www.eia.gov/opendata |
-| GDELT | Event Detection (news / geo) | Free (no key needed) | — |
-| NewsAPI | Event Detection (news headlines) | Free | https://newsapi.org |
-| SEC EDGAR | Feature Generation (insider activity) | Free (no key needed) | — |
-| Quiver Quant | Feature Generation (insider conviction) | Free / Limited | https://www.quiverquant.com |
-| MarineTraffic | Feature Generation (shipping / tanker flows) | Free tier | https://www.marinetraffic.com |
-| Reddit API | Feature Generation (narrative sentiment) | Free | https://www.reddit.com/wiki/api |
+| Alpha Vantage | Crude prices (WTI, Brent) | <https://www.alphavantage.co/support/#api-key> | Free tier; rate-limited |
+| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required | Public API |
+| Polygon.io | Options data (fallback) | <https://polygon.io/> | Free tier available |
+| EIA API | Supply & inventory data | <https://www.eia.gov/opendata/> | Free; weekly cadence |
+| NewsAPI | News & geopolitical events | <https://newsapi.org/register> | Free developer tier |
+| GDELT | Geopolitical events | No key required | Public dataset |
+| SEC EDGAR | Insider activity | No key required | Public API |
+| Quiver Quant | Insider conviction scores | <https://www.quiverquant.com/> | Free/limited tier |
+| Reddit API | Narrative / sentiment | <https://www.reddit.com/prefs/apps> | Free; OAuth2 app required |
+| Stocktwits | Narrative / sentiment | <https://api.stocktwits.com/> | Free public stream |
+| MarineTraffic | Shipping / tanker flows | <https://www.marinetraffic.com/> | Free tier available |
+
+> **Tip:** For the MVP (Phase 1), only **Alpha Vantage**, **yfinance**, and optionally **Polygon.io** are strictly required. Additional keys unlock Phase 2 and Phase 3 signals.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and activate a virtual environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
 python -m venv .venv
@@ -142,202 +131,187 @@ source .venv/bin/activate
 .venv\Scripts\Activate.ps1
 ```
 
-### 3. Install dependencies
+### 3. Install Dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure environment variables
+### 4. Configure Environment Variables
 
-Copy the provided template and populate your credentials:
+Copy the provided template and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value marked `REQUIRED`.
+Open `.env` in your editor and fill in the values described in the table below.
 
-#### Complete environment variable reference
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
-| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | ✅ | — | API key for EIA supply / inventory data |
-| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI headline feed |
-| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider data (Phase 3) |
-| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
-| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit app client ID for sentiment feed (Phase 3) |
-| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit app client secret (Phase 3) |
-| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | Reddit API user-agent string (Phase 3) |
-| `DATA_DIR` | ⬜ | `./data` | Root directory for raw and derived data storage |
-| `OUTPUT_DIR` | ⬜ | `./output` | Directory where `candidates.json` is written |
-| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
-| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Days of historical data to retain on disk |
-| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`3`); gates which agents are enabled |
-| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score for a candidate to appear in output |
-| `TZ` | ⬜ | `UTC` | Timezone for all timestamps; strongly recommended to leave as `UTC` |
+| `ALPHA_VANTAGE_API_KEY` | ✅ Phase 1 | — | API key for Alpha Vantage crude price feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options data fallback |
+| `EIA_API_KEY` | ✅ Phase 2 | — | API key for EIA supply & inventory feed |
+| `NEWS_API_KEY` | ✅ Phase 2 | — | API key for NewsAPI geopolitical/news feed |
+| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
+| `REDDIT_CLIENT_ID` | ✅ Phase 3 | — | Reddit OAuth2 application client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ Phase 3 | — | Reddit OAuth2 application client secret |
+| `REDDIT_USER_AGENT` | ✅ Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `MARINETRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic shipping feed |
+| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Polling interval for market data feeds (minutes cadence) |
+| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `PHASE` | No | `1` | Active pipeline phase (`1`–`3`); controls which agents and signals are enabled |
 
-> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` already excludes it.
-
-#### Example `.env` (Phase 1)
+Example `.env` for a Phase 1 run:
 
 ```dotenv
-# --- Required ---
+# === Phase 1 — Core Market Signals ===
 ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=your_polygon_key_here
-EIA_API_KEY=your_eia_key_here
-NEWS_API_KEY=your_newsapi_key_here
+POLYGON_API_KEY=                        # optional fallback
+EIA_API_KEY=                            # required for Phase 2+
+NEWS_API_KEY=                           # required for Phase 2+
 
-# --- Optional overrides ---
-DATA_DIR=./data
+PHASE=1
+DATA_REFRESH_INTERVAL_MINUTES=5
+HISTORY_RETENTION_DAYS=365
 OUTPUT_DIR=./output
 LOG_LEVEL=INFO
-PIPELINE_PHASE=1
-EDGE_SCORE_THRESHOLD=0.30
-TZ=UTC
 ```
 
-### 5. Initialise the data store
+> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` excludes it by default.
 
-Creates the directory structure and seeds the SQLite database used for historical storage:
+### 5. Initialise the Database
+
+The pipeline stores historical raw and derived data locally (sized for 6–12 months of history):
 
 ```bash
-python -m agent init
+python manage.py init-db
 ```
 
 Expected output:
 
 ```
-[INFO] Data directory created at ./data
-[INFO] Output directory created at ./output
-[INFO] Historical database initialised (retention: 365 days)
-[INFO] Initialisation complete.
+[INFO] Initialising database at ./data/market_state.db ...
+[INFO] Schema applied. Historical data retention set to 365 days.
+[INFO] Done.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline phases
-
-Set `PIPELINE_PHASE` in `.env` to control which agents are active:
-
-| Phase | Name | Active agents / signals |
-|---|---|---|
-| `1` | Core Market Signals & Options | Data Ingestion, Feature Generation (IV / volatility gap, curve steepness), Strategy Evaluation |
-| `2` | Supply & Event Augmentation | Adds Event Detection (EIA inventory, GDELT/NewsAPI), supply disruption indices |
-| `3` | Alternative / Contextual Signals | Adds insider conviction (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic) |
-
-### Single run (one-shot)
-
-Executes the full pipeline once and writes `candidates.json` to `OUTPUT_DIR`:
-
-```bash
-python -m agent run
-```
-
-### Continuous mode (polling)
-
-Runs the pipeline on the cadence defined by `MARKET_DATA_INTERVAL_MINUTES`:
-
-```bash
-python -m agent run --continuous
-```
-
-Stop with <kbd>Ctrl</kbd>+<kbd>C</kbd>. The pipeline handles partial or missing data gracefully and will not crash on a failed upstream fetch.
-
-### Run a specific agent only
-
-Each agent can be invoked independently for testing or incremental development:
-
-```bash
-# Data Ingestion only
-python -m agent run --agent ingestion
-
-# Event Detection only
-python -m agent run --agent events
-
-# Feature Generation only
-python -m agent run --agent features
-
-# Strategy Evaluation only (reads from cached feature store)
-python -m agent run --agent strategy
-```
-
-### Override output path
-
-```bash
-python -m agent run --output /tmp/my_candidates.json
-```
-
-### Dry run (no disk writes)
-
-Runs the full pipeline and prints output to stdout without writing files:
-
-```bash
-python -m agent run --dry-run
-```
-
-### Pipeline execution flow (sequence)
+### Pipeline Execution Flow
 
 ```mermaid
 sequenceDiagram
-    participant CLI as CLI / Scheduler
+    participant CLI as User / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS  as Feature Store (disk)
-    participant OUT as Output (candidates.json)
+    participant FS as File System (JSON Output)
 
-    CLI->>DIA: trigger run
-    DIA->>DIA: fetch crude, ETF, equity, options chain
-    DIA->>FS: write normalised market state
-    DIA->>EDA: market state ready
-
-    EDA->>EDA: scan news, geo, EIA, shipping
-    EDA->>EDA: assign confidence & intensity scores
-    EDA->>FS: write scored events
-
-    FGA->>FS: read market state + events
-    FGA->>FGA: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock prob.
-    FGA->>FS: write derived features
-
-    SEA->>FS: read derived features
-    SEA->>SEA: evaluate eligible structures
-    SEA->>SEA: compute edge scores & rank candidates
-    SEA->>OUT: write candidates.json
-    SEA->>CLI: run complete
+    CLI->>DIA: python run_pipeline.py --phase 1
+    DIA->>DIA: Fetch crude, ETF/equity prices & options chains
+    DIA->>EDA: market_state object
+    EDA->>EDA: Score news / geo events (confidence + intensity)
+    EDA->>FGA: scored_events + market_state
+    FGA->>FGA: Compute volatility gaps, curve steepness, etc.
+    FGA->>SEA: derived_features store
+    SEA->>SEA: Evaluate structures; rank by edge_score
+    SEA->>FS: Write ranked_candidates_<timestamp>.json
+    FS-->>CLI: Pipeline complete ✓
 ```
+
+### Single Run
+
+Execute one full pass of the pipeline:
+
+```bash
+python run_pipeline.py
+```
+
+To override the active phase without editing `.env`:
+
+```bash
+python run_pipeline.py --phase 2
+```
+
+To specify a custom output directory for this run:
+
+```bash
+python run_pipeline.py --output-dir /tmp/pipeline-out
+```
+
+### Continuous (Polling) Mode
+
+Run the pipeline on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence:
+
+```bash
+python run_pipeline.py --continuous
+```
+
+Press `Ctrl+C` to stop. The pipeline will finish the current cycle before exiting cleanly.
+
+### Running Individual Agents
+
+Each agent can be executed independently for development or debugging:
+
+```bash
+# Data Ingestion only
+python -m agents.data_ingestion
+
+# Event Detection only (requires a saved market state)
+python -m agents.event_detection --state ./output/market_state_latest.json
+
+# Feature Generation only
+python -m agents.feature_generation --state ./output/market_state_latest.json
+
+# Strategy Evaluation only
+python -m agents.strategy_evaluation --features ./output/features_latest.json
+```
+
+### Phase-by-Phase Feature Availability
+
+| Phase | Name | Signals Enabled | Additional Keys Needed |
+|---|---|---|---|
+| 1 | Core Market Signals & Options | Crude prices, ETF/equity prices, IV surface, long straddles, call/put spreads | `ALPHA_VANTAGE_API_KEY` |
+| 2 | Supply & Event Augmentation | + EIA inventory, refinery utilisation, GDELT/NewsAPI event detection, supply disruption indices | `EIA_API_KEY`, `NEWS_API_KEY` |
+| 3 | Alternative / Contextual Signals | + Insider trades, narrative velocity (Reddit/Stocktwits), shipping data, cross-sector correlation | `REDDIT_CLIENT_ID/SECRET`, optionally `QUIVER_QUANT_API_KEY`, `MARINETRAFFIC_API_KEY` |
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output File Location
+
+After each pipeline run, a timestamped JSON file is written to `OUTPUT_DIR`:
 
 ```
-./output/candidates.json
+./output/ranked_candidates_2026-03-15T14:32:00Z.json
 ```
 
-The file contains a JSON array. Each element is one ranked strategy candidate.
+A symlink `ranked_candidates_latest.json` always points to the most recent file.
 
-### Output schema
+### Output Schema
+
+Each element in the output array represents one ranked strategy candidate:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher means stronger signal confluence |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; **higher = stronger signal confluence** |
 | `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example output
+### Example Output
 
 ```json
 [
@@ -354,69 +328,61 @@ The file contains a JSON array. Each element is one ranked strategy candidate.
     "generated_at": "2026-03-15T14:32:00Z"
   },
   {
-    "instrument": "XLE",
+    "instrument": "XOM",
     "structure": "call_spread",
-    "expiration": 21,
-    "edge_score": 0.38,
+    "expiration": 45,
+    "edge_score": 0.31,
     "signals": {
       "volatility_gap": "positive",
-      "futures_curve_steepness": "elevated",
-      "supply_shock_probability": "moderate"
+      "supply_shock_probability": "elevated",
+      "sector_dispersion": "high"
     },
     "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading edge scores
+### Reading the Edge Score
 
-| Edge score range | Interpretation | Suggested action |
+| Edge Score Range | Interpretation | Suggested Action |
 |---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High-priority candidate — review carefully |
-| `0.50 – 0.69` | Moderate confluence | Warrants further analysis |
-| `0.30 – 0.49` | Weak / marginal signal | Low confidence — treat as informational |
-| `< 0.30` | Below threshold | Filtered out by default (`EDGE_SCORE_THRESHOLD`) |
+| 0.70 – 1.00 | Strong signal confluence | High-priority candidate; review signals carefully |
+| 0.40 – 0.69 | Moderate confluence | Candidate worth monitoring; validate with additional research |
+| 0.10 – 0.39 | Weak confluence | Low-conviction signal; treat as background noise unless a specific thesis supports it |
+| 0.00 – 0.09 | Negligible | Discard |
 
-> The edge score is a heuristic composite; it is not a probability of profit. Always perform your own due diligence before placing a trade.
+> **Important:** The edge score is a heuristic composite, not a probability of profit. Always perform independent due diligence before placing any trade. The system is **advisory only**.
 
-### Signal reference
+### Signal Reference
 
-| Signal key | Description | Qualitative values |
+| Signal Key | Description | Source Agent |
 |---|---|---|
-| `volatility_gap` | Realised volatility vs. implied volatility differential | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | Slope of the oil futures term structure | `elevated`, `flat`, `inverted` |
-| `sector_dispersion` | Cross-sector correlation divergence | `high`, `moderate`, `low` |
-| `insider_conviction_score` | Aggregated insider trade activity (EDGAR/Quiver) | `high`, `moderate`, `low` |
-| `narrative_velocity` | Rate of change of energy-related headline / social volume | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | Modelled probability of near-term supply disruption | `high`, `moderate`, `low` |
-| `tanker_disruption_index` | Shipping / chokepoint anomaly score | `high`, `moderate`, `low` |
+| `volatility_gap` | Realised vs. implied volatility divergence | Feature Generation |
+| `futures_curve_steepness` | Contango / backwardation gradient | Feature Generation |
+| `sector_dispersion` | Spread between energy sub-sector moves | Feature Generation |
+| `insider_conviction_score` | Aggregated insider trading signal | Feature Generation |
+| `narrative_velocity` | Acceleration of energy-related headlines | Feature Generation |
+| `supply_shock_probability` | Modelled probability of a supply disruption | Feature Generation |
+| `tanker_disruption_index` | Shipping-flow anomaly score | Event Detection |
+| `refinery_outage_score` | Refinery utilisation deviation | Event Detection |
+| `geopolitical_intensity` | Geo-event confidence × intensity product | Event Detection |
 
-### Visualising output in thinkorswim
+### Visualisation
 
-The JSON output is designed to be consumed by any JSON-capable dashboard. For thinkorswim, import `candidates.json` via the platform's scripting interface or paste individual candidates into a watchlist notes field.
+The JSON output is compatible with **thinkorswim** or any JSON-capable dashboard. To load the latest candidates directly:
+
+```bash
+cat ./output/ranked_candidates_latest.json | python -m json.tool
+```
 
 ---
 
 ## Troubleshooting
 
-### General diagnostic commands
+### Common Issues
 
-```bash
-# Check environment variable loading
-python -m agent config check
-
-# Validate API connectivity for all configured sources
-python -m agent config test-connections
-
-# Print the current feature store snapshot
-python -m agent debug features
-
-# Print the last N log lines
-python -m agent logs --tail 50
-```
-
-### Common issues
-
-| Symptom | Likely cause | Resolution |
+| Symptom | Likely Cause | Resolution |
 |---|---|---|
-| `candidates.json` is empty | All candidates below `EDGE_SCORE_THRESHOLD` | Lower `EDGE_SCORE_THRESHOLD` in `.env` or check
+| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` not loaded or variable missing | Confirm `.env` exists in project root and contains the key; verify `python-dotenv` is installed |
+| `RateLimitError` from Alpha Vantage | Free-tier rate limit exceeded | Increase `DATA_REFRESH_INTERVAL_MINUTES`; consider caching raw responses |
+| Empty `ranked_candidates_*.json` | No candidates exceeded the minimum threshold | Check `LOG_LEVEL=DEBUG` output; verify market data was fetched

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through installing, configuring, and running the full pipeline end-to-end, and explains how to read and act on its output.
+> This guide walks a developer through installing, configuring, and running the full four-agent pipeline from a clean environment to ranked options candidates.
 
 ---
 
@@ -18,199 +18,203 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a four-agent Python pipeline that detects volatility mispricing in oil-related instruments and produces ranked, explainable options trading candidates.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
 
-### What the pipeline does
-
-| Stage | Agent | Input | Output |
-|---|---|---|---|
-| 1 | **Data Ingestion Agent** | Raw API feeds | Unified market state object |
-| 2 | **Event Detection Agent** | Market state + news/geo feeds | Scored supply & geopolitical events |
-| 3 | **Feature Generation Agent** | Market state + event scores | Derived signal set |
-| 4 | **Strategy Evaluation Agent** | Derived signals | Ranked candidate opportunities (JSON) |
-
-Data flows **unidirectionally** through the agents via a shared market state object and a derived features store. No stage writes back to an earlier stage.
+The pipeline is composed of four loosely coupled agents that execute in sequence, communicating through a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
-    subgraph Feeds["External Feeds"]
-        F1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        F2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        F3[Options Chains\nYahoo Finance / Polygon.io]
-        F4[Supply & Inventory\nEIA API]
-        F5[News & Geo Events\nGDELT / NewsAPI]
-        F6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        F7[Shipping & Logistics\nMarineTraffic / VesselFinder]
-        F8[Narrative & Sentiment\nReddit / Stocktwits]
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
+        A8[Narrative & Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Pipeline["Agent Pipeline"]
-        A1["🟦 Data Ingestion Agent\nFetch & Normalize"]
-        A2["🟨 Event Detection Agent\nSupply & Geo Signals"]
-        A3["🟩 Feature Generation Agent\nDerived Signal Computation"]
-        A4["🟥 Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Pipeline
+        direction TB
+        P1["① Data Ingestion Agent\nFetch & Normalize"]
+        P2["② Event Detection Agent\nSupply & Geo Signals"]
+        P3["③ Feature Generation Agent\nDerived Signal Computation"]
+        P4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Store["Shared State"]
-        MS[(Market State\nObject)]
-        FS[(Derived\nFeatures Store)]
+    subgraph Output
+        O1[Ranked Candidates\nJSON / Dashboard]
     end
 
-    subgraph Output["Output"]
-        JSON[Ranked Candidates\nJSON]
-    end
+    A1 & A2 & A3 --> P1
+    A4 & A5      --> P1
+    A6 & A7 & A8 --> P1
 
-    F1 & F2 & F3 & F4 --> A1
-    F5 --> A2
-    F6 & F7 & F8 --> A3
-
-    A1 -->|writes| MS
-    MS -->|reads| A2
-    A2 -->|scored events| MS
-    MS -->|reads| A3
-    A3 -->|writes| FS
-    FS -->|reads| A4
-    A4 --> JSON
+    P1 -->|market state object| P2
+    P2 -->|scored events| P3
+    P3 -->|derived features| P4
+    P4 --> O1
 ```
 
-### In-scope instruments (MVP)
+### Agent Responsibilities
 
-| Category | Instruments |
-|---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
+| # | Agent | Role | Key Outputs |
+|---|-------|------|-------------|
+| 1 | **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical store |
+| 2 | **Event Detection Agent** | Supply & Geo Signals | Events with confidence and intensity scores |
+| 3 | **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
+| 4 | **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
 
-### In-scope option structures (MVP)
-
-`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
-
-> **Advisory only.** Automated trade execution is out of scope. All output is for informational purposes.
+> **Advisory only.** The pipeline surfaces opportunities; it does **not** execute trades automatically.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
-|---|---|
+|-------------|---------|
 | Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL2 recommended on Windows) |
+| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| Network | Outbound HTTPS to API endpoints |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS to data-source APIs |
 
-### Required tools
+### Required Tools
 
 ```bash
 # Verify Python version
-python --version   # must be >= 3.10
+python --version        # should print 3.10.x or later
 
 # Verify pip
 pip --version
 
-# Optional but recommended: create an isolated environment
-python -m venv .venv
-source .venv/bin/activate      # Linux / macOS
-# .venv\Scripts\activate       # Windows PowerShell
+# Verify git
+git --version
 ```
 
-### API accounts
+### API Access
 
-Obtain free (or free-tier) credentials from the following providers before proceeding. All are zero-cost for MVP usage.
+You need free-tier (or low-cost) accounts for the data sources used by each pipeline phase. Register for the services you intend to use before proceeding.
 
-| Provider | Used by | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | Crude prices | https://www.alphavantage.co/support/#api-key |
-| MetalpriceAPI | Crude prices (fallback) | https://metalpriceapi.com |
-| Polygon.io | Options chains | https://polygon.io |
-| EIA API | Supply & inventory | https://www.eia.gov/opendata/ |
-| NewsAPI | News & geo events | https://newsapi.org |
-| Quiver Quant | Insider activity | https://www.quiverquant.com |
-| MarineTraffic | Shipping & logistics | https://www.marinetraffic.com/en/p/api-services |
+| Data Source | Registration URL | Cost | Notes |
+|-------------|-----------------|------|-------|
+| Alpha Vantage | https://www.alphavantage.co | Free | WTI, Brent spot/futures |
+| MetalpriceAPI | https://metalpriceapi.com | Free | Crude price fallback |
+| Polygon.io | https://polygon.io | Free/Limited | Options chains |
+| EIA API | https://www.eia.gov/opendata | Free | Inventory, refinery utilization |
+| NewsAPI | https://newsapi.org | Free | Geopolitical news events |
+| GDELT | https://www.gdeltproject.org | Free | No key required |
+| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider filings |
+| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider trade scores |
+| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flows |
+| VesselFinder | https://www.vesselfinder.com | Free tier | Tanker flow fallback |
+| Reddit API | https://www.reddit.com/prefs/apps | Free | Narrative sentiment |
+| Stocktwits | https://api.stocktwits.com | Free | Retail sentiment |
 
-> `yfinance`, GDELT, SEC EDGAR, Reddit, and Stocktwits do not require API keys for basic access.
+> **Phase dependency:** API keys are required incrementally by MVP phase. See [MVP Phasing](#mvp-phasing-and-enabling-agents) for details.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the repository
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Install dependencies
+### 2. Create and Activate a Virtual Environment
 
 ```bash
+python -m venv .venv
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
+```
+
+### 3. Install Dependencies
+
+```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 3. Configure environment variables
+### 4. Configure Environment Variables
 
-The pipeline reads all secrets and tuneable parameters from environment variables. The recommended approach is to copy the provided template and edit it in place.
+All runtime configuration is supplied through environment variables. Copy the provided template and fill in your values:
 
 ```bash
 cp .env.example .env
-# then open .env in your editor of choice
 ```
 
-#### Full environment variable reference
+Then open `.env` in your editor and populate the values described in the table below.
+
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
-|---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | No | — | Fallback crude price key (MetalpriceAPI) |
-| `POLYGON_API_KEY` | No | — | Polygon.io key for options chain data |
-| `EIA_API_KEY` | Yes | — | EIA Open Data API key for supply/inventory |
-| `NEWS_API_KEY` | Yes | — | NewsAPI key for news & geopolitical events |
-| `QUIVER_API_KEY` | No | — | Quiver Quant key for insider conviction data |
-| `MARINETRAFFIC_API_KEY` | No | — | MarineTraffic API key for tanker flow data |
-| `DATA_DIR` | No | `./data` | Root directory for persisted market state and historical data |
-| `OUTPUT_DIR` | No | `./output` | Directory where ranked candidate JSON files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for minute-level market data feeds |
-| `OPTIONS_DATA_INTERVAL_HOURS` | No | `24` | Polling cadence for options chain data (daily feeds) |
-| `EIA_INTERVAL_HOURS` | No | `168` | Polling cadence for EIA inventory data (weekly = 168 h) |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain for backtesting support |
-| `MIN_EDGE_SCORE` | No | `0.20` | Minimum `edge_score` threshold; candidates below this are suppressed |
-| `TARGET_INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to evaluate |
-| `TARGET_STRUCTURES` | No | `long_straddle,call_spread,put_spread,calendar_spread` | Comma-separated list of option structures to evaluate |
-| `TIMEZONE` | No | `UTC` | Timezone for all timestamps in output (`UTC` strongly recommended) |
+|----------|----------|---------|-------------|
+| `ALPHA_VANTAGE_API_KEY` | Phase 1 | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Optional | — | Fallback crude price key (MetalpriceAPI) |
+| `POLYGON_API_KEY` | Phase 1 | — | Polygon.io key for options chain data |
+| `EIA_API_KEY` | Phase 2 | — | EIA Open Data API key for supply/inventory |
+| `NEWSAPI_KEY` | Phase 2 | — | NewsAPI key for geopolitical news events |
+| `QUIVER_API_KEY` | Phase 3 | — | Quiver Quant key for insider conviction data |
+| `MARINETRAFFIC_API_KEY` | Phase 3 | — | MarineTraffic key for tanker flow data |
+| `REDDIT_CLIENT_ID` | Phase 3 | — | Reddit OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | Phase 3 | — | Reddit OAuth client secret |
+| `REDDIT_USER_AGENT` | Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
+| `STOCKTWITS_API_KEY` | Phase 3 | — | Stocktwits API key for retail sentiment |
+| `DATA_DIR` | All | `./data` | Directory for persisted raw and derived data |
+| `OUTPUT_DIR` | All | `./output` | Directory where JSON candidate files are written |
+| `LOG_LEVEL` | All | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `MARKET_DATA_INTERVAL_MIN` | All | `5` | Polling interval in minutes for market price feeds |
+| `HISTORY_RETENTION_DAYS` | All | `365` | Days of historical data to retain (180–365 recommended) |
+| `PIPELINE_PHASE` | All | `1` | Active MVP phase (`1`–`4`); gates which agents and sources are enabled |
+| `INSTRUMENTS` | All | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to track |
+| `OPTIONS_EXPIRY_WINDOW_DAYS` | All | `90` | Maximum calendar days to expiration for candidate options |
+| `EDGE_SCORE_THRESHOLD` | All | `0.25` | Minimum edge score for a candidate to appear in output |
 
-#### Example `.env` file
+#### Example `.env` File
 
 ```dotenv
-# === Required API keys ===
+# ── Core keys (Phase 1) ───────────────────────────────────────────────────
 ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# === Optional API keys ===
 POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+
+# ── Supply & event keys (Phase 2) ────────────────────────────────────────
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWSAPI_KEY=YOUR_NEWSAPI_KEY_HERE
+
+# ── Alternative signal keys (Phase 3) ────────────────────────────────────
 QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
 MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
+REDDIT_CLIENT_ID=YOUR_REDDIT_ID
+REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_API_KEY=YOUR_ST_KEY_HERE
 
-# === Storage ===
+# ── Pipeline behaviour ────────────────────────────────────────────────────
+PIPELINE_PHASE=1
 DATA_DIR=./data
 OUTPUT_DIR=./output
-HISTORY_RETENTION_DAYS=365
-
-# === Pipeline behaviour ===
-MARKET_DATA_INTERVAL_MINUTES=5
-OPTIONS_DATA_INTERVAL_HOURS=24
-EIA_INTERVAL_HOURS=168
-MIN_EDGE_SCORE=0.20
 LOG_LEVEL=INFO
-TIMEZONE=UTC
+MARKET_DATA_INTERVAL_MIN=5
+HISTORY_RETENTION_DAYS=365
+INSTRUMENTS=USO,XLE,XOM,CVX,CL=F,BZ=F
+OPTIONS_EXPIRY_WINDOW_DAYS=90
+EDGE_SCORE_THRESHOLD=0.25
 ```
 
-### 4. Initialise the data store
+### 5. Initialise the Data Store
 
-Run the initialisation command once to create the required directory structure and seed the historical data store:
+Run the initialisation command to create the required directory structure and empty database tables before the first pipeline run:
 
 ```bash
 python -m agent init
@@ -219,148 +223,140 @@ python -m agent init
 Expected output:
 
 ```
-[INFO] Creating data directory at ./data
-[INFO] Creating output directory at ./output
-[INFO] Historical store initialised (retention: 365 days)
-[INFO] Init complete.
+[INFO] Data directory created: ./data
+[INFO] Output directory created: ./output
+[INFO] Historical store initialised (SQLite): ./data/market_history.db
+[INFO] Initialisation complete.
 ```
+
+### MVP Phasing and Enabling Agents
+
+The `PIPELINE_PHASE` variable gates which data sources and agents are active. Increment the phase only after the corresponding API keys are configured.
+
+| Phase | Name | What is enabled |
+|-------|------|-----------------|
+| `1` | Core Market Signals & Options | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
+| `2` | Supply & Event Augmentation | EIA inventory, refinery utilisation, event detection via GDELT/NewsAPI, supply disruption indices |
+| `3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, cross-sector correlation; full edge score |
+| `4` | High-Fidelity Enhancements | OPIS or regional refined pricing (paid), exotic/multi-legged structures, execution integration |
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline phases
+### Single On-Demand Run
 
-The pipeline ships with support for the four MVP phases. You can run a specific phase or the full stack. Phases build on each other — running Phase 3 implicitly requires Phases 1 and 2 to have run at least once.
-
-| Phase flag | Name | What it enables |
-|---|---|---|
-| `--phase 1` | Core Market Signals & Options | Crude/ETF prices, options surface, straddle & spread strategies |
-| `--phase 2` | Supply & Event Augmentation | EIA inventory, GDELT/NewsAPI event detection, event-driven scoring |
-| `--phase 3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, full edge scoring |
-| `--phase 4` | High-Fidelity Enhancements | Reserved for future paid data sources and exotic structures |
-
-### Single run (one-shot)
-
-Execute the full pipeline once and write results to `OUTPUT_DIR`:
+Execute all four agents once in sequence and write candidates to `OUTPUT_DIR`:
 
 ```bash
 python -m agent run
 ```
 
-Run only through Phase 2:
+The pipeline stages run in order and log their progress to stdout:
 
-```bash
-python -m agent run --phase 2
+```
+[INFO] ── Stage 1/4: Data Ingestion Agent ──────────────────────────────
+[INFO] Fetching WTI spot price          ... OK (Alpha Vantage)
+[INFO] Fetching Brent spot price        ... OK (Alpha Vantage)
+[INFO] Fetching options chain: USO      ... OK (Polygon.io)
+[INFO] Fetching options chain: XLE      ... OK (Polygon.io)
+[INFO] Market state object written      ... ./data/market_state.json
+
+[INFO] ── Stage 2/4: Event Detection Agent ─────────────────────────────
+[INFO] Scanning GDELT for energy events ... 3 events detected
+[INFO] Events scored and stored         ... ./data/events.json
+
+[INFO] ── Stage 3/4: Feature Generation Agent ──────────────────────────
+[INFO] Computing volatility gaps        ... done
+[INFO] Computing futures curve steepness... done
+[INFO] Computing supply shock probability... done
+[INFO] Derived features written         ... ./data/features.json
+
+[INFO] ── Stage 4/4: Strategy Evaluation Agent ─────────────────────────
+[INFO] Evaluating option structures     ... 12 candidates scored
+[INFO] Candidates above threshold (0.25): 4
+[INFO] Output written                   ... ./output/candidates_20260315T143002Z.json
+[INFO] Pipeline complete.
 ```
 
-Run a single named agent in isolation (useful for debugging):
+### Running a Single Agent in Isolation
+
+Each agent can be run independently for debugging or incremental updates:
 
 ```bash
-python -m agent run --agent ingestion
-python -m agent run --agent event_detection
-python -m agent run --agent feature_generation
-python -m agent run --agent strategy_evaluation
+# Run only the Data Ingestion Agent
+python -m agent run --stage ingest
+
+# Run only the Event Detection Agent
+python -m agent run --stage events
+
+# Run only the Feature Generation Agent
+python -m agent run --stage features
+
+# Run only the Strategy Evaluation Agent
+python -m agent run --stage strategy
 ```
 
-### Continuous mode (scheduled polling)
+### Continuous / Scheduled Mode
 
-Run the pipeline continuously, respecting the cadence variables defined in `.env`:
+To poll market feeds at the configured `MARKET_DATA_INTERVAL_MIN` cadence and re-evaluate strategies on each tick:
 
 ```bash
 python -m agent run --continuous
 ```
 
-In continuous mode the scheduler honours:
-- `MARKET_DATA_INTERVAL_MINUTES` for fast feeds (prices)
-- `OPTIONS_DATA_INTERVAL_HOURS` for options chains
-- `EIA_INTERVAL_HOURS` for supply/inventory data
+> **Tip:** For production use, consider running in a container or behind a process supervisor (e.g., `systemd`, `supervisord`, or a cron job) rather than relying on the built-in loop.
 
-Stop with `Ctrl+C`; the pipeline completes its current cycle before exiting.
+#### Example cron schedule (Linux)
 
-### Running inside Docker (recommended for production)
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run one-shot with your .env file mounted
-docker run --rm \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest run
-
-# Run in continuous mode
-docker run -d \
-  --name energy-agent \
-  --env-file .env \
-  -v "$(pwd)/data:/app/data" \
-  -v "$(pwd)/output:/app/output" \
-  energy-options-agent:latest run --continuous
+```cron
+# Run the full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
+*/5 9-17 * * 1-5 /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
 ```
 
-### Typical run sequence (what the pipeline does internally)
+### Dry-Run Mode
 
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Market State / Feature Store
-    participant Out as JSON Output
+Validate configuration and connectivity without writing any output files:
 
-    CLI->>DIA: trigger run
-    DIA->>Store: fetch raw feeds; write normalised market state
-    DIA-->>CLI: ingestion complete
+```bash
+python -m agent run --dry-run
+```
 
-    CLI->>EDA: trigger run
-    EDA->>Store: read market state; read news/geo feeds
-    EDA->>Store: write scored events (confidence + intensity)
-    EDA-->>CLI: event detection complete
+### Overriding Configuration at the Command Line
 
-    CLI->>FGA: trigger run
-    FGA->>Store: read market state + scored events
-    FGA->>Store: write derived features\n(vol gap, curve steepness, dispersion,\ninsider score, narrative velocity,\nsupply shock probability)
-    FGA-->>CLI: feature generation complete
+Any environment variable can be overridden inline for a single run:
 
-    CLI->>SEA: trigger run
-    SEA->>Store: read derived features
-    SEA->>Out: write ranked candidate JSON\n(instrument, structure, expiration,\nedge_score, signals, generated_at)
-    SEA-->>CLI: strategy evaluation complete
+```bash
+PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output file location
+### Output File Location
 
-Each pipeline run produces a timestamped JSON file in `OUTPUT_DIR`:
+Each run appends a timestamped JSON file to `OUTPUT_DIR`:
 
 ```
 output/
-└── candidates_2026-03-15T14:32:00Z.json
+└── candidates_20260315T143002Z.json
 ```
 
-A `latest.json` symlink always points to the most recent run.
+### Output Schema
 
-### Output schema
-
-Each element in the output array is a **strategy candidate** with the following fields:
+Each file contains a JSON array of candidate objects. The fields are:
 
 | Field | Type | Description |
-|---|---|---|
+|-------|------|-------------|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | `integer` (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signal names to their qualitative levels |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example output
+### Example Candidate Output
 
 ```json
 [
@@ -374,37 +370,12 @@ Each element in the output array is a **strategy candidate** with the following 
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:30:02Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 21,
+    "expiration": 45,
     "edge_score": 0.31,
     "signals": {
-      "supply_shock_probability": "elevated",
-      "volatility_gap": "positive",
-      "eia_inventory_draw": "above_average"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
-```
-
-### Reading the edge score
-
-| `edge_score` range | Interpretation | Suggested action |
-|---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High-priority candidate; review all contributing signals |
-| `0.40 – 0.69` | Moderate confluence | Candidate warrants further analysis |
-| `0.20 – 0.39` | Weak / marginal signal | Low conviction; monitor only |
-| `< 0.20` | Below threshold | Suppressed by default (`MIN_EDGE_SCORE`) |
-
-> The `edge_score` is a composite heuristic, not a probability of profit. It reflects the degree to which multiple independent signals agree that a mispricing opportunity may exist.
-
-### Reading the signals map
-
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent:
-
-| Signal key | Description |
-|---|---|
+      "volatility_gap": "positive

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide walks you through configuring, running, and interpreting results from the full four-agent pipeline. It assumes you are comfortable with Python and the command line but are new to this project.
+> This guide walks you through installing, configuring, and running the full Energy Options Opportunity Agent pipeline from the command line.
 
 ---
 
@@ -18,302 +18,295 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
+The Energy Options Opportunity Agent is a modular, autonomous Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, geopolitical events, and alternative datasets, then produces **structured, ranked candidate options strategies**.
 
-### What the pipeline does
-
-| Stage | Agent | Output |
-|---|---|---|
-| **1 · Ingest** | Data Ingestion Agent | Unified market state object |
-| **2 · Detect** | Event Detection Agent | Scored supply / geopolitical events |
-| **3 · Derive** | Feature Generation Agent | Volatility gaps, curve metrics, shock probabilities |
-| **4 · Rank** | Strategy Evaluation Agent | Ranked opportunities with edge scores |
-
-### In-scope instruments (MVP)
-
-| Class | Symbols |
-|---|---|
-| Crude futures | Brent, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy equities | XOM, CVX |
-
-### In-scope option structures (MVP)
-
-`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
-
-> **Advisory only.** The system produces ranked recommendations; it does **not** execute trades automatically.
-
----
-
-### Pipeline Architecture
+The system is composed of **four loosely coupled agents** that execute in a fixed, unidirectional sequence:
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[(Crude / ETF\nPrices)]
-        A2[(Options\nChains)]
-        A3[(EIA Supply\nData)]
-        A4[(News /\nGDELT)]
-        A5[(Insider /\nShipping /\nSentiment)]
+    subgraph Pipeline
+        direction LR
+        A["🛢️ Data Ingestion Agent\n─────────────────\nFetch & Normalize\ncrude prices, ETFs,\nequities, options chains"]
+        B["📡 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nNews, disruptions,\nchokepoints, scores"]
+        C["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol gaps, curve steepness,\nnarrative velocity, etc."]
+        D["📊 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge scores, structures,\nexplainability signals"]
     end
 
-    subgraph Agent_1["① Data Ingestion Agent"]
-        B[Fetch & Normalize\nAll Feeds]
-    end
+    RAW["Raw Feeds\n(prices, news,\nEIA, EDGAR,\nshipping)"]
+    OUT["Ranked Candidates\n(JSON output)"]
 
-    subgraph Agent_2["② Event Detection Agent"]
-        C[Detect Supply Disruptions\nGeopolitical Events\nScore Confidence / Intensity]
-    end
+    RAW --> A --> B --> C --> D --> OUT
 
-    subgraph Agent_3["③ Feature Generation Agent"]
-        D[Compute Derived Signals\nVol Gap · Curve · Dispersion\nInsider · Narrative · Shock Prob]
-    end
-
-    subgraph Agent_4["④ Strategy Evaluation Agent"]
-        E[Evaluate Option Structures\nRank by Edge Score\nAttach Signal References]
-    end
-
-    subgraph Output
-        F[(JSON Candidates\nfor Dashboard /\nthinkorswim)]
-    end
-
-    A1 & A2 & A3 & A4 & A5 --> B
-    B -->|market_state| C
-    C -->|event_scores| D
-    D -->|features_store| E
-    E --> F
+    style A fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style B fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style C fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style D fill:#1e3a5f,color:#fff,stroke:#4a90d9
+    style RAW fill:#2d2d2d,color:#ccc,stroke:#666
+    style OUT fill:#1a4731,color:#fff,stroke:#2ecc71
 ```
 
-Data flows **unidirectionally**. Each agent is independently deployable; a failure in one agent degrades output quality but does not crash the pipeline.
+Each agent communicates through a **shared market state object** and a **derived features store**. Agents are independently deployable, so you can update or re-run any single stage without disrupting the rest of the pipeline.
+
+### In-scope instruments (MVP)
+
+| Category | Instruments |
+|---|---|
+| Crude futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
+
+### In-scope option structures (MVP)
+
+| Structure | Enum value |
+|---|---|
+| Long straddle | `long_straddle` |
+| Call spread | `call_spread` |
+| Put spread | `put_spread` |
+| Calendar spread | `calendar_spread` |
+
+> **Advisory only.** The system does not execute trades. All output is informational.
 
 ---
 
 ## Prerequisites
 
+Before running the pipeline, ensure the following are in place.
+
 ### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10 or later |
-| RAM | 2 GB available |
-| Disk | 5 GB free (grows with retained history) |
 | OS | Linux, macOS, or Windows (WSL2 recommended) |
-| Deployment target | Local machine, single VM, or Docker container |
-
-### External accounts & API keys
-
-All primary data sources are free or have a usable free tier.
-
-| Source | Used for | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | WTI / Brent spot prices | <https://www.alphavantage.co/support/#api-key> |
-| yfinance / Yahoo Finance | ETF & equity prices, options chains | No key required |
-| Polygon.io *(optional)* | Higher-quality options data | <https://polygon.io> |
-| EIA API | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
-| GDELT | News & geopolitical events | No key required |
-| NewsAPI *(optional)* | Supplemental news feed | <https://newsapi.org> |
-| SEC EDGAR | Insider activity | No key required |
-| Quiver Quant *(optional)* | Parsed insider trades | <https://www.quiverquant.com> |
-| MarineTraffic / VesselFinder | Tanker flow data | Free tier at respective sites |
-| Reddit | Retail sentiment | No key required (public API) |
-| Stocktwits | Narrative velocity | No key required (public API) |
+| Python | 3.10 or later |
+| RAM | 2 GB |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
 ### Python dependencies
+
+Install dependencies from the project root:
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Core libraries expected in `requirements.txt`:
+Key packages the pipeline depends on include:
 
-```text
-yfinance>=0.2
-requests>=2.31
-pandas>=2.0
-numpy>=1.26
-python-dotenv>=1.0
-schedule>=1.2
-```
+| Package | Purpose |
+|---|---|
+| `yfinance` | ETF and equity price data (Yahoo Finance) |
+| `requests` | HTTP calls to Alpha Vantage, EIA, GDELT, EDGAR, NewsAPI |
+| `pandas` / `numpy` | Data normalization and feature computation |
+| `pydantic` | Market state and output schema validation |
+| `schedule` | Cadenced refresh loops |
+| `python-dotenv` | Loading environment variables from `.env` |
+
+### API accounts
+
+All required data sources are **free or low-cost**. Register for API keys before proceeding.
+
+| Source | Sign-up URL | Cost | Used by |
+|---|---|---|---|
+| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free | Crude prices |
+| NewsAPI | https://newsapi.org/register | Free tier | News & geo events |
+| Polygon.io | https://polygon.io | Free/Limited | Options chains |
+| EIA API | https://www.eia.gov/opendata/ | Free | Supply/inventory data |
+| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider activity |
+| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider conviction |
+| MarineTraffic | https://www.marinetraffic.com/en/online-services/plans | Free tier | Tanker/shipping flows |
+
+> **Note:** `yfinance`, GDELT, Reddit (`praw`), and Stocktwits do not require API keys for basic access.
 
 ---
 
 ## Setup & Configuration
 
-### 1 · Clone the repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2 · Create a virtual environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
 source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows PowerShell
+# .venv\Scripts\activate         # Windows
+```
+
+### 3. Install dependencies
+
+```bash
 pip install -r requirements.txt
 ```
 
-### 3 · Create the environment file
+### 4. Configure environment variables
 
-Copy the provided template and fill in your values:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and populate each variable (see table below).
+Open `.env` in your editor and fill in the values described in the table below.
 
-### 4 · Environment variables reference
+#### Environment variable reference
 
-| Variable | Required | Default | Description |
+| Variable | Required | Description | Example |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | **Yes** | — | API key for crude price feeds |
-| `EIA_API_KEY` | **Yes** | — | API key for EIA inventory & refinery data |
-| `POLYGON_API_KEY` | No | — | Higher-quality options chain data (falls back to yfinance if unset) |
-| `NEWS_API_KEY` | No | — | NewsAPI key for supplemental news (GDELT used if unset) |
-| `QUIVER_QUANT_API_KEY` | No | — | Parsed insider trade data (falls back to raw EDGAR if unset) |
-| `MARINE_TRAFFIC_API_KEY` | No | — | Tanker flow data from MarineTraffic |
-| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes) |
-| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA data polling (hours) |
-| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for insider data polling (hours) |
-| `HISTORY_RETENTION_DAYS` | No | `180` | Days of raw and derived history to retain (180–365 recommended) |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `LOG_LEVEL` | No | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F` | Comma-separated list of instruments to monitor |
-| `EDGE_SCORE_THRESHOLD` | No | `0.30` | Minimum edge score for a candidate to be included in output |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | API key for crude price feeds (WTI, Brent) | `ABC123XYZ` |
+| `NEWSAPI_KEY` | ✅ | API key for news and geopolitical event feeds | `abc123def456` |
+| `POLYGON_API_KEY` | ✅ | API key for options chain data (strike, expiry, IV, volume) | `abc123...` |
+| `EIA_API_KEY` | ✅ | API key for EIA inventory and refinery utilization feeds | `abc123...` |
+| `QUIVER_QUANT_API_KEY` | ⬜ | API key for insider trade conviction scores (optional in Phase 1) | `qv_abc123` |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ | API key for tanker and shipping flow data (optional in Phase 1–2) | `mt_abc123` |
+| `OUTPUT_DIR` | ✅ | Directory where ranked candidate JSON files are written | `./output` |
+| `HISTORICAL_DATA_DIR` | ✅ | Directory for persisted raw and derived historical data | `./data/historical` |
+| `HISTORICAL_RETENTION_DAYS` | ⬜ | Days of historical data to retain (default: `365`) | `180` |
+| `MARKET_DATA_REFRESH_INTERVAL_SECONDS` | ⬜ | Refresh cadence for real-time price feeds (default: `60`) | `120` |
+| `LOG_LEVEL` | ⬜ | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` (default: `INFO`) | `DEBUG` |
+| `PIPELINE_PHASE` | ⬜ | Active MVP phase: `1`, `2`, `3` (default: `1`) | `2` |
 
-**Example `.env`:**
+A minimal `.env` for Phase 1 looks like this:
 
 ```dotenv
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-EIA_API_KEY=your_eia_key_here
+ALPHA_VANTAGE_API_KEY=your_key_here
+NEWSAPI_KEY=your_key_here
+POLYGON_API_KEY=your_key_here
+EIA_API_KEY=your_key_here
 
-# Optional — remove or leave blank to use free fallbacks
-POLYGON_API_KEY=
-NEWS_API_KEY=
-QUIVER_QUANT_API_KEY=
-MARINE_TRAFFIC_API_KEY=
-
-# Tuning
-DATA_REFRESH_INTERVAL_MINUTES=5
-EIA_REFRESH_INTERVAL_HOURS=24
-EDGAR_REFRESH_INTERVAL_HOURS=24
-HISTORY_RETENTION_DAYS=180
 OUTPUT_DIR=./output
+HISTORICAL_DATA_DIR=./data/historical
 LOG_LEVEL=INFO
-INSTRUMENTS=USO,XLE,XOM,CVX,CL=F
-EDGE_SCORE_THRESHOLD=0.30
+PIPELINE_PHASE=1
 ```
 
-### 5 · Verify configuration
+### 5. Initialise data directories
 
 ```bash
-python -m agent.cli check-config
+mkdir -p ./output ./data/historical
 ```
 
-Expected output:
+### 6. Verify configuration
 
-```
-[✓] ALPHA_VANTAGE_API_KEY  — set
-[✓] EIA_API_KEY            — set
-[!] POLYGON_API_KEY        — not set (fallback: yfinance)
-[!] NEWS_API_KEY           — not set (fallback: GDELT)
-[!] QUIVER_QUANT_API_KEY   — not set (fallback: EDGAR)
-[!] MARINE_TRAFFIC_API_KEY — not set (fallback: disabled)
-Configuration valid. Ready to run.
-```
-
-Items marked `[!]` are optional; the pipeline continues with free fallbacks.
-
-### 6 · Initialise the data store
-
-Run the one-time bootstrap to create local storage directories and seed historical data:
+Run the built-in configuration check before the first full pipeline run:
 
 ```bash
-python -m agent.cli bootstrap
+python -m agent check-config
 ```
 
-This may take several minutes on first run as it fetches historical prices required for volatility and curve calculations.
+Expected output on success:
+
+```
+[✓] ALPHA_VANTAGE_API_KEY — reachable
+[✓] NEWSAPI_KEY — reachable
+[✓] POLYGON_API_KEY — reachable
+[✓] EIA_API_KEY — reachable
+[✓] OUTPUT_DIR — writable
+[✓] HISTORICAL_DATA_DIR — writable
+Configuration OK. Pipeline phase: 1
+```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline flow (setup sequence)
+### Pipeline execution flow
+
+The four agents execute in strict sequence. Data flows unidirectionally — the output of each stage is the input of the next:
 
 ```mermaid
 sequenceDiagram
-    participant User
-    participant CLI
-    participant Ingestion as Data Ingestion Agent
-    participant Events as Event Detection Agent
-    participant Features as Feature Generation Agent
-    participant Strategy as Strategy Evaluation Agent
-    participant Store as Output Store
+    autonumber
+    participant CLI as CLI / Scheduler
+    participant DI as Data Ingestion Agent
+    participant ED as Event Detection Agent
+    participant FG as Feature Generation Agent
+    participant SE as Strategy Evaluation Agent
+    participant FS as Features Store
+    participant OUT as JSON Output
 
-    User->>CLI: python -m agent.cli run
-    CLI->>Ingestion: fetch_and_normalize()
-    Ingestion-->>CLI: market_state
-    CLI->>Events: detect_events(market_state)
-    Events-->>CLI: event_scores
-    CLI->>Features: generate_features(market_state, event_scores)
-    Features-->>CLI: features_store
-    CLI->>Strategy: evaluate_strategies(features_store)
-    Strategy-->>CLI: ranked_candidates[]
-    CLI->>Store: write_output(ranked_candidates)
-    Store-->>User: ./output/candidates_<timestamp>.json
+    CLI->>DI: Trigger run
+    DI->>DI: Fetch crude prices, ETFs,\nequities, options chains
+    DI->>FS: Write unified market state object
+    DI->>ED: Handoff (market state ready)
+
+    ED->>FS: Read market state
+    ED->>ED: Monitor news/geo feeds;\nassign confidence + intensity scores
+    ED->>FS: Write detected events
+
+    FG->>FS: Read market state + events
+    FG->>FG: Compute vol gaps, curve steepness,\nsector dispersion, narrative velocity,\ninsider conviction, supply shock prob
+    FG->>FS: Write derived features
+
+    SE->>FS: Read all derived features
+    SE->>SE: Evaluate eligible option structures;\ncompute edge scores;\nattach contributing signals
+    SE->>OUT: Write ranked candidates (JSON)
+    OUT-->>CLI: Return results
 ```
 
-### Single pipeline run
+### Run modes
 
-Execute one complete pass through all four agents and write results to `OUTPUT_DIR`:
+#### Single run (one-shot)
+
+Executes the full four-agent pipeline once and writes results to `OUTPUT_DIR`.
 
 ```bash
-python -m agent.cli run
+python -m agent run
 ```
 
-### Continuous (scheduled) run
+#### Continuous mode (scheduled)
 
-Run the pipeline on a recurring schedule driven by `DATA_REFRESH_INTERVAL_MINUTES`:
+Runs the pipeline on a repeating cadence. Market data is refreshed at the interval defined by `MARKET_DATA_REFRESH_INTERVAL_SECONDS`; slower feeds (EIA, EDGAR) refresh daily or weekly automatically.
 
 ```bash
-python -m agent.cli run --continuous
+python -m agent run --continuous
 ```
 
-Stop with **Ctrl + C**. The scheduler respects the slower cadences configured for EIA and EDGAR feeds automatically.
+#### Run a single agent in isolation
 
-### Run a single agent in isolation
-
-Each agent can be invoked independently for testing or debugging:
+Each agent can be invoked independently for debugging or incremental updates. The agent reads from and writes to the shared features store.
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent.cli run --agent ingestion
+# Re-run only the Data Ingestion Agent
+python -m agent run --agent ingestion
 
-# Run only the Event Detection Agent (requires existing market_state)
-python -m agent.cli run --agent events
+# Re-run only the Event Detection Agent
+python -m agent run --agent event-detection
 
-# Run only the Feature Generation Agent (requires market_state + event_scores)
-python -m agent.cli run --agent features
+# Re-run only the Feature Generation Agent
+python -m agent run --agent feature-generation
 
-# Run only the Strategy Evaluation Agent (requires features_store)
-python -m agent.cli run --agent strategy
+# Re-run only the Strategy Evaluation Agent
+python -m agent run --agent strategy-evaluation
 ```
 
-### Command reference
+#### Run a specific MVP phase
 
-| Command | Description |
+Override the configured phase at runtime:
+
+```bash
+python -m agent run --phase 2
+```
+
+| Phase | Name | What is active |
+|---|---|---|
+| `1` | Core Market Signals & Options | Crude benchmarks, USO/XLE prices, options surface analysis, long straddles and call/put spreads |
+| `2` | Supply & Event Augmentation | Phase 1 + EIA inventory, refinery utilization, GDELT/NewsAPI event detection, supply disruption indices |
+| `3` | Alternative / Contextual Signals | Phase 2 + EDGAR/Quiver insider trades, Reddit/Stocktwits narrative velocity, MarineTraffic shipping data, full cross-sector correlation |
+
+#### Common flags
+
+| Flag | Description |
 |---|---|
-| `check-config` | Validate environment variables and API key reachability |
-| `bootstrap` | Initialise data store and seed historical data (run once) |
-| `run` | Execute a single pipeline pass |
-| `run --continuous` | Execute on a repeating schedule |
-| `run --agent <name>` | Execute a single agent in isolation |
-| `run --dry-run` | Run all agents but suppress writing output files |
-| `run --instruments XOM,CVX` | Override `INSTRUMENTS` for this run only |
-| `run --log-level DEBUG` | Override `LOG_LEVEL` for this run only |
+| `--phase <1\|2\|3>` | Override active MVP phase |
+| `--continuous` | Run pipeline on a repeating schedule |
+| `--agent <name>` | Run a single named agent only |
+| `--output-dir <path>` | Override `OUTPUT_DIR` for this run |
+| `--log-level <level>` | Override `LOG_LEVEL` for this run |
+| `--dry-run` | Execute all pipeline logic but do not write output files |
 
 ---
 
@@ -321,26 +314,23 @@ python -m agent.cli run --agent strategy
 
 ### Output location
 
-Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR` (default `./output`):
+Each pipeline run writes one JSON file to `OUTPUT_DIR`, named with a UTC timestamp:
 
 ```
-./output/
-  candidates_2026-03-15T14:32:00Z.json
-  candidates_2026-03-15T14:37:00Z.json
-  ...
+./output/candidates_2026-03-15T14:30:00Z.json
 ```
+
+The file contains an array of **strategy candidate objects**, ranked in descending order of `edge_score`.
 
 ### Output schema
 
-Each file contains an array of **candidate objects**. Every candidate has the following fields:
-
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | enum | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | integer (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | float `[0.0 – 1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
-| `signals` | object | Map of contributing signals and their qualitative levels |
+| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; **higher = stronger signal confluence** |
+| `signals` | `object` | Map of contributing signals and their states, for explainability |
 | `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
 ### Example output file
@@ -357,54 +347,45 @@ Each file contains an array of **candidate objects**. Every candidate has the fo
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:30:00Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
     "expiration": 45,
-    "edge_score": 0.38,
+    "edge_score": 0.31,
     "signals": {
+      "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "futures_curve_steepness": "steep",
-      "sector_dispersion": "high"
+      "sector_dispersion": "widening"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
+    "generated_at": "2026-03-15T14:30:00Z"
   }
 ]
 ```
 
-### Reading the `edge_score`
+### Understanding `edge_score`
 
-| Score range | Interpretation | Suggested action |
+The `edge_score` is a composite float in the range `[0.0, 1.0]` that reflects the degree to which multiple independent signals align to suggest a mispricing opportunity.
+
+| Score range | Interpretation |
+|---|---|
+| `0.00 – 0.20` | Weak or single-signal confluence; low conviction |
+| `0.21 – 0.40` | Moderate confluence; worth monitoring |
+| `0.41 – 0.60` | Strong multi-signal alignment; primary candidates for review |
+| `0.61 – 1.00` | Very strong confluence; highest-priority candidates |
+
+> **Important:** `edge_score` reflects signal alignment, not a prediction of profitability. All output is advisory. No automated trade execution occurs.
+
+### Understanding the `signals` map
+
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Common signal keys and their possible states are listed below.
+
+| Signal key | Possible states | Source agent |
 |---|---|---|
-| `0.70 – 1.00` | Strong signal confluence | High priority for review |
-| `0.50 – 0.69` | Moderate confluence | Worth evaluating with additional context |
-| `0.30 – 0.49` | Weak but notable signal | Monitor; revisit on next run |
-| `< 0.30` | Below threshold | Filtered out by default (see `EDGE_SCORE_THRESHOLD`) |
-
-> **Note:** Edge scores are computed from heuristic functions in the MVP. They indicate relative opportunity strength within this run; they are **not** a guarantee of profitability.
-
-### Reading the `signals` map
-
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Qualitative values indicate direction or intensity:
-
-| Signal key | What it measures | Values |
-|---|---|---|
-| `volatility_gap` | Realized vs. implied volatility divergence | `positive` · `negative` · `neutral` |
-| `futures_curve_steepness` | Steepness of the WTI / Brent futures curve | `steep` · `flat` · `inverted` |
-| `sector_dispersion` | Cross-sector price correlation breakdown | `high` · `moderate` · `low` |
-| `insider_conviction` | Aggregated insider trade signal | `strong` · `moderate` · `weak` |
-| `narrative_velocity` | Rate of change in energy news headlines | `rising` · `stable` · `falling` |
-| `supply_shock_probability` | Modelled probability of a supply disruption | `elevated` · `moderate` · `low` |
-| `tanker_disruption_index` | Shipping flow anomalies at key chokepoints | `high` · `moderate` · `low` |
-
-### Consuming output in thinkorswim or a custom dashboard
-
-The JSON output is compatible with any JSON-capable dashboard. To load candidates into thinkorswim or a spreadsheet tool, you can transform the output with the included helper:
-
-```bash
-python -m agent.cli export --format csv --input ./output/candidates_2026-03-15T14:32:00Z.json
-```
-
-This
+| `volatility_gap` | `positive`, `negative`, `neutral` | Feature Generation |
+| `futures_curve_steepness` | `steep`, `flat`, `inverted` | Feature Generation |
+| `sector_dispersion` | `widening`, `narrowing`, `stable` | Feature Generation |
+| `insider_conviction_score` | `high`, `moderate`, `low` | Feature Generation |
+| `narrative_velocity` | `rising`, `stable`, `falling` | Feature Generation |
+| `supply_shock_probability` | `elevated`,

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through installing, configuring, and running the full four-agent pipeline from a clean environment to ranked options candidates.
+> This guide walks you through installing, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
 
 ---
 
@@ -18,55 +18,67 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces a structured, ranked list of candidate options strategies.
+The **Energy Options Opportunity Agent** is a modular, autonomous Python pipeline composed of four loosely coupled agents. It ingests market data, supply signals, news events, and alternative datasets, then produces a ranked list of candidate options strategies with full explainability.
 
-The pipeline is composed of four loosely coupled agents that execute in sequence, communicating through a shared **market state object** and a **derived features store**.
+### Pipeline Architecture
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping / Logistics\nMarineTraffic / VesselFinder]
-        A8[Narrative & Sentiment\nReddit / Stocktwits]
+    subgraph Feeds["External Data Feeds"]
+        F1(Alpha Vantage / MetalpriceAPI)
+        F2(Yahoo Finance / yfinance)
+        F3(EIA API)
+        F4(GDELT / NewsAPI)
+        F5(SEC EDGAR / Quiver Quant)
+        F6(MarineTraffic / VesselFinder)
+        F7(Reddit / Stocktwits)
     end
 
-    subgraph Pipeline
-        direction TB
-        P1["① Data Ingestion Agent\nFetch & Normalize"]
-        P2["② Event Detection Agent\nSupply & Geo Signals"]
-        P3["③ Feature Generation Agent\nDerived Signal Computation"]
-        P4["④ Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Pipeline["Four-Agent Pipeline"]
+        A1["📥 Data Ingestion Agent\n─────────────────\nFetch & Normalize\nMarket State Object"]
+        A2["🔍 Event Detection Agent\n─────────────────\nSupply & Geo Signals\nConfidence + Intensity Scores"]
+        A3["⚙️ Feature Generation Agent\n─────────────────\nDerived Signal Computation\nVol Gaps, Curve, Dispersion…"]
+        A4["🏆 Strategy Evaluation Agent\n─────────────────\nOpportunity Ranking\nEdge Scores + Explainability"]
     end
 
-    subgraph Output
-        O1[Ranked Candidates\nJSON / Dashboard]
-    end
+    OUT["📄 JSON Output\nRanked Candidate Strategies"]
 
-    A1 & A2 & A3 --> P1
-    A4 & A5      --> P1
-    A6 & A7 & A8 --> P1
-
-    P1 -->|market state object| P2
-    P2 -->|scored events| P3
-    P3 -->|derived features| P4
-    P4 --> O1
+    Feeds --> A1
+    A1 -->|"Unified Market State"| A2
+    A2 -->|"Event Scores"| A3
+    A3 -->|"Derived Features"| A4
+    A4 --> OUT
 ```
 
-### Agent Responsibilities
+Data flows **unidirectionally** through the pipeline. Each agent can be deployed and updated independently without disrupting the others.
 
-| # | Agent | Role | Key Outputs |
-|---|-------|------|-------------|
-| 1 | **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical store |
-| 2 | **Event Detection Agent** | Supply & Geo Signals | Events with confidence and intensity scores |
-| 3 | **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
-| 4 | **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
+### What Each Agent Does
 
-> **Advisory only.** The pipeline surfaces opportunities; it does **not** execute trades automatically.
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical price/vol store |
+| **Event Detection Agent** | Supply & Geo Signals | Confidence and intensity scores per detected event |
+| **Feature Generation Agent** | Derived Signal Computation | Vol gaps, curve steepness, sector dispersion, supply shock probability, etc. |
+| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with `edge_score` and contributing signals |
+
+### In-Scope Instruments
+
+| Category | Instruments |
+|---|---|
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+
+### In-Scope Option Structures (MVP)
+
+| Structure | Enum Value |
+|---|---|
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
+
+> ⚠️ **Advisory Only.** The system generates ranked recommendations. No automated trade execution occurs in this release.
 
 ---
 
@@ -75,18 +87,18 @@ flowchart LR
 ### System Requirements
 
 | Requirement | Minimum |
-|-------------|---------|
+|---|---|
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| Operating system | Linux, macOS, or Windows (WSL2 recommended) |
-| RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS to data-source APIs |
+| RAM | 2 GB available |
+| Disk | 5 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-### Required Tools
+### Required Software
 
 ```bash
 # Verify Python version
-python --version        # should print 3.10.x or later
+python --version   # must be >= 3.10
 
 # Verify pip
 pip --version
@@ -95,26 +107,23 @@ pip --version
 git --version
 ```
 
-### API Access
+### API Accounts
 
-You need free-tier (or low-cost) accounts for the data sources used by each pipeline phase. Register for the services you intend to use before proceeding.
+You must obtain free (or free-tier) API keys from the following services before running the pipeline. All are zero-cost for the MVP data volumes.
 
-| Data Source | Registration URL | Cost | Notes |
-|-------------|-----------------|------|-------|
-| Alpha Vantage | https://www.alphavantage.co | Free | WTI, Brent spot/futures |
-| MetalpriceAPI | https://metalpriceapi.com | Free | Crude price fallback |
-| Polygon.io | https://polygon.io | Free/Limited | Options chains |
-| EIA API | https://www.eia.gov/opendata | Free | Inventory, refinery utilization |
-| NewsAPI | https://newsapi.org | Free | Geopolitical news events |
-| GDELT | https://www.gdeltproject.org | Free | No key required |
-| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Free | Insider filings |
-| Quiver Quant | https://www.quiverquant.com | Free/Limited | Insider trade scores |
-| MarineTraffic | https://www.marinetraffic.com | Free tier | Tanker flows |
-| VesselFinder | https://www.vesselfinder.com | Free tier | Tanker flow fallback |
-| Reddit API | https://www.reddit.com/prefs/apps | Free | Narrative sentiment |
-| Stocktwits | https://api.stocktwits.com | Free | Retail sentiment |
-
-> **Phase dependency:** API keys are required incrementally by MVP phase. See [MVP Phasing](#mvp-phasing-and-enabling-agents) for details.
+| Service | URL | Used By | Notes |
+|---|---|---|---|
+| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Data Ingestion | WTI / Brent spot & futures |
+| NewsAPI | https://newsapi.org/register | Event Detection | Energy headlines |
+| EIA Open Data | https://www.eia.gov/opendata/ | Event Detection | Inventory & refinery data |
+| Polygon.io | https://polygon.io | Data Ingestion | Options chains (free tier) |
+| Quiver Quant | https://www.quiverquant.com | Feature Generation | Insider trade data |
+| SEC EDGAR | https://efts.sec.gov/LATEST/search-index | Feature Generation | No key required |
+| GDELT | https://www.gdeltproject.org | Event Detection | No key required |
+| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Feature Generation | Free tier |
+| Reddit API | https://www.reddit.com/prefs/apps | Feature Generation | Narrative velocity |
+| Yahoo Finance / yfinance | (no key needed) | Data Ingestion | ETF & equity prices |
+| Stocktwits | https://api.stocktwits.com/developers | Feature Generation | Sentiment |
 
 ---
 
@@ -132,11 +141,11 @@ cd energy-options-agent
 ```bash
 python -m venv .venv
 
-# Linux / macOS
+# macOS / Linux
 source .venv/bin/activate
 
 # Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+.\.venv\Scripts\Activate.ps1
 ```
 
 ### 3. Install Dependencies
@@ -148,187 +157,188 @@ pip install -r requirements.txt
 
 ### 4. Configure Environment Variables
 
-All runtime configuration is supplied through environment variables. Copy the provided template and fill in your values:
+The pipeline reads all secrets and tunable parameters from environment variables. The recommended approach is a `.env` file in the project root (loaded automatically at startup via `python-dotenv`).
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor and populate the values described in the table below.
-
-#### Environment Variable Reference
-
-| Variable | Required | Default | Description |
-|----------|----------|---------|-------------|
-| `ALPHA_VANTAGE_API_KEY` | Phase 1 | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Optional | — | Fallback crude price key (MetalpriceAPI) |
-| `POLYGON_API_KEY` | Phase 1 | — | Polygon.io key for options chain data |
-| `EIA_API_KEY` | Phase 2 | — | EIA Open Data API key for supply/inventory |
-| `NEWSAPI_KEY` | Phase 2 | — | NewsAPI key for geopolitical news events |
-| `QUIVER_API_KEY` | Phase 3 | — | Quiver Quant key for insider conviction data |
-| `MARINETRAFFIC_API_KEY` | Phase 3 | — | MarineTraffic key for tanker flow data |
-| `REDDIT_CLIENT_ID` | Phase 3 | — | Reddit OAuth client ID |
-| `REDDIT_CLIENT_SECRET` | Phase 3 | — | Reddit OAuth client secret |
-| `REDDIT_USER_AGENT` | Phase 3 | `energy-agent/1.0` | Reddit API user-agent string |
-| `STOCKTWITS_API_KEY` | Phase 3 | — | Stocktwits API key for retail sentiment |
-| `DATA_DIR` | All | `./data` | Directory for persisted raw and derived data |
-| `OUTPUT_DIR` | All | `./output` | Directory where JSON candidate files are written |
-| `LOG_LEVEL` | All | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `MARKET_DATA_INTERVAL_MIN` | All | `5` | Polling interval in minutes for market price feeds |
-| `HISTORY_RETENTION_DAYS` | All | `365` | Days of historical data to retain (180–365 recommended) |
-| `PIPELINE_PHASE` | All | `1` | Active MVP phase (`1`–`4`); gates which agents and sources are enabled |
-| `INSTRUMENTS` | All | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to track |
-| `OPTIONS_EXPIRY_WINDOW_DAYS` | All | `90` | Maximum calendar days to expiration for candidate options |
-| `EDGE_SCORE_THRESHOLD` | All | `0.25` | Minimum edge score for a candidate to appear in output |
-
-#### Example `.env` File
-
-```dotenv
-# ── Core keys (Phase 1) ───────────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-
-# ── Supply & event keys (Phase 2) ────────────────────────────────────────
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWSAPI_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# ── Alternative signal keys (Phase 3) ────────────────────────────────────
-QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
-MARINETRAFFIC_API_KEY=YOUR_MT_KEY_HERE
-REDDIT_CLIENT_ID=YOUR_REDDIT_ID
-REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
-REDDIT_USER_AGENT=energy-agent/1.0
-STOCKTWITS_API_KEY=YOUR_ST_KEY_HERE
-
-# ── Pipeline behaviour ────────────────────────────────────────────────────
-PIPELINE_PHASE=1
-DATA_DIR=./data
-OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-MARKET_DATA_INTERVAL_MIN=5
-HISTORY_RETENTION_DAYS=365
-INSTRUMENTS=USO,XLE,XOM,CVX,CL=F,BZ=F
-OPTIONS_EXPIRY_WINDOW_DAYS=90
-EDGE_SCORE_THRESHOLD=0.25
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation command to create the required directory structure and empty database tables before the first pipeline run:
+Open `.env` in your editor and fill in every value:
 
 ```bash
-python -m agent init
+# ── API Keys ───────────────────────────────────────────────────────────────
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+NEWS_API_KEY=your_newsapi_key
+EIA_API_KEY=your_eia_key
+POLYGON_API_KEY=your_polygon_key
+QUIVER_QUANT_API_KEY=your_quiverquant_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-options-agent/1.0
+STOCKTWITS_API_TOKEN=your_stocktwits_token
+
+# ── Data Storage ────────────────────────────────────────────────────────────
+DATA_DIR=./data                  # Root directory for all persisted data
+RETENTION_DAYS=365               # Historical data retention window (days)
+
+# ── Pipeline Cadence ────────────────────────────────────────────────────────
+MARKET_DATA_INTERVAL_MINUTES=5   # Refresh cadence for prices & options
+EIA_FETCH_SCHEDULE=weekly        # weekly | daily
+EDGAR_FETCH_SCHEDULE=daily       # daily | weekly
+
+# ── Instruments ─────────────────────────────────────────────────────────────
+INSTRUMENTS=CL=F,BZ=F,USO,XLE,XOM,CVX   # Comma-separated list
+
+# ── Strategy Evaluation ─────────────────────────────────────────────────────
+EDGE_SCORE_THRESHOLD=0.30        # Minimum edge_score to include in output
+MAX_CANDIDATES=20                # Maximum ranked candidates per run
+OPTION_STRUCTURES=long_straddle,call_spread,put_spread,calendar_spread
+
+# ── Output ──────────────────────────────────────────────────────────────────
+OUTPUT_DIR=./output              # JSON output destination
+OUTPUT_FORMAT=json               # json (future: csv, dashboard)
+LOG_LEVEL=INFO                   # DEBUG | INFO | WARNING | ERROR
 ```
+
+#### Complete Environment Variable Reference
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | Crude price feed (WTI, Brent) |
+| `NEWS_API_KEY` | ✅ | — | Energy headline ingestion |
+| `EIA_API_KEY` | ✅ | — | Inventory & refinery utilization |
+| `POLYGON_API_KEY` | ✅ | — | Options chains (strike, expiry, IV, volume) |
+| `QUIVER_QUANT_API_KEY` | ✅ | — | Insider conviction data |
+| `MARINE_TRAFFIC_API_KEY` | ✅ | — | Tanker flow data |
+| `REDDIT_CLIENT_ID` | ✅ | — | Reddit API OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | ✅ | — | Reddit API OAuth client secret |
+| `REDDIT_USER_AGENT` | ✅ | — | Reddit API user-agent string |
+| `STOCKTWITS_API_TOKEN` | ✅ | — | Stocktwits sentiment stream |
+| `DATA_DIR` | ✅ | `./data` | Root path for raw & derived data storage |
+| `RETENTION_DAYS` | ❌ | `365` | Days of historical data to retain |
+| `MARKET_DATA_INTERVAL_MINUTES` | ❌ | `5` | Price & options refresh cadence |
+| `EIA_FETCH_SCHEDULE` | ❌ | `weekly` | EIA data pull frequency |
+| `EDGAR_FETCH_SCHEDULE` | ❌ | `daily` | EDGAR insider data pull frequency |
+| `INSTRUMENTS` | ❌ | `CL=F,BZ=F,USO,XLE,XOM,CVX` | Instruments to monitor |
+| `EDGE_SCORE_THRESHOLD` | ❌ | `0.30` | Minimum score to surface a candidate |
+| `MAX_CANDIDATES` | ❌ | `20` | Maximum candidates emitted per run |
+| `OPTION_STRUCTURES` | ❌ | all four | Comma-separated list of eligible structures |
+| `OUTPUT_DIR` | ❌ | `./output` | Directory for JSON output files |
+| `OUTPUT_FORMAT` | ❌ | `json` | Output format (`json` in MVP) |
+| `LOG_LEVEL` | ❌ | `INFO` | Python logging level |
+
+### 5. Initialise Data Directories
+
+```bash
+python -m agent.cli init
+```
+
+This command creates the `DATA_DIR` and `OUTPUT_DIR` subdirectory tree and validates that all required API keys are present before the first run.
 
 Expected output:
 
 ```
-[INFO] Data directory created: ./data
-[INFO] Output directory created: ./output
-[INFO] Historical store initialised (SQLite): ./data/market_history.db
-[INFO] Initialisation complete.
+[INFO] Data directory initialised at ./data
+[INFO] Output directory initialised at ./output
+[INFO] All required API keys present ✓
+[INFO] Ready to run.
 ```
-
-### MVP Phasing and Enabling Agents
-
-The `PIPELINE_PHASE` variable gates which data sources and agents are active. Increment the phase only after the corresponding API keys are configured.
-
-| Phase | Name | What is enabled |
-|-------|------|-----------------|
-| `1` | Core Market Signals & Options | Crude benchmarks (WTI, Brent), USO/XLE prices, options surface analysis, long straddles and call/put spreads |
-| `2` | Supply & Event Augmentation | EIA inventory, refinery utilisation, event detection via GDELT/NewsAPI, supply disruption indices |
-| `3` | Alternative / Contextual Signals | Insider trades, narrative velocity, shipping data, cross-sector correlation; full edge score |
-| `4` | High-Fidelity Enhancements | OPIS or regional refined pricing (paid), exotic/multi-legged structures, execution integration |
 
 ---
 
 ## Running the Pipeline
 
-### Single On-Demand Run
+### Full Pipeline — Single Run
 
-Execute all four agents once in sequence and write candidates to `OUTPUT_DIR`:
-
-```bash
-python -m agent run
-```
-
-The pipeline stages run in order and log their progress to stdout:
-
-```
-[INFO] ── Stage 1/4: Data Ingestion Agent ──────────────────────────────
-[INFO] Fetching WTI spot price          ... OK (Alpha Vantage)
-[INFO] Fetching Brent spot price        ... OK (Alpha Vantage)
-[INFO] Fetching options chain: USO      ... OK (Polygon.io)
-[INFO] Fetching options chain: XLE      ... OK (Polygon.io)
-[INFO] Market state object written      ... ./data/market_state.json
-
-[INFO] ── Stage 2/4: Event Detection Agent ─────────────────────────────
-[INFO] Scanning GDELT for energy events ... 3 events detected
-[INFO] Events scored and stored         ... ./data/events.json
-
-[INFO] ── Stage 3/4: Feature Generation Agent ──────────────────────────
-[INFO] Computing volatility gaps        ... done
-[INFO] Computing futures curve steepness... done
-[INFO] Computing supply shock probability... done
-[INFO] Derived features written         ... ./data/features.json
-
-[INFO] ── Stage 4/4: Strategy Evaluation Agent ─────────────────────────
-[INFO] Evaluating option structures     ... 12 candidates scored
-[INFO] Candidates above threshold (0.25): 4
-[INFO] Output written                   ... ./output/candidates_20260315T143002Z.json
-[INFO] Pipeline complete.
-```
-
-### Running a Single Agent in Isolation
-
-Each agent can be run independently for debugging or incremental updates:
+Execute all four agents in sequence for a one-shot evaluation:
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent run --stage ingest
-
-# Run only the Event Detection Agent
-python -m agent run --stage events
-
-# Run only the Feature Generation Agent
-python -m agent run --stage features
-
-# Run only the Strategy Evaluation Agent
-python -m agent run --stage strategy
+python -m agent.cli run
 ```
 
-### Continuous / Scheduled Mode
+The pipeline stages execute in order:
 
-To poll market feeds at the configured `MARKET_DATA_INTERVAL_MIN` cadence and re-evaluate strategies on each tick:
+```mermaid
+sequenceDiagram
+    participant CLI
+    participant Ingest as Data Ingestion Agent
+    participant Events as Event Detection Agent
+    participant Features as Feature Generation Agent
+    participant Strategy as Strategy Evaluation Agent
+    participant Output as JSON Output
+
+    CLI->>Ingest: start ingestion
+    Ingest-->>Ingest: fetch crude, ETF, equity prices
+    Ingest-->>Ingest: fetch options chains
+    Ingest-->>Ingest: normalize → market state object
+    Ingest->>Events: market state object
+    Events-->>Events: scan GDELT / NewsAPI
+    Events-->>Events: score supply disruptions, refinery outages, chokepoints
+    Events->>Features: market state + event scores
+    Features-->>Features: compute vol gaps, curve steepness, dispersion
+    Features-->>Features: compute insider conviction, narrative velocity
+    Features-->>Features: compute supply shock probability
+    Features->>Strategy: derived features store
+    Strategy-->>Strategy: evaluate long_straddle, spreads, calendar spreads
+    Strategy-->>Strategy: compute edge scores, attach contributing signals
+    Strategy->>Output: ranked candidates (JSON)
+    Output-->>CLI: ./output/candidates_<timestamp>.json
+```
+
+### Continuous Mode (Scheduled Refresh)
+
+To run the pipeline repeatedly on the `MARKET_DATA_INTERVAL_MINUTES` cadence, use the `--watch` flag:
 
 ```bash
-python -m agent run --continuous
+python -m agent.cli run --watch
 ```
 
-> **Tip:** For production use, consider running in a container or behind a process supervisor (e.g., `systemd`, `supervisord`, or a cron job) rather than relying on the built-in loop.
+Press `Ctrl+C` to stop. Each completed cycle writes a new timestamped output file to `OUTPUT_DIR`.
 
-#### Example cron schedule (Linux)
+### Running Individual Agents
 
-```cron
-# Run the full pipeline every 5 minutes during market hours (Mon–Fri, 09:00–17:00 ET)
-*/5 9-17 * * 1-5 /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
-```
-
-### Dry-Run Mode
-
-Validate configuration and connectivity without writing any output files:
+Each agent can be invoked in isolation for debugging or incremental development:
 
 ```bash
-python -m agent run --dry-run
+# Agent 1 — fetch and normalize data only
+python -m agent.cli run --agent ingest
+
+# Agent 2 — event detection only (requires a prior ingest run)
+python -m agent.cli run --agent events
+
+# Agent 3 — feature generation only (requires prior ingest + events)
+python -m agent.cli run --agent features
+
+# Agent 4 — strategy evaluation only (requires all prior agents)
+python -m agent.cli run --agent strategy
 ```
 
-### Overriding Configuration at the Command Line
+### Filtering Output at Runtime
 
-Any environment variable can be overridden inline for a single run:
+Override configuration values without editing `.env`:
 
 ```bash
-PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
+# Raise the minimum edge score threshold
+python -m agent.cli run --edge-threshold 0.50
+
+# Limit to a single instrument
+python -m agent.cli run --instruments USO
+
+# Limit to one option structure
+python -m agent.cli run --structures long_straddle
+
+# Combine filters
+python -m agent.cli run --instruments XOM,CVX --structures call_spread,put_spread --edge-threshold 0.40
 ```
+
+### Checking Pipeline Health
+
+```bash
+python -m agent.cli status
+```
+
+Displays API connectivity, last successful run timestamp, record counts in the data store, and any feed errors.
 
 ---
 
@@ -336,27 +346,32 @@ PIPELINE_PHASE=2 EDGE_SCORE_THRESHOLD=0.30 python -m agent run
 
 ### Output File Location
 
-Each run appends a timestamped JSON file to `OUTPUT_DIR`:
+Each run produces a file in `OUTPUT_DIR` named:
 
 ```
-output/
-└── candidates_20260315T143002Z.json
+candidates_<ISO8601_UTC_timestamp>.json
+```
+
+For example:
+
+```
+./output/candidates_2026-03-15T14_32_07Z.json
 ```
 
 ### Output Schema
 
-Each file contains a JSON array of candidate objects. The fields are:
+Each file contains a JSON array of candidate objects. All candidates have an `edge_score` at or above `EDGE_SCORE_THRESHOLD`, sorted descending by `edge_score`.
 
 | Field | Type | Description |
-|-------|------|-------------|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+|---|---|---|
+| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
+| `structure` | enum string | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signal names to qualitative levels |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example Candidate Output
+### Annotated Example
 
 ```json
 [
@@ -370,12 +385,10 @@ Each file contains a JSON array of candidate objects. The fields are:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:30:02Z"
+    "generated_at": "2026-03-15T14:32:07Z"
   },
   {
-    "instrument": "XLE",
+    "instrument": "XOM",
     "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive
+    "expiration": 21,
+    

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> Advisory system only. No automated trade execution occurs at any point in the pipeline.
+> **Version 1.0 • March 2026**
+> Advisory only. The system surfaces ranked options candidates; it does **not** execute trades.
 
 ---
 
@@ -18,347 +18,326 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a modular Python pipeline that detects volatility mispricing in oil-related instruments and surfaces ranked options trading candidates. It is designed for a single developer running on local hardware or a low-cost cloud VM.
 
-### Pipeline Architecture
-
-The system is composed of four loosely coupled agents that pass data through a shared **market state object** and a **derived features store**.
+The pipeline is composed of four loosely coupled agents that execute in sequence:
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
-        A2([ETF & Equity Prices\nyfinance])
-        A3([Options Chains\nYahoo / Polygon.io])
-        A4([Supply / Inventory\nEIA API])
-        A5([News & Geo Events\nGDELT / NewsAPI])
-        A6([Insider Activity\nSEC EDGAR / Quiver])
-        A7([Shipping\nMarineTraffic])
-        A8([Sentiment\nReddit / Stocktwits])
+    subgraph Ingestion["1 · Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nIV · Strike · Volume]
     end
 
-    subgraph Pipeline["Four-Agent Pipeline"]
-        direction TB
-        B["🟦 Data Ingestion Agent\nFetch & Normalize\n→ Market State Object"]
-        C["🟨 Event Detection Agent\nSupply & Geo Signals\n→ Scored Events"]
-        D["🟩 Feature Generation Agent\nDerived Signal Computation\n→ Features Store"]
-        E["🟥 Strategy Evaluation Agent\nOpportunity Ranking\n→ Ranked Candidates"]
-        B --> C --> D --> E
+    subgraph Events["2 · Event Detection Agent"]
+        B1[News & Geo\nGDELT · NewsAPI]
+        B2[Supply / Inventory\nEIA API]
+        B3[Shipping\nMarineTraffic]
+        B4[Confidence &\nIntensity Scores]
     end
 
-    subgraph Output
-        F([JSON Candidates\nedge_score · signals\nexpiration · structure])
+    subgraph Features["3 · Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs Implied]
+        C2[Futures Curve\nSteepness]
+        C3[Supply Shock\nProbability]
+        C4[Narrative Velocity\nInsider Conviction]
     end
 
-    Inputs --> B
-    E --> Output
+    subgraph Strategy["4 · Strategy Evaluation Agent"]
+        D1[Eligible Structures\nStraddle · Spreads]
+        D2[Edge Score\n0.0 – 1.0]
+        D3[Ranked Candidates\nJSON Output]
+    end
+
+    Ingestion -->|market state object| Events
+    Events    -->|scored events| Features
+    Features  -->|derived signals| Strategy
+    Strategy  -->|candidates.json| Output[(Output\nJSON / Dashboard)]
 ```
 
-### In-Scope Instruments
+### In-scope instruments
 
 | Category | Instruments |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-Scope Option Structures (MVP)
+### In-scope option structures (MVP)
 
-| Structure | Enum Value |
+| Structure | Enum value |
 |---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
+| Long straddle | `long_straddle` |
+| Call spread | `call_spread` |
+| Put spread | `put_spread` |
+| Calendar spread | `calendar_spread` |
 
-> **Out of scope (MVP):** exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
+> **Out of scope (Phase 4 / future):** exotic or multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| OS | Linux, macOS, or Windows (WSL recommended) |
+| Python | 3.10 or later |
+| Operating system | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 5 GB (6–12 months of historical data) |
-| Network | Outbound HTTPS to external APIs |
+| Disk | 5 GB free (6–12 months of historical data) |
+| Network | Outbound HTTPS to API endpoints |
 
-### Python Dependencies
-
-Install all dependencies from the project root:
+### Required tools
 
 ```bash
-pip install -r requirements.txt
+# Verify Python version
+python --version          # must be >= 3.10
+
+# Verify pip
+pip --version
+
+# Verify git
+git --version
 ```
 
-Key packages the pipeline relies on include:
+### API accounts
 
-| Package | Purpose |
-|---|---|
-| `yfinance` | ETF, equity, and options chain data |
-| `requests` | HTTP calls to EIA, Alpha Vantage, GDELT, NewsAPI |
-| `pandas` / `numpy` | Data normalization and feature computation |
-| `pydantic` | Market state object and output schema validation |
-| `schedule` or `apscheduler` | Cadence-based refresh scheduling |
+The following free or freemium accounts are required. Register before proceeding.
 
-### API Accounts
-
-You must obtain API keys (all free or freemium) before running the pipeline:
-
-| Service | Registration URL | Tier Needed |
-|---|---|---|
-| Alpha Vantage | https://www.alphavantage.co/support/#api-key | Free |
-| MetalpriceAPI | https://metalpriceapi.com | Free |
-| Polygon.io | https://polygon.io | Free / Limited |
-| EIA API | https://www.eia.gov/opendata/ | Free |
-| NewsAPI | https://newsapi.org | Free |
-| GDELT | No key required (public dataset) | — |
-| SEC EDGAR | No key required (public dataset) | — |
-| Quiver Quant | https://www.quiverquant.com | Free / Limited |
-| MarineTraffic | https://www.marinetraffic.com/en/ais-api-services | Free tier |
+| Service | Used by | Tier needed | Sign-up URL |
+|---|---|---|---|
+| Alpha Vantage | Data Ingestion (crude prices) | Free | https://www.alphavantage.co |
+| Yahoo Finance / yfinance | Data Ingestion (ETF, equity, options) | Free (no key needed) | — |
+| Polygon.io | Data Ingestion (options chains, fallback) | Free / Limited | https://polygon.io |
+| EIA API | Event Detection (supply / inventory) | Free | https://www.eia.gov/opendata |
+| GDELT | Event Detection (news / geo) | Free (no key needed) | — |
+| NewsAPI | Event Detection (news headlines) | Free | https://newsapi.org |
+| SEC EDGAR | Feature Generation (insider activity) | Free (no key needed) | — |
+| Quiver Quant | Feature Generation (insider conviction) | Free / Limited | https://www.quiverquant.com |
+| MarineTraffic | Feature Generation (shipping / tanker flows) | Free tier | https://www.marinetraffic.com |
+| Reddit API | Feature Generation (narrative sentiment) | Free | https://www.reddit.com/wiki/api |
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate.bat     # Windows CMD
-# .venv\Scripts\Activate.ps1     # Windows PowerShell
+
+# Linux / macOS
+source .venv/bin/activate
+
+# Windows (PowerShell)
+.venv\Scripts\Activate.ps1
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the example environment file and populate it with your credentials:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set each value. The full set of supported environment variables is listed below.
+Open `.env` in your editor and fill in every value marked `REQUIRED`.
 
-#### Environment Variable Reference
+#### Complete environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Yes | — | API key for MetalpriceAPI (Brent/WTI spot) |
-| `POLYGON_API_KEY` | No | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory and refinery utilization |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy news |
-| `QUIVER_QUANT_API_KEY` | No | — | API key for Quiver Quant insider activity |
-| `MARINETRAFFIC_API_KEY` | No | — | API key for MarineTraffic tanker flow data |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `DATA_STORE_DIR` | No | `./data` | Root directory for raw and derived historical data |
-| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
-| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Refresh cadence in minutes for market price feeds |
-| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Refresh cadence in hours for EIA and EDGAR feeds |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_PHASE` | No | `1` | Active MVP phase (`1`–`4`); gates which agents are enabled |
-| `MIN_EDGE_SCORE` | No | `0.20` | Minimum edge score threshold for emitting a candidate |
-| `MAX_CANDIDATES` | No | `10` | Maximum number of ranked candidates per pipeline run |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for Alpha Vantage crude price feed |
+| `POLYGON_API_KEY` | ✅ | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | ✅ | — | API key for EIA supply / inventory data |
+| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI headline feed |
+| `QUIVER_QUANT_API_KEY` | ⬜ | — | API key for Quiver Quant insider data (Phase 3) |
+| `MARINE_TRAFFIC_API_KEY` | ⬜ | — | API key for MarineTraffic tanker flow data (Phase 3) |
+| `REDDIT_CLIENT_ID` | ⬜ | — | Reddit app client ID for sentiment feed (Phase 3) |
+| `REDDIT_CLIENT_SECRET` | ⬜ | — | Reddit app client secret (Phase 3) |
+| `REDDIT_USER_AGENT` | ⬜ | `energy-agent/1.0` | Reddit API user-agent string (Phase 3) |
+| `DATA_DIR` | ⬜ | `./data` | Root directory for raw and derived data storage |
+| `OUTPUT_DIR` | ⬜ | `./output` | Directory where `candidates.json` is written |
+| `LOG_LEVEL` | ⬜ | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⬜ | `5` | Polling cadence for minute-level market data feeds |
+| `HISTORY_RETENTION_DAYS` | ⬜ | `365` | Days of historical data to retain on disk |
+| `PIPELINE_PHASE` | ⬜ | `1` | Active MVP phase (`1`–`3`); gates which agents are enabled |
+| `EDGE_SCORE_THRESHOLD` | ⬜ | `0.30` | Minimum edge score for a candidate to appear in output |
+| `TZ` | ⬜ | `UTC` | Timezone for all timestamps; strongly recommended to leave as `UTC` |
 
-> **Tip:** Variables marked **No** under *Required* are optional. The pipeline degrades gracefully when optional data sources are unavailable — it will log a warning and continue rather than halting.
+> **Security note:** Never commit `.env` to version control. The repository's `.gitignore` already excludes it.
 
-#### Example `.env`
+#### Example `.env` (Phase 1)
 
 ```dotenv
-# --- Required API Keys ---
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-METALPRICE_API_KEY=YOUR_MP_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-NEWS_API_KEY=YOUR_NEWS_API_KEY_HERE
+# --- Required ---
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
+POLYGON_API_KEY=your_polygon_key_here
+EIA_API_KEY=your_eia_key_here
+NEWS_API_KEY=your_newsapi_key_here
 
-# --- Optional API Keys ---
-POLYGON_API_KEY=
-QUIVER_QUANT_API_KEY=
-MARINETRAFFIC_API_KEY=
-
-# --- Pipeline Behaviour ---
-PIPELINE_PHASE=1
-MIN_EDGE_SCORE=0.20
-MAX_CANDIDATES=10
-MARKET_DATA_INTERVAL_MIN=5
-SLOW_FEED_INTERVAL_HOURS=24
-
-# --- Storage ---
+# --- Optional overrides ---
+DATA_DIR=./data
 OUTPUT_DIR=./output
-DATA_STORE_DIR=./data
-RETENTION_DAYS=365
-
-# --- Observability ---
 LOG_LEVEL=INFO
+PIPELINE_PHASE=1
+EDGE_SCORE_THRESHOLD=0.30
+TZ=UTC
 ```
 
-### 5. Initialise the Data Store
+### 5. Initialise the data store
 
-Run the one-time initialisation script to create the required directory structure and seed the historical data store:
+Creates the directory structure and seeds the SQLite database used for historical storage:
 
 ```bash
-python -m agent.cli init
+python -m agent init
 ```
 
 Expected output:
 
 ```
-[INFO] Creating data store at ./data ...
-[INFO] Creating output directory at ./output ...
-[INFO] Initialisation complete. Run `python -m agent.cli run` to start the pipeline.
+[INFO] Data directory created at ./data
+[INFO] Output directory created at ./output
+[INFO] Historical database initialised (retention: 365 days)
+[INFO] Initialisation complete.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Data Flow (Sequence)
+### Pipeline phases
+
+Set `PIPELINE_PHASE` in `.env` to control which agents are active:
+
+| Phase | Name | Active agents / signals |
+|---|---|---|
+| `1` | Core Market Signals & Options | Data Ingestion, Feature Generation (IV / volatility gap, curve steepness), Strategy Evaluation |
+| `2` | Supply & Event Augmentation | Adds Event Detection (EIA inventory, GDELT/NewsAPI), supply disruption indices |
+| `3` | Alternative / Contextual Signals | Adds insider conviction (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), shipping data (MarineTraffic) |
+
+### Single run (one-shot)
+
+Executes the full pipeline once and writes `candidates.json` to `OUTPUT_DIR`:
+
+```bash
+python -m agent run
+```
+
+### Continuous mode (polling)
+
+Runs the pipeline on the cadence defined by `MARKET_DATA_INTERVAL_MINUTES`:
+
+```bash
+python -m agent run --continuous
+```
+
+Stop with <kbd>Ctrl</kbd>+<kbd>C</kbd>. The pipeline handles partial or missing data gracefully and will not crash on a failed upstream fetch.
+
+### Run a specific agent only
+
+Each agent can be invoked independently for testing or incremental development:
+
+```bash
+# Data Ingestion only
+python -m agent run --agent ingestion
+
+# Event Detection only
+python -m agent run --agent events
+
+# Feature Generation only
+python -m agent run --agent features
+
+# Strategy Evaluation only (reads from cached feature store)
+python -m agent run --agent strategy
+```
+
+### Override output path
+
+```bash
+python -m agent run --output /tmp/my_candidates.json
+```
+
+### Dry run (no disk writes)
+
+Runs the full pipeline and prints output to stdout without writing files:
+
+```bash
+python -m agent run --dry-run
+```
+
+### Pipeline execution flow (sequence)
 
 ```mermaid
 sequenceDiagram
-    autonumber
     participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant FS as File System (JSON Output)
+    participant FS  as Feature Store (disk)
+    participant OUT as Output (candidates.json)
 
-    CLI->>DIA: trigger run()
-    DIA->>DIA: fetch crude, ETF, equity prices
-    DIA->>DIA: fetch options chains
-    DIA->>DIA: normalize → MarketStateObject
-    DIA-->>EDA: MarketStateObject
+    CLI->>DIA: trigger run
+    DIA->>DIA: fetch crude, ETF, equity, options chain
+    DIA->>FS: write normalised market state
+    DIA->>EDA: market state ready
 
-    EDA->>EDA: scan GDELT / NewsAPI
-    EDA->>EDA: score supply disruptions, outages, chokepoints
-    EDA-->>FGA: MarketStateObject + ScoredEvents
+    EDA->>EDA: scan news, geo, EIA, shipping
+    EDA->>EDA: assign confidence & intensity scores
+    EDA->>FS: write scored events
 
-    FGA->>FGA: compute volatility gaps (realized vs. implied)
-    FGA->>FGA: compute curve steepness, dispersion, insider scores
-    FGA->>FGA: compute narrative velocity, supply shock probability
-    FGA-->>SEA: FeaturesStore
+    FGA->>FS: read market state + events
+    FGA->>FGA: compute volatility gap, curve steepness,\nsector dispersion, insider conviction,\nnarrative velocity, supply shock prob.
+    FGA->>FS: write derived features
 
-    SEA->>SEA: evaluate eligible option structures
-    SEA->>SEA: compute edge scores
-    SEA->>SEA: rank candidates, attach signal references
-    SEA-->>FS: write ranked_candidates_<timestamp>.json
-```
-
-### Single Run (One-Shot)
-
-Execute the full pipeline once and write output to `OUTPUT_DIR`:
-
-```bash
-python -m agent.cli run
-```
-
-To override the active phase without editing `.env`:
-
-```bash
-python -m agent.cli run --phase 2
-```
-
-To lower the minimum edge score for a broader candidate set:
-
-```bash
-python -m agent.cli run --min-edge-score 0.10
-```
-
-### Continuous Mode (Scheduled)
-
-Run the pipeline on a recurring cadence driven by `MARKET_DATA_INTERVAL_MIN`:
-
-```bash
-python -m agent.cli run --continuous
-```
-
-The scheduler will:
-- Refresh market price feeds every `MARKET_DATA_INTERVAL_MIN` minutes.
-- Refresh slow feeds (EIA, EDGAR) every `SLOW_FEED_INTERVAL_HOURS` hours.
-- Append a new output file per cycle to `OUTPUT_DIR`.
-
-Stop the process with `Ctrl+C`.
-
-### Running Individual Agents
-
-Each agent can be run in isolation for development or debugging:
-
-```bash
-# Data Ingestion only
-python -m agent.cli run --agent ingestion
-
-# Event Detection only (requires a prior ingestion snapshot)
-python -m agent.cli run --agent event-detection
-
-# Feature Generation only
-python -m agent.cli run --agent feature-generation
-
-# Strategy Evaluation only
-python -m agent.cli run --agent strategy-evaluation
-```
-
-### Running in Docker
-
-A minimal container target is provided for cloud or server deployment:
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run with your local .env file
-docker run --env-file .env \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/output:/app/output \
-  energy-options-agent:latest
+    SEA->>FS: read derived features
+    SEA->>SEA: evaluate eligible structures
+    SEA->>SEA: compute edge scores & rank candidates
+    SEA->>OUT: write candidates.json
+    SEA->>CLI: run complete
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
-
-Each pipeline run writes a timestamped JSON file to `OUTPUT_DIR`:
+### Output file location
 
 ```
-output/
-└── ranked_candidates_2026-03-15T14:05:00Z.json
+./output/candidates.json
 ```
 
-### Output Schema
+The file contains a JSON array. Each element is one ranked strategy candidate.
 
-Each file contains an array of candidate objects. The fields are:
+### Output schema
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | One of: `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative levels |
+| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Calendar days to target expiration from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher means stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
 | `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example Output
+### Example output
 
 ```json
 [
@@ -372,59 +351,72 @@ Each file contains an array of candidate objects. The fields are:
       "volatility_gap": "positive",
       "narrative_velocity": "rising"
     },
-    "generated_at": "2026-03-15T14:05:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   },
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
+    "expiration": 21,
+    "edge_score": 0.38,
     "signals": {
-      "supply_shock_probability": "elevated",
       "volatility_gap": "positive",
-      "sector_dispersion": "widening"
+      "futures_curve_steepness": "elevated",
+      "supply_shock_probability": "moderate"
     },
-    "generated_at": "2026-03-15T14:05:00Z"
+    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading the Edge Score
+### Reading edge scores
 
-| Edge Score Range | Interpretation |
-|---|---|
-| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
-| `0.40 – 0.69` | Moderate confluence — worthy of further review |
-| `0.20 – 0.39` | Weak signal — monitor rather than act |
-| `< 0.20` | Below threshold — suppressed by default (`MIN_EDGE_SCORE`) |
+| Edge score range | Interpretation | Suggested action |
+|---|---|---|
+| `0.70 – 1.00` | Strong signal confluence | High-priority candidate — review carefully |
+| `0.50 – 0.69` | Moderate confluence | Warrants further analysis |
+| `0.30 – 0.49` | Weak / marginal signal | Low confidence — treat as informational |
+| `< 0.30` | Below threshold | Filtered out by default (`EDGE_SCORE_THRESHOLD`) |
 
-> **Important:** The edge score is an advisory signal, not a trade recommendation. The system does not execute trades and does not account for individual risk tolerance, position sizing, or transaction costs.
+> The edge score is a heuristic composite; it is not a probability of profit. Always perform your own due diligence before placing a trade.
 
-### Signal Reference
+### Signal reference
 
-The `signals` map reports the state of each contributing derived feature at the time of evaluation:
+| Signal key | Description | Qualitative values |
+|---|---|---|
+| `volatility_gap` | Realised volatility vs. implied volatility differential | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | Slope of the oil futures term structure | `elevated`, `flat`, `inverted` |
+| `sector_dispersion` | Cross-sector correlation divergence | `high`, `moderate`, `low` |
+| `insider_conviction_score` | Aggregated insider trade activity (EDGAR/Quiver) | `high`, `moderate`, `low` |
+| `narrative_velocity` | Rate of change of energy-related headline / social volume | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | Modelled probability of near-term supply disruption | `high`, `moderate`, `low` |
+| `tanker_disruption_index` | Shipping / chokepoint anomaly score | `high`, `moderate`, `low` |
 
-| Signal Key | What It Measures |
-|---|---|
-| `volatility_gap` | Realized vs. implied volatility divergence |
-| `futures_curve_steepness` | Contango or backwardation steepness |
-| `sector_dispersion` | Cross-instrument spread within the energy sector |
-| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
-| `narrative_velocity` | Headline acceleration from GDELT / NewsAPI / Reddit |
-| `supply_shock_probability` | Probability of near-term supply disruption |
-| `tanker_disruption_index` | Shipping flow anomaly from MarineTraffic |
+### Visualising output in thinkorswim
 
-### Using the Output with thinkorswim
-
-The JSON output is compatible with any thinkorswim thinkScript study or third-party dashboard that can consume a JSON file. Load `ranked_candidates_<timestamp>.json` from your `OUTPUT_DIR` into your visualization layer. Candidates are pre-sorted by `edge_score` descending.
+The JSON output is designed to be consumed by any JSON-capable dashboard. For thinkorswim, import `candidates.json` via the platform's scripting interface or paste individual candidates into a watchlist notes field.
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
+### General diagnostic commands
 
-| Symptom | Likely Cause | Resolution |
+```bash
+# Check environment variable loading
+python -m agent config check
+
+# Validate API connectivity for all configured sources
+python -m agent config test-connections
+
+# Print the current feature store snapshot
+python -m agent debug features
+
+# Print the last N log lines
+python -m agent logs --tail 50
+```
+
+### Common issues
+
+| Symptom | Likely cause | Resolution |
 |---|---|---|
-| `KeyError: ALPHA_VANTAGE_API_KEY` | Environment variable not set | Verify `.env` is populated and loaded; re-run `source .venv/bin/activate` |
-| `WARNING: options chain unavailable for XOM` | Polygon.io
+| `candidates.json` is empty | All candidates below `EDGE_SCORE_THRESHOLD` | Lower `EDGE_SCORE_THRESHOLD` in `.env` or check

--- a/docs/timescaledb_migration.md
+++ b/docs/timescaledb_migration.md
@@ -1,0 +1,202 @@
+# TimescaleDB Migration Guide
+
+**Energy Options Opportunity Agent — PRD §6.2**
+
+---
+
+## Overview
+
+The Energy Options Opportunity Agent uses PostgreSQL 15 for Phase 1. Phase 2
+adds TimescaleDB — a PostgreSQL extension that converts regular tables into
+hypertables (time-partitioned tables). This delivers faster time-range queries
+for backtesting and long-lived market-data series with zero application code
+changes.
+
+Schema design guarantees zero-friction migration: all time-series tables already
+use `TIMESTAMPTZ` columns, and no ORM or query changes are required. The
+migration is a single-file SQL script applied once.
+
+---
+
+## Migration Triggers
+
+**Run the migration when ANY of the following is true (PRD §6.2):**
+
+| # | Trigger | How to check |
+|---|---------|-------------|
+| 1 | Historical data exceeds **6 months** of tick-level market data | `SELECT count(*), min(timestamp), max(timestamp) FROM market_prices;` |
+| 2 | Backtesting range queries **consistently exceed 5 seconds** | Run a 30-day window query; `EXPLAIN ANALYZE SELECT ... WHERE timestamp BETWEEN ...` |
+| 3 | Team size grows **beyond a single contributor** | Sprint planning / team roster |
+
+---
+
+## Tables Being Converted
+
+| Table | Partition column | Data description |
+|-------|-----------------|-----------------|
+| `market_prices` | `timestamp` | WTI, Brent, USO, XLE, XOM, CVX tick prices |
+| `options_chain` | `timestamp` | Options records for USO, XLE, XOM, CVX |
+| `eia_inventory` | `fetched_at` | Weekly EIA petroleum status reports |
+| `detected_events` | `detected_at` | Classified energy market events |
+
+---
+
+## Pre-Migration Checklist
+
+Before running the migration script, confirm:
+
+- [ ] PostgreSQL 15+ is running (`SELECT version();`)
+- [ ] `db/schema.sql` has been applied: all four tables exist
+  ```sql
+  SELECT table_name FROM information_schema.tables
+  WHERE table_name IN ('market_prices','options_chain','eia_inventory','detected_events');
+  ```
+- [ ] `docker-compose.yml` is using `timescale/timescaledb:2.15.2-pg15`
+  (already updated — see Docker Compose section below)
+- [ ] Database backup taken if live data is present
+  ```bash
+  pg_dump $DATABASE_URL > backup_$(date +%Y%m%d).sql
+  ```
+
+---
+
+## Step-by-Step Migration
+
+### 1. Start the database (Docker Compose)
+
+```bash
+docker compose up -d
+docker compose ps   # confirm db service is healthy
+```
+
+### 2. Apply the base schema (if not already applied)
+
+```bash
+psql $DATABASE_URL -f db/schema.sql
+```
+
+### 3. Apply the TimescaleDB migration
+
+```bash
+psql $DATABASE_URL -f db/migrate_timescaledb.sql
+```
+
+Expected output:
+
+```
+CREATE EXTENSION
+create_hypertable
+------------------
+ (1,1)
+(1 row)
+
+create_hypertable
+------------------
+ (2,1)
+(1 row)
+
+create_hypertable
+------------------
+ (3,1)
+(1 row)
+
+create_hypertable
+------------------
+ (4,1)
+(1 row)
+```
+
+If running against a database where the migration was already applied, each
+`create_hypertable` call returns a `NOTICE` ("table is already a hypertable")
+and exits successfully — the script is fully idempotent.
+
+### 4. Verify
+
+```sql
+SELECT hypertable_name, num_dimensions, num_chunks
+FROM timescaledb_information.hypertables;
+```
+
+Expected: 4 rows — `market_prices`, `options_chain`, `eia_inventory`, `detected_events`.
+
+```bash
+# Quick schema spot-check:
+psql $DATABASE_URL -c "\d market_prices"
+psql $DATABASE_URL -c "\d options_chain"
+```
+
+---
+
+## Docker Compose
+
+`docker-compose.yml` uses `timescale/timescaledb:2.15.2-pg15` — the TimescaleDB
+image that bundles PostgreSQL 15 and the extension pre-installed. No additional
+Docker changes are required before running the migration.
+
+To restart with a clean database (development only — destroys all data):
+
+```bash
+docker compose down -v
+docker compose up -d
+psql $DATABASE_URL -f db/schema.sql
+psql $DATABASE_URL -f db/migrate_timescaledb.sql
+```
+
+---
+
+## Rollback Procedure
+
+TimescaleDB does not provide a direct "undo hypertable" command. If you need to
+revert the four tables to regular PostgreSQL tables:
+
+**Step 1 — Back up data (before rolling back)**
+
+```bash
+psql $DATABASE_URL -c "\COPY market_prices    TO '/tmp/market_prices_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY options_chain    TO '/tmp/options_chain_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY eia_inventory    TO '/tmp/eia_inventory_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY detected_events  TO '/tmp/detected_events_bak.csv'  CSV HEADER"
+```
+
+**Step 2 — Drop the hypertables** (destructive — loses all data in the tables)
+
+```sql
+DROP TABLE market_prices;
+DROP TABLE options_chain;
+DROP TABLE eia_inventory;
+DROP TABLE detected_events;
+```
+
+**Step 3 — Re-create as regular tables**
+
+```bash
+psql $DATABASE_URL -f db/schema.sql
+```
+
+**Step 4 — Re-import data**
+
+```bash
+psql $DATABASE_URL -c "\COPY market_prices    FROM '/tmp/market_prices_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY options_chain    FROM '/tmp/options_chain_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY eia_inventory    FROM '/tmp/eia_inventory_bak.csv'    CSV HEADER"
+psql $DATABASE_URL -c "\COPY detected_events  FROM '/tmp/detected_events_bak.csv'  CSV HEADER"
+```
+
+**Step 5 — Drop the extension** (only if no other databases use TimescaleDB)
+
+```sql
+DROP EXTENSION IF EXISTS timescaledb CASCADE;
+```
+
+> **Warning:** Steps 2–3 are destructive. Always complete Step 1 first.
+
+---
+
+## References
+
+- PRD §6.2 — TimescaleDB Migration
+- PRD §12.7 — Coverage Gaps (migration plan flagged)
+- `db/schema.sql` — base schema; all hypertable candidates annotated in header
+- `db/migrate_timescaledb.sql` — idempotent migration script
+- `docker-compose.yml` — `timescale/timescaledb:2.15.2-pg15` image
+- [TimescaleDB docs: create_hypertable](https://docs.timescale.com/api/latest/hypertable/create_hypertable/)

--- a/docs/uat_reports/112-uat-report-2026-03-19.md
+++ b/docs/uat_reports/112-uat-report-2026-03-19.md
@@ -1,0 +1,53 @@
+# UAT Run Snapshot — Issue #112
+Date: 2026-03-19
+
+Summary
+- Runner: `scripts/uat_run.py` (offline replay)
+- Env: Local venv; `DATABASE_URL` present in `.env`; TimescaleDB running.
+
+Backtest evaluate() (GDELT sample):
+```
+{
+  "threshold": 2.0,
+  "hold_days": 3,
+  "events": { "count": 0, "mean": 0.0, "median": 0.0, "std": 0.0 },
+  "non_events": { "count": 13, "mean": 0.08920825546201107, "median": 0.04363479648159152, "std": 0.07859866688969086 }
+}
+```
+
+Pipeline output (injected DetectedEvent)
+- Candidates produced: 3
+
+```
+[
+  {
+    "instrument": "CL=F",
+    "structure": "long_straddle",
+    "edge_score": 0.6828022799999999,
+    "signals": {
+      "volatility_gap": "positive",
+      "sector_dispersion": "medium",
+      "supply_shock_probability": "high",
+      "futures_curve_steepness": "backwardation"
+    }
+  },
+  {
+    "instrument": "CL=F",
+    "structure": "call_spread",
+    "edge_score": 0.6828022799999999,
+    "signals": { ... }
+  },
+  {
+    "instrument": "CL=F",
+    "structure": "put_spread",
+    "edge_score": 0.6828022799999999,
+    "signals": { ... }
+  }
+]
+```
+
+Notes
+- Offline run printed candidates to stdout; with `DATABASE_URL` set the runner can persist candidates to the `strategy_candidates` table.
+- If you want these rows persisted now, I can re-run the UAT with persistence and capture example DB rows.
+
+Saved by agent: 2026-03-19

--- a/scripts/uat_run.py
+++ b/scripts/uat_run.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""UAT runner: replay a known supply event and run the pipeline."""
+from __future__ import annotations
+
+import json
+import pathlib
+from datetime import datetime, timezone
+
+import sys
+
+# Ensure project root is on sys.path so local packages (backtests, src) import correctly
+repo = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(repo))
+
+from backtests.backtest_gdelt_vol import evaluate as gdelt_evaluate
+from src.agents.event_detection.models import (
+    DetectedEvent,
+    EventType,
+    EventIntensity,
+)
+import src.pipeline as pipeline
+from src.agents.feature_generation.models import FeatureSet, VolatilityGap
+from src.agents.ingestion.models import MarketState
+from datetime import datetime as _dt
+
+
+def main() -> int:
+    repo = pathlib.Path(__file__).resolve().parents[1]
+    gdelt = repo / "backtests" / "sample_gdelt.csv"
+    prices = repo / "backtests" / "sample_prices.csv"
+
+    print("Running GDELT backtest evaluate() on sample data...")
+    out = gdelt_evaluate(gdelt, prices, threshold=2.0, hold=3)
+    print(json.dumps(out, indent=2))
+
+    # Construct a DetectedEvent for the GDELT spike date
+    detected = DetectedEvent(
+        event_id="uat-gdelt-20220224",
+        event_type=EventType.SUPPLY_DISRUPTION,
+        description="Backtest supply spike (sample)",
+        source="backtest",
+        confidence_score=0.9,
+        intensity=EventIntensity.HIGH,
+        detected_at=datetime(2022, 2, 24, tzinfo=timezone.utc),
+        affected_instruments=["CL=F", "USO"],
+        raw_headline="Sample GDELT volume spike detected",
+    )
+
+    print("Injecting one DetectedEvent into pipeline and running run_pipeline()...")
+
+    # Monkeypatch the run_event_detection used by pipeline
+    pipeline.run_event_detection = lambda: [detected]
+
+    # Construct a synthetic FeatureSet for UAT to avoid DB expectations
+    fs = FeatureSet(
+        snapshot_time=_dt.now(tz=timezone.utc),
+        volatility_gaps=[
+            VolatilityGap(
+                instrument="CL=F",
+                realized_vol=0.15,
+                implied_vol=0.30,
+                gap=0.15,
+                computed_at=_dt.now(tz=timezone.utc),
+            )
+        ],
+        sector_dispersion=0.08,
+        futures_curve_steepness=-0.02,
+        supply_shock_probability=0.8,
+    )
+
+    # Monkeypatch run_ingestion and run_feature_generation to return controlled data
+    pipeline.run_ingestion = lambda: MarketState(snapshot_time=detected.detected_at, prices=[], options=[], ingestion_errors=[])
+    pipeline.run_feature_generation = lambda market_state, events: fs
+
+    candidates = pipeline.run_pipeline()
+
+    print(f"Pipeline produced {len(candidates)} candidate(s)")
+    if candidates:
+        # Print a summary of top 5 candidates
+        summary = [
+            {
+                "instrument": c.instrument,
+                "structure": c.structure.value if hasattr(c.structure, "value") else str(c.structure),
+                "edge_score": c.edge_score,
+                "signals": c.signals,
+            }
+            for c in candidates[:5]
+        ]
+        print(json.dumps(summary, indent=2))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agents/event_detection/db.py
+++ b/src/agents/event_detection/db.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import logging
 
+from pydantic import ValidationError
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
@@ -15,6 +16,9 @@ from src.agents.event_detection.models import DetectedEvent, EIAInventoryRecord
 from src.core.db import get_engine  # noqa: F401
 
 logger = logging.getLogger(__name__)
+
+# Default row limit for read_recent_events; avoids magic number in function signature.
+_DEFAULT_RECENT_EVENTS_LIMIT: int = 100
 
 
 def write_detected_events(events: list[DetectedEvent], engine: Engine) -> int:
@@ -72,7 +76,9 @@ def write_detected_events(events: list[DetectedEvent], engine: Engine) -> int:
     return len(events)
 
 
-def read_recent_events(engine: Engine, limit: int = 100) -> list[DetectedEvent]:
+def read_recent_events(
+    engine: Engine, limit: int = _DEFAULT_RECENT_EVENTS_LIMIT
+) -> list[DetectedEvent]:
     """
     Read the most recent detected events from the database.
 
@@ -101,20 +107,37 @@ def read_recent_events(engine: Engine, limit: int = 100) -> list[DetectedEvent]:
         logger.exception("read_recent_events failed")
         raise
 
-    return [
-        DetectedEvent(
-            event_id=row["event_id"],
-            event_type=row["event_type"],
-            description=row["description"],
-            source=row["source"],
-            confidence_score=float(row["confidence_score"]),
-            intensity=row["intensity"],
-            detected_at=row["detected_at"],
-            affected_instruments=row["affected_instruments"] or [],
-            raw_headline=row["raw_headline"],
-        )
-        for row in rows
-    ]
+    events: list[DetectedEvent] = []
+    for row in rows:
+        # affected_instruments is JSONB; psycopg2 returns a Python list, but some
+        # drivers may return a raw JSON string. Handle both to be driver-agnostic.
+        raw_instruments = row["affected_instruments"]
+        if isinstance(raw_instruments, str):
+            raw_instruments = json.loads(raw_instruments)
+        instruments: list[str] = raw_instruments or []
+
+        try:
+            events.append(
+                DetectedEvent(
+                    event_id=row["event_id"],
+                    event_type=row["event_type"],
+                    description=row["description"],
+                    source=row["source"],
+                    confidence_score=float(row["confidence_score"]),
+                    intensity=row["intensity"],
+                    detected_at=row["detected_at"],
+                    affected_instruments=instruments,
+                    raw_headline=row["raw_headline"],
+                )
+            )
+        except ValidationError:
+            logger.warning(
+                "read_recent_events: skipping malformed row event_id=%r",
+                row.get("event_id"),
+                exc_info=True,
+            )
+
+    return events
 
 
 def write_eia_records(records: list[EIAInventoryRecord], engine: Engine) -> int:

--- a/src/agents/event_detection/db.py
+++ b/src/agents/event_detection/db.py
@@ -5,11 +5,13 @@ PostgreSQL via SQLAlchemy. Schema TimescaleDB-compatible (ESOD Section 4.3).
 
 from __future__ import annotations
 
+import json
 import logging
 
+from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from src.agents.event_detection.models import DetectedEvent
+from src.agents.event_detection.models import DetectedEvent, EIAInventoryRecord
 from src.core.db import get_engine  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -19,21 +21,55 @@ def write_detected_events(events: list[DetectedEvent], engine: Engine) -> int:
     """
     Persist detected events to the detected_events table.
 
+    Idempotent: ON CONFLICT (event_id) DO NOTHING — re-classifying the same
+    article URL produces no duplicate rows.
+
     Args:
         events: Validated DetectedEvent objects to insert.
         engine: SQLAlchemy Engine for the target database.
 
     Returns:
-        Number of records successfully written.
+        Number of records submitted for insertion (including no-op conflicts).
 
     Raises:
-        NotImplementedError: Until implemented.
+        sqlalchemy.exc.SQLAlchemyError: Propagates on connection failure or
+            unexpected constraint violation after logging the exception.
     """
-    raise NotImplementedError(
-        "write_detected_events not yet implemented. "
-        "TODO: Batch INSERT into detected_events table. "
-        "Use detected_at column (TIMESTAMPTZ) for TimescaleDB compatibility."
-    )
+    if not events:
+        return 0
+
+    sql = text("""
+        INSERT INTO detected_events
+            (event_id, event_type, description, source, confidence_score,
+             intensity, detected_at, affected_instruments, raw_headline)
+        VALUES
+            (:event_id, :event_type, :description, :source, :confidence_score,
+             :intensity, :detected_at, :affected_instruments, :raw_headline)
+        ON CONFLICT (event_id) DO NOTHING
+        """)
+    rows = [
+        {
+            "event_id": e.event_id,
+            "event_type": e.event_type.value,
+            "description": e.description,
+            "source": e.source,
+            "confidence_score": e.confidence_score,
+            "intensity": e.intensity.value,
+            "detected_at": e.detected_at,
+            "affected_instruments": json.dumps(e.affected_instruments),
+            "raw_headline": e.raw_headline,
+        }
+        for e in events
+    ]
+    try:
+        with engine.begin() as conn:
+            conn.execute(sql, rows)
+    except Exception:
+        logger.exception("write_detected_events failed; %d event(s) not persisted", len(events))
+        raise
+
+    logger.info("write_detected_events: submitted %d event(s) to detected_events", len(events))
+    return len(events)
 
 
 def read_recent_events(engine: Engine, limit: int = 100) -> list[DetectedEvent]:
@@ -42,15 +78,89 @@ def read_recent_events(engine: Engine, limit: int = 100) -> list[DetectedEvent]:
 
     Args:
         engine: SQLAlchemy Engine.
-        limit: Maximum number of events to return.
+        limit: Maximum number of events to return (default 100).
 
     Returns:
-        List of DetectedEvent objects ordered by detected_at desc.
+        List of DetectedEvent objects ordered by detected_at DESC.
 
     Raises:
-        NotImplementedError: Until implemented.
+        sqlalchemy.exc.SQLAlchemyError: Propagates on connection failure after
+            logging the exception.
     """
-    raise NotImplementedError(
-        "read_recent_events not yet implemented. "
-        "TODO: Query detected_events ORDER BY detected_at DESC LIMIT limit."
-    )
+    sql = text("""
+        SELECT event_id, event_type, description, source, confidence_score,
+               intensity, detected_at, affected_instruments, raw_headline
+        FROM detected_events
+        ORDER BY detected_at DESC
+        LIMIT :limit
+        """)
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(sql, {"limit": limit}).mappings().all()
+    except Exception:
+        logger.exception("read_recent_events failed")
+        raise
+
+    return [
+        DetectedEvent(
+            event_id=row["event_id"],
+            event_type=row["event_type"],
+            description=row["description"],
+            source=row["source"],
+            confidence_score=float(row["confidence_score"]),
+            intensity=row["intensity"],
+            detected_at=row["detected_at"],
+            affected_instruments=row["affected_instruments"] or [],
+            raw_headline=row["raw_headline"],
+        )
+        for row in rows
+    ]
+
+
+def write_eia_records(records: list[EIAInventoryRecord], engine: Engine) -> int:
+    """
+    Persist EIA inventory records to the eia_inventory table.
+
+    Idempotent: ON CONFLICT (period) DO NOTHING — re-ingesting the same
+    reporting week produces no duplicate rows.
+
+    Args:
+        records: Validated EIAInventoryRecord objects to insert.
+        engine: SQLAlchemy Engine for the target database.
+
+    Returns:
+        Number of records submitted for insertion (including no-op conflicts).
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: Propagates on connection failure or
+            unexpected constraint violation after logging the exception.
+    """
+    if not records:
+        return 0
+
+    sql = text("""
+        INSERT INTO eia_inventory
+            (period, crude_stocks_mb, refinery_utilization_pct, source, fetched_at)
+        VALUES
+            (:period, :crude_stocks_mb, :refinery_utilization_pct, :source, :fetched_at)
+        ON CONFLICT (period) DO NOTHING
+        """)
+    rows = [
+        {
+            "period": r.period,
+            "crude_stocks_mb": r.crude_stocks_mb,
+            "refinery_utilization_pct": r.refinery_utilization_pct,
+            "source": r.source,
+            "fetched_at": r.fetched_at,
+        }
+        for r in records
+    ]
+    try:
+        with engine.begin() as conn:
+            conn.execute(sql, rows)
+    except Exception:
+        logger.exception("write_eia_records failed; %d record(s) not persisted", len(records))
+        raise
+
+    logger.info("write_eia_records: submitted %d record(s) to eia_inventory", len(records))
+    return len(records)

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -23,6 +23,7 @@ import os
 from pydantic import ValidationError
 import requests
 
+from src.agents.event_detection.db import write_detected_events, write_eia_records
 from src.agents.event_detection.models import (
     ClassifyLLMResponse,
     DetectedEvent,
@@ -30,6 +31,7 @@ from src.agents.event_detection.models import (
     EventIntensity,
     EventType,
 )
+from src.core.db import get_engine
 from src.core.llm_wrapper import LLMWrapper
 from src.core.retry import with_retry
 
@@ -440,18 +442,94 @@ def classify_event(article: dict[str, object]) -> DetectedEvent | None:
     return event
 
 
+_MS_PER_SECOND: int = 1000
+
+
 def run_event_detection() -> list[DetectedEvent]:
     """
     Execute one full event detection cycle.
 
-    Returns:
-        List of DetectedEvent objects detected in this cycle.
+    Fetches articles from NewsAPI and GDELT, classifies each with the LLM,
+    persists detected events and EIA inventory records to PostgreSQL, and
+    emits a structured JSON cycle-complete log.
 
-    Raises:
-        NotImplementedError: Until implemented in issue #105.
+    Each source and DB write runs in an independent try/except — one failure
+    never aborts the others. The function never raises.
+
+    Returns:
+        List of DetectedEvent objects classified in this cycle. EIA records
+        are persisted to eia_inventory and not included in the return value.
     """
-    raise NotImplementedError(
-        "run_event_detection not yet implemented. "
-        "TODO: Orchestrate fetch_news_events, fetch_gdelt_events, classify_event, "
-        "write_detected_events. See issue #105."
+    start_time = datetime.now(tz=UTC)
+    errors: list[str] = []
+    news_articles: list[dict[str, object]] = []
+    gdelt_articles: list[dict[str, object]] = []
+
+    # --- Fetch feeds ---
+    try:
+        news_articles = fetch_news_events()
+    except Exception as exc:
+        logger.exception("fetch_news_events failed")
+        errors.append(f"fetch_news_events: {exc}")
+
+    try:
+        gdelt_articles = fetch_gdelt_events()
+    except Exception as exc:
+        logger.exception("fetch_gdelt_events failed")
+        errors.append(f"fetch_gdelt_events: {exc}")
+
+    # --- Classify articles ---
+    all_articles = news_articles + gdelt_articles
+    events: list[DetectedEvent] = []
+    for article in all_articles:
+        result = classify_event(article)
+        if result is not None:
+            events.append(result)
+
+    # --- Persist to PostgreSQL ---
+    events_written = 0
+    _engine = None
+    try:
+        _engine = get_engine()
+    except Exception as exc:
+        logger.exception("run_event_detection: failed to acquire DB engine")
+        errors.append(f"get_engine: {exc}")
+
+    if _engine is not None and events:
+        try:
+            events_written = write_detected_events(events, _engine)
+        except Exception as exc:
+            logger.exception("write_detected_events failed; events not persisted")
+            errors.append(f"write_detected_events: {exc}")
+
+    # --- Fetch and persist EIA inventory ---
+    try:
+        eia_records = fetch_eia_data()
+        if _engine is not None and eia_records:
+            try:
+                write_eia_records(eia_records, _engine)
+            except Exception as exc:
+                logger.exception("write_eia_records failed; EIA records not persisted")
+                errors.append(f"write_eia_records: {exc}")
+    except Exception as exc:
+        logger.exception("fetch_eia_data failed")
+        errors.append(f"fetch_eia_data: {exc}")
+
+    # --- Structured cycle log ---
+    end_time = datetime.now(tz=UTC)
+    duration_ms = int((end_time - start_time).total_seconds() * _MS_PER_SECOND)
+    logger.info(
+        json.dumps(
+            {
+                "event": "event_detection_cycle_complete",
+                "news_articles": len(news_articles),
+                "gdelt_articles": len(gdelt_articles),
+                "events_classified": len(events),
+                "events_written": events_written,
+                "error_count": len(errors),
+                "duration_ms": duration_ms,
+            }
+        )
     )
+
+    return events

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -37,6 +37,15 @@ from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
+
+class EventDetectionError(RuntimeError):
+    """Raised by run_event_detection() on unrecoverable failure.
+
+    Allows pipeline.py to catch event detection failures without depending
+    on the underlying HTTP library (requests, httpx, etc.).
+    """
+
+
 _HTTP_TIMEOUT_SECONDS: int = 10
 
 # NewsAPI query for energy market relevance
@@ -454,11 +463,16 @@ def run_event_detection() -> list[DetectedEvent]:
     emits a structured JSON cycle-complete log.
 
     Each source and DB write runs in an independent try/except — one failure
-    never aborts the others. The function never raises.
+    never aborts the others.
 
     Returns:
         List of DetectedEvent objects classified in this cycle. EIA records
         are persisted to eia_inventory and not included in the return value.
+
+    Raises:
+        EventDetectionError: On unrecoverable failure. In normal operation all
+            internal errors are caught and accumulated; this exception is the
+            documented signal for callers (e.g. run_pipeline) to enter degraded mode.
     """
     start_time = datetime.now(tz=UTC)
     errors: list[str] = []

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -527,6 +527,7 @@ def run_event_detection() -> list[DetectedEvent]:
                 "events_classified": len(events),
                 "events_written": events_written,
                 "error_count": len(errors),
+                "errors": errors,
                 "duration_ms": duration_ms,
             }
         )

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -26,6 +26,7 @@ import requests
 from src.agents.event_detection.models import (
     ClassifyLLMResponse,
     DetectedEvent,
+    EIAInventoryRecord,
     EventIntensity,
     EventType,
 )
@@ -45,6 +46,11 @@ _NEWSAPI_PAGE_SIZE: int = 20
 _GDELT_QUERY: str = "crude oil supply disruption OR OPEC OR refinery"
 _GDELT_MAX_RECORDS: int = 20
 _GDELT_TIMESPAN_MINUTES: int = 1440  # 24 hours
+
+# EIA API v2 endpoints and fetch parameters
+_EIA_CRUDE_STOCKS_PATH: str = "/v2/petroleum/sum/sndw/data/"
+_EIA_REFINERY_UTIL_PATH: str = "/v2/petroleum/pnp/wiup/data/"
+_EIA_FETCH_WEEKS: int = 4  # most recent 4 weeks per fetch
 
 # LLM model for event classification — Haiku for speed and cost efficiency
 _CLASSIFY_MODEL_ID: str = "claude-haiku-4-5-20251001"
@@ -190,6 +196,126 @@ def fetch_gdelt_events() -> list[dict[str, object]]:
 
     logger.info("fetch_gdelt_events: retrieved %d article(s) from GDELT", len(articles))
     return articles
+
+
+def _fetch_eia_series(
+    base_url: str,
+    api_key: str,
+    path: str,
+) -> dict[str, float | None]:
+    """
+    Fetch one EIA API v2 data series and return a period → value mapping.
+
+    Args:
+        base_url: EIA API base URL (e.g. https://api.eia.gov).
+        api_key: EIA API key.
+        path: Series path (e.g. /v2/petroleum/sum/sndw/data/).
+
+    Returns:
+        Dict mapping period string (YYYY-WW) to float value or None if
+        the EIA record has a null value for that period.
+
+    Raises:
+        requests.HTTPError: Propagates on non-2xx response.
+    """
+    params: dict[str, str | int] = {
+        "api_key": api_key,
+        "frequency": "weekly",
+        "data[0]": "value",
+        "sort[0][column]": "period",
+        "sort[0][direction]": "desc",
+        "length": _EIA_FETCH_WEEKS,
+    }
+    response = requests.get(
+        f"{base_url}{path}",
+        params=params,
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    data: dict[str, object] = response.json()
+
+    raw_inner: object = data.get("response", {})
+    inner: dict[str, object] = raw_inner if isinstance(raw_inner, dict) else {}
+    raw_records: object = inner.get("data", [])
+    records: list[dict[str, object]] = raw_records if isinstance(raw_records, list) else []
+
+    result: dict[str, float | None] = {}
+    for record in records:
+        period_raw = record.get("period", "")
+        period: str = period_raw if isinstance(period_raw, str) else ""
+        if not period:
+            continue
+        raw_value = record.get("value")
+        value: float | None = None
+        if raw_value is not None:
+            try:
+                value = float(raw_value)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                logger.warning(
+                    "_fetch_eia_series: unparseable value %r for period=%r in %s",
+                    raw_value,
+                    period,
+                    path,
+                )
+        result[period] = value
+    return result
+
+
+@with_retry()
+def fetch_eia_data() -> list[EIAInventoryRecord]:
+    """
+    Fetch weekly EIA petroleum inventory data for the most recent 4 weeks.
+
+    Queries two EIA API v2 series:
+      - /v2/petroleum/sum/sndw/data/ : U.S. crude oil stocks (millions of barrels)
+      - /v2/petroleum/pnp/wiup/data/ : U.S. refinery utilization rate (percent)
+
+    Records from both series are merged by period and returned as a list of
+    EIAInventoryRecord objects sorted newest-first.
+
+    If EIA_API_KEY is not set, logs a WARNING and returns [] (degraded mode).
+    Override the base URL for testing via the EIA_BASE_URL env var.
+
+    Returns:
+        List of EIAInventoryRecord, one per reporting period, newest first.
+        Empty list if the API key is absent or both series return no data.
+
+    Raises:
+        requests.HTTPError: Propagates after all retry attempts if either
+            series endpoint returns a non-2xx status.
+    """
+    api_key = os.environ.get("EIA_API_KEY")
+    if not api_key:
+        logger.warning("EIA_API_KEY not set; skipping EIA fetch (degraded mode)")
+        return []
+
+    base_url = os.environ.get("EIA_BASE_URL", "https://api.eia.gov")
+    fetched_at = datetime.now(tz=UTC)
+
+    crude_by_period = _fetch_eia_series(base_url, api_key, _EIA_CRUDE_STOCKS_PATH)
+    refinery_by_period = _fetch_eia_series(base_url, api_key, _EIA_REFINERY_UTIL_PATH)
+
+    all_periods: set[str] = set(crude_by_period) | set(refinery_by_period)
+    records: list[EIAInventoryRecord] = []
+    for period in all_periods:
+        try:
+            record = EIAInventoryRecord(
+                period=period,
+                crude_stocks_mb=crude_by_period.get(period),
+                refinery_utilization_pct=refinery_by_period.get(period),
+                fetched_at=fetched_at,
+            )
+            records.append(record)
+        except Exception:
+            logger.warning(
+                "fetch_eia_data: skipping malformed record for period=%r",
+                period,
+                exc_info=True,
+            )
+
+    records.sort(key=lambda r: r.period, reverse=True)
+    logger.info("fetch_eia_data: retrieved %d EIA record(s)", len(records))
+    return records
 
 
 @with_retry()

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -182,6 +182,11 @@ def fetch_gdelt_events() -> list[dict[str, object]]:
             dt = datetime.strptime(seendate, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
             normalized_seendate: str = dt.isoformat()
         except (ValueError, TypeError):
+            logger.warning(
+                "fetch_gdelt_events: unparseable seendate %r for url=%r; using raw value",
+                seendate,
+                article.get("url", ""),
+            )
             normalized_seendate = seendate
         articles.append(
             {

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -23,7 +23,12 @@ import os
 from pydantic import ValidationError
 import requests
 
-from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+from src.agents.event_detection.models import (
+    ClassifyLLMResponse,
+    DetectedEvent,
+    EventIntensity,
+    EventType,
+)
 from src.core.llm_wrapper import LLMWrapper
 from src.core.retry import with_retry
 
@@ -43,6 +48,7 @@ _GDELT_TIMESPAN_MINUTES: int = 1440  # 24 hours
 
 # LLM model for event classification — Haiku for speed and cost efficiency
 _CLASSIFY_MODEL_ID: str = "claude-haiku-4-5-20251001"
+_CLASSIFY_MAX_TOKENS: int = 256
 
 # Prompt template for LLM event classification (kept ≤ 500 tokens)
 _CLASSIFY_PROMPT_TEMPLATE: str = """\
@@ -186,6 +192,27 @@ def fetch_gdelt_events() -> list[dict[str, object]]:
     return articles
 
 
+@with_retry()
+def _call_llm_classify(prompt: str) -> str:
+    """
+    Invoke the LLM and return the raw text response.
+
+    Decorated with @with_retry() so transient network/rate-limit errors are
+    retried before propagating to classify_event.
+
+    Args:
+        prompt: Formatted classification prompt.
+
+    Returns:
+        Raw string content from the LLM response.
+
+    Raises:
+        requests.HTTPError / tenacity.RetryError: After all retry attempts.
+    """
+    llm = LLMWrapper(model_id=_CLASSIFY_MODEL_ID)
+    return llm.complete(prompt, temperature=0.0, max_tokens=_CLASSIFY_MAX_TOKENS).content
+
+
 def classify_event(article: dict[str, object]) -> DetectedEvent | None:
     """
     Classify a raw article dict into a typed, scored DetectedEvent using an LLM.
@@ -224,11 +251,18 @@ def classify_event(article: dict[str, object]) -> DetectedEvent | None:
     )
 
     try:
-        llm = LLMWrapper(model_id=_CLASSIFY_MODEL_ID)
-        response = llm.complete(prompt, temperature=0.0, max_tokens=256)
-        parsed: dict[str, object] = json.loads(response.content)
+        raw_content = _call_llm_classify(prompt)
+        parsed_dict: object = json.loads(raw_content)
+        classified = ClassifyLLMResponse.model_validate(parsed_dict)
     except json.JSONDecodeError:
         logger.warning("classify_event: LLM returned non-JSON for event_id=%s; skipping", event_id)
+        return None
+    except ValidationError:
+        logger.warning(
+            "classify_event: LLM response failed schema validation for event_id=%s; skipping",
+            event_id,
+            exc_info=True,
+        )
         return None
     except Exception:
         logger.warning(
@@ -238,7 +272,7 @@ def classify_event(article: dict[str, object]) -> DetectedEvent | None:
         )
         return None
 
-    if not parsed.get("is_relevant", True):
+    if not classified.is_relevant:
         logger.debug("classify_event: article not relevant, event_id=%s", event_id)
         return None
 
@@ -252,25 +286,21 @@ def classify_event(article: dict[str, object]) -> DetectedEvent | None:
     except ValueError:
         detected_at = datetime.now(tz=UTC)
 
-    raw_instruments = parsed.get("affected_instruments", [])
-    instruments: list[str] = (
-        [str(i) for i in raw_instruments] if isinstance(raw_instruments, list) else []
-    )
     try:
         event = DetectedEvent(
             event_id=event_id,
-            event_type=EventType(str(parsed.get("event_type", "unknown"))),
-            description=str(parsed.get("description", title)),
+            event_type=EventType(classified.event_type),
+            description=classified.description,
             source=source_name,
-            confidence_score=float(parsed.get("confidence_score", 0.5)),  # type: ignore[arg-type]
-            intensity=EventIntensity(str(parsed.get("intensity", "low"))),
+            confidence_score=classified.confidence_score,
+            intensity=EventIntensity(classified.intensity),
             detected_at=detected_at,
-            affected_instruments=instruments,
+            affected_instruments=classified.affected_instruments,
             raw_headline=title,
         )
     except (ValidationError, TypeError, ValueError):
         logger.warning(
-            "classify_event: Pydantic validation failed for event_id=%s; skipping",
+            "classify_event: DetectedEvent construction failed for event_id=%s; skipping",
             event_id,
             exc_info=True,
         )

--- a/src/agents/event_detection/event_detection_agent.py
+++ b/src/agents/event_detection/event_detection_agent.py
@@ -14,55 +14,269 @@ no langchain.*/langgraph.* imports, tenacity on all external API calls.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+import hashlib
+import json
 import logging
+import os
 
-from src.agents.event_detection.models import DetectedEvent
+from pydantic import ValidationError
+import requests
+
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+from src.core.llm_wrapper import LLMWrapper
 from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
+_HTTP_TIMEOUT_SECONDS: int = 10
+
+# NewsAPI query for energy market relevance
+_NEWSAPI_QUERY: str = "crude oil OR WTI OR Brent OR energy supply OR OPEC"
+_NEWSAPI_BASE_URL: str = "https://newsapi.org/v2/everything"
+_NEWSAPI_PAGE_SIZE: int = 20
+
+# GDELT Doc API v2 query and parameters
+_GDELT_QUERY: str = "crude oil supply disruption OR OPEC OR refinery"
+_GDELT_MAX_RECORDS: int = 20
+_GDELT_TIMESPAN_MINUTES: int = 1440  # 24 hours
+
+# LLM model for event classification — Haiku for speed and cost efficiency
+_CLASSIFY_MODEL_ID: str = "claude-haiku-4-5-20251001"
+
+# Prompt template for LLM event classification (kept ≤ 500 tokens)
+_CLASSIFY_PROMPT_TEMPLATE: str = """\
+You are an energy market analyst. Classify the following news article.
+
+Title: {title}
+Source: {source}
+Published: {published_at}
+Description: {description}
+
+Respond with a JSON object only — no preamble, no markdown:
+{{
+  "is_relevant": true or false,
+  "event_type": one of ["supply_disruption","refinery_outage","tanker_chokepoint",\
+"geopolitical","sanctions","unknown"],
+  "confidence_score": float between 0.0 and 1.0,
+  "intensity": one of ["low","medium","high"],
+  "description": "one-sentence summary of the event",
+  "affected_instruments": list of ticker strings from ["USO","XLE","XOM","CVX","CL=F","BZ=F"] or []
+}}
+
+Set is_relevant to false if the article is not about energy markets, supply, or geopolitics\
+ affecting oil prices.
+"""
+
 
 @with_retry()
-def fetch_news_events() -> list[DetectedEvent]:
+def fetch_news_events() -> list[dict[str, object]]:
     """
-    Fetch and parse energy-relevant events from NewsAPI.
+    Fetch recent energy-related article metadata from NewsAPI.
+
+    Queries the NewsAPI /v2/everything endpoint for articles matching
+    energy/commodity keywords published in the last 24 hours. Returns
+    raw article dicts for downstream classification by classify_event().
+
+    If NEWSAPI_KEY is not set, logs a WARNING and returns [] (degraded mode).
 
     Returns:
-        Validated DetectedEvent objects.
+        List of raw article dicts with at minimum: title, description,
+        source (dict with name key), publishedAt, url. Empty list if the
+        key is absent or the response contains no articles.
 
     Raises:
-        NotImplementedError: Until implemented.
+        requests.HTTPError: Propagates after all retry attempts if the
+            API returns a non-2xx status code.
     """
-    raise NotImplementedError(
-        "fetch_news_events not yet implemented. "
-        "TODO: Query NewsAPI for energy keywords. "
-        "Parse and validate each result into DetectedEvent. "
-        "See .env.example for NEWSAPI_KEY."
+    api_key = os.environ.get("NEWSAPI_KEY")
+    if not api_key:
+        logger.warning("NEWSAPI_KEY not set; skipping NewsAPI fetch (degraded mode)")
+        return []
+
+    from_dt = (datetime.now(tz=UTC) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    params: dict[str, str | int] = {
+        "q": _NEWSAPI_QUERY,
+        "sortBy": "publishedAt",
+        "pageSize": _NEWSAPI_PAGE_SIZE,
+        "language": "en",
+        "from": from_dt,
+        "apiKey": api_key,
+    }
+    response = requests.get(
+        _NEWSAPI_BASE_URL,
+        params=params,
+        timeout=_HTTP_TIMEOUT_SECONDS,
     )
+    response.raise_for_status()
+    data: dict[str, object] = response.json()
+
+    raw: object = data.get("articles", [])
+    articles: list[dict[str, object]] = raw if isinstance(raw, list) else []
+    logger.info("fetch_news_events: retrieved %d article(s) from NewsAPI", len(articles))
+    return articles
 
 
-def classify_event(headline: str, source: str) -> DetectedEvent:
+@with_retry()
+def fetch_gdelt_events() -> list[dict[str, object]]:
     """
-    Classify a raw headline into a typed, scored DetectedEvent.
+    Fetch recent energy-related articles from the GDELT Project Doc API v2.
 
-    Phase 1 uses keyword-based heuristic scoring.
-    ML-based classification is deferred to a future phase (ESOD Section 8).
+    Free tier, no API key required. Queries for energy/commodity disruption
+    keywords over the past 24 hours. Returns raw article dicts for downstream
+    classification by classify_event().
+
+    Falls back to the default GDELT URL if GDELT_BASE_URL is not set.
+
+    Returns:
+        List of raw article dicts with at minimum: title, url, seendate
+        (normalized to ISO 8601 UTC), domain. Empty list if the response
+        contains no articles.
+
+    Raises:
+        requests.HTTPError: Propagates after all retry attempts if the
+            API returns a non-2xx status code.
+    """
+    base_url = os.environ.get("GDELT_BASE_URL", "http://api.gdeltproject.org/api/v2")
+
+    gdelt_params: dict[str, str | int] = {
+        "query": _GDELT_QUERY,
+        "mode": "artlist",
+        "maxrecords": _GDELT_MAX_RECORDS,
+        "format": "json",
+        "timespan": _GDELT_TIMESPAN_MINUTES,
+    }
+    response = requests.get(
+        f"{base_url}/doc/doc",
+        params=gdelt_params,
+        timeout=_HTTP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    data: dict[str, object] = response.json()
+
+    raw_gdelt: object = data.get("articles", [])
+    raw_articles: list[dict[str, object]] = raw_gdelt if isinstance(raw_gdelt, list) else []
+    if not raw_articles:
+        logger.info("fetch_gdelt_events: no articles returned from GDELT")
+        return []
+
+    # Normalize seendate (YYYYMMDDTHHMMSSZ) to ISO 8601 for consistent handling
+    articles: list[dict[str, object]] = []
+    for article in raw_articles:
+        seendate_raw = article.get("seendate", "")
+        seendate: str = seendate_raw if isinstance(seendate_raw, str) else ""
+        try:
+            dt = datetime.strptime(seendate, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+            normalized_seendate: str = dt.isoformat()
+        except (ValueError, TypeError):
+            normalized_seendate = seendate
+        articles.append(
+            {
+                "title": article.get("title", ""),
+                "url": article.get("url", ""),
+                "seendate": normalized_seendate,
+                "publishedAt": normalized_seendate,  # unified key for classify_event
+                "domain": article.get("domain", ""),
+                "source": {"name": article.get("domain", "gdelt")},
+            }
+        )
+
+    logger.info("fetch_gdelt_events: retrieved %d article(s) from GDELT", len(articles))
+    return articles
+
+
+def classify_event(article: dict[str, object]) -> DetectedEvent | None:
+    """
+    Classify a raw article dict into a typed, scored DetectedEvent using an LLM.
+
+    Routes through src/core/llm_wrapper.py — never imports the provider SDK directly.
+    Returns None if the article is not energy-market-relevant or if the LLM
+    response cannot be parsed into a valid DetectedEvent.
+
+    The event_id is derived deterministically from the article URL (SHA-256 prefix)
+    so re-classifying the same article is idempotent.
 
     Args:
-        headline: Raw headline text from the news feed.
-        source: Source identifier (e.g., 'newsapi', 'gdelt').
+        article: Raw article dict with at minimum title and url. Optional keys:
+            description, publishedAt (or seendate), source (dict with name key).
 
     Returns:
-        DetectedEvent with type, confidence_score, and intensity assigned.
-
-    Raises:
-        NotImplementedError: Until implemented.
+        Validated DetectedEvent on success; None if irrelevant or parse failure.
     """
-    raise NotImplementedError(
-        "classify_event not yet implemented. "
-        "TODO: Apply keyword-based heuristics for Phase 1. "
-        "Example: 'Strait of Hormuz' -> EventType.TANKER_CHOKEPOINT, HIGH."
+    url = str(article.get("url", ""))
+    title = str(article.get("title", ""))
+    description = str(article.get("description", title))
+    published_at = str(article.get("publishedAt") or article.get("seendate", ""))
+
+    source_raw = article.get("source", {})
+    source_name: str = (
+        source_raw.get("name", "unknown") if isinstance(source_raw, dict) else str(source_raw)
     )
+
+    event_id = hashlib.sha256(url.encode()).hexdigest()[:16]
+
+    prompt = _CLASSIFY_PROMPT_TEMPLATE.format(
+        title=title,
+        source=source_name,
+        published_at=published_at,
+        description=description,
+    )
+
+    try:
+        llm = LLMWrapper(model_id=_CLASSIFY_MODEL_ID)
+        response = llm.complete(prompt, temperature=0.0, max_tokens=256)
+        parsed: dict[str, object] = json.loads(response.content)
+    except json.JSONDecodeError:
+        logger.warning("classify_event: LLM returned non-JSON for event_id=%s; skipping", event_id)
+        return None
+    except Exception:
+        logger.warning(
+            "classify_event: LLM call failed for event_id=%s; skipping",
+            event_id,
+            exc_info=True,
+        )
+        return None
+
+    if not parsed.get("is_relevant", True):
+        logger.debug("classify_event: article not relevant, event_id=%s", event_id)
+        return None
+
+    # Parse detected_at from article timestamp
+    try:
+        detected_at = (
+            datetime.fromisoformat(published_at.replace("Z", "+00:00"))
+            if published_at
+            else datetime.now(tz=UTC)
+        )
+    except ValueError:
+        detected_at = datetime.now(tz=UTC)
+
+    raw_instruments = parsed.get("affected_instruments", [])
+    instruments: list[str] = (
+        [str(i) for i in raw_instruments] if isinstance(raw_instruments, list) else []
+    )
+    try:
+        event = DetectedEvent(
+            event_id=event_id,
+            event_type=EventType(str(parsed.get("event_type", "unknown"))),
+            description=str(parsed.get("description", title)),
+            source=source_name,
+            confidence_score=float(parsed.get("confidence_score", 0.5)),  # type: ignore[arg-type]
+            intensity=EventIntensity(str(parsed.get("intensity", "low"))),
+            detected_at=detected_at,
+            affected_instruments=instruments,
+            raw_headline=title,
+        )
+    except (ValidationError, TypeError, ValueError):
+        logger.warning(
+            "classify_event: Pydantic validation failed for event_id=%s; skipping",
+            event_id,
+            exc_info=True,
+        )
+        return None
+
+    return event
 
 
 def run_event_detection() -> list[DetectedEvent]:
@@ -73,9 +287,10 @@ def run_event_detection() -> list[DetectedEvent]:
         List of DetectedEvent objects detected in this cycle.
 
     Raises:
-        NotImplementedError: Until implemented.
+        NotImplementedError: Until implemented in issue #105.
     """
     raise NotImplementedError(
         "run_event_detection not yet implemented. "
-        "TODO: Orchestrate fetch_news_events, classify_event, write_detected_events."
+        "TODO: Orchestrate fetch_news_events, fetch_gdelt_events, classify_event, "
+        "write_detected_events. See issue #105."
     )

--- a/src/agents/event_detection/models.py
+++ b/src/agents/event_detection/models.py
@@ -65,3 +65,19 @@ class EIAInventoryRecord(BaseModel):
     )
     source: str = Field(default="eia", description="Data source identifier")
     fetched_at: datetime = Field(..., description="UTC timestamp of the fetch")
+
+
+class ClassifyLLMResponse(BaseModel):
+    """
+    Pydantic boundary model for the LLM JSON response from classify_event.
+
+    Validates the raw dict returned by json.loads() before any field is accessed,
+    satisfying ESOD-1 (Pydantic at every module boundary).
+    """
+
+    is_relevant: bool
+    event_type: str
+    confidence_score: float = Field(..., ge=0.0, le=1.0)
+    intensity: str
+    description: str
+    affected_instruments: list[str] = Field(default_factory=list)

--- a/src/agents/event_detection/models.py
+++ b/src/agents/event_detection/models.py
@@ -46,3 +46,22 @@ class DetectedEvent(BaseModel):
     detected_at: datetime = Field(..., description="UTC timestamp of detection")
     affected_instruments: list[str] = Field(default_factory=list)
     raw_headline: str | None = Field(default=None)
+
+
+class EIAInventoryRecord(BaseModel):
+    """
+    Weekly EIA petroleum status report record.
+
+    Stores crude oil stocks and refinery utilization for one reporting period.
+    period follows EIA format: 'YYYY-WW' (e.g. '2024-10' for week 10 of 2024).
+    """
+
+    period: str = Field(..., description="EIA reporting period, e.g. '2024-10'")
+    crude_stocks_mb: float | None = Field(
+        default=None, description="U.S. crude oil stocks in millions of barrels"
+    )
+    refinery_utilization_pct: float | None = Field(
+        default=None, description="Refinery utilization rate as a percentage"
+    )
+    source: str = Field(default="eia", description="Data source identifier")
+    fetched_at: datetime = Field(..., description="UTC timestamp of the fetch")

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -57,8 +57,51 @@ _FRONT_MONTH_INSTRUMENT: str = "CL=F"
 _SECOND_MONTH_TICKER: str = "CLG=F"
 
 
+def _month_code_for(month: int) -> str:
+    """Return CME futures month code for a 1..12 month."""
+    codes = [
+        "F",
+        "G",
+        "H",
+        "J",
+        "K",
+        "M",
+        "N",
+        "Q",
+        "U",
+        "V",
+        "X",
+        "Z",
+    ]
+    return codes[(month - 1) % 12]
+
+
+def _resolve_second_month_ticker(lookahead_months: int = 6) -> str | None:
+    """Try to resolve a valid second-month WTI ticker by probing nearby month codes.
+
+    Attempts up to `lookahead_months` months ahead from current UTC month and
+    returns the first ticker whose yfinance `fast_info.last_price` is present.
+    Returns None if no candidate yields a price.
+    """
+    now = datetime.now(UTC)
+    for i in range(1, lookahead_months + 1):
+        candidate_month = ((now.month - 1 + i) % 12) + 1
+        code = _month_code_for(candidate_month)
+        ticker = f"CL{code}=F"
+        try:
+            info = yf.Ticker(ticker).fast_info
+            price = getattr(info, "last_price", None)
+            if price is not None:
+                return ticker
+        except Exception:
+            # ignore and try next candidate
+            continue
+    return None
+
+
+
 @with_retry()
-def _fetch_second_month_price(ticker: str = _SECOND_MONTH_TICKER) -> float:
+def _fetch_second_month_price(ticker: str | None = None) -> float:
     """Fetch the second-month WTI futures price via yfinance.
 
     Decorated with @with_retry() so transient network failures are retried
@@ -73,6 +116,14 @@ def _fetch_second_month_price(ticker: str = _SECOND_MONTH_TICKER) -> float:
     Raises:
         RuntimeError: If yfinance returns no price data.
     """
+    # If caller did not provide a ticker, attempt dynamic resolution first.
+    if not ticker:
+        resolved = _resolve_second_month_ticker()
+        if resolved:
+            ticker = resolved
+        else:
+            ticker = _SECOND_MONTH_TICKER  # fallback-only default
+
     info = yf.Ticker(ticker).fast_info
     price: float | None = getattr(info, "last_price", None)
     if price is None:

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -48,6 +48,10 @@ _CV_CAP: float = 1.0
 _MEAN_PRICE_ZERO: float = 0.0
 
 # Type weights for supply shock probability (issue #106)
+# Event-type weights for supply shock probability estimation.
+# Values reflect domain calibration of relative market impact severity
+# (issue #106): supply disruptions and refinery outages are direct supply
+# shocks; geopolitical/sanctions are indirect; unknown events are near-zero.
 _TYPE_WEIGHT: dict[str, float] = {
     "supply_disruption": 1.0,
     "refinery_outage": 0.9,
@@ -57,11 +61,13 @@ _TYPE_WEIGHT: dict[str, float] = {
     "unknown": 0.1,
 }
 
-# Intensity weights for supply shock probability estimation
+# Intensity weights for supply shock probability estimation.
+# Values calibrated per issue #106: high=1.0 (full weight), medium=0.6,
+# low=0.3 (rounded from prior 0.66/0.33 to cleaner calibration points).
 _INTENSITY_WEIGHT: dict[str, float] = {
     "high": 1.0,
-    "medium": 0.6,
-    "low": 0.3,
+    "medium": 0.6,  # rounded from 0.66 per issue #106 calibration
+    "low": 0.3,  # rounded from 0.33 per issue #106 calibration
 }
 
 
@@ -216,8 +222,8 @@ def compute_supply_shock_probability(events: list[DetectedEvent]) -> float | Non
 
     total = 0.0
     for ev in events:
-        type_w = _TYPE_WEIGHT.get(str(ev.event_type), 0.0)
-        intensity_w = _INTENSITY_WEIGHT.get(str(ev.intensity), 0.0)
+        type_w = _TYPE_WEIGHT.get(ev.event_type.value, 0.0)
+        intensity_w = _INTENSITY_WEIGHT.get(ev.intensity.value, 0.0)
         total += type_w * intensity_w * ev.confidence_score
 
     return min(total, 1.0)

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -93,11 +93,12 @@ def _resolve_second_month_ticker(lookahead_months: int = 6) -> str | None:
             price = getattr(info, "last_price", None)
             if price is not None:
                 return ticker
-        except Exception:
-            # ignore and try next candidate
+        except Exception as exc:  # avoid bare except; log and continue
+            logger.debug(
+                "_resolve_second_month_ticker: yfinance probe failed for %s: %s", ticker, exc
+            )
             continue
     return None
-
 
 
 @with_retry()

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -47,10 +47,22 @@ _CV_CAP: float = 1.0
 # Guard: mean sector price must exceed this before CV division is safe
 _MEAN_PRICE_ZERO: float = 0.0
 
+# Type weights for supply shock probability (issue #106)
+_TYPE_WEIGHT: dict[str, float] = {
+    "supply_disruption": 1.0,
+    "refinery_outage": 0.9,
+    "tanker_chokepoint": 0.7,
+    "geopolitical": 0.5,
+    "sanctions": 0.4,
+    "unknown": 0.1,
+}
+
 # Intensity weights for supply shock probability estimation
-_INTENSITY_WEIGHT_LOW: float = 0.33
-_INTENSITY_WEIGHT_MEDIUM: float = 0.66
-_INTENSITY_WEIGHT_HIGH: float = 1.0
+_INTENSITY_WEIGHT: dict[str, float] = {
+    "high": 1.0,
+    "medium": 0.6,
+    "low": 0.3,
+}
 
 
 def compute_volatility_gap(market_state: MarketState) -> list[VolatilityGap]:
@@ -182,68 +194,33 @@ def compute_sector_dispersion(market_state: MarketState) -> float | None:
     return min(cv, _CV_CAP)
 
 
-def compute_supply_shock_probability(events: list[DetectedEvent]) -> float:
+def compute_supply_shock_probability(events: list[DetectedEvent]) -> float | None:
     """
-    Estimate supply shock probability based on detected events.
+    Estimate supply shock probability from a list of DetectedEvent objects.
+
+    Score formula: for each event, compute
+        weight = TYPE_WEIGHT[event_type] * INTENSITY_WEIGHT[intensity] * confidence_score
+    Sum all weights and cap the result at 1.0.
+
+    Returns None when the event list is empty to signal "no data available"
+    (distinct from 0.0, which means "data present but no shock detected").
 
     Args:
-        events: DetectedEvent objects from Event Detection Agent.
+        events: DetectedEvent objects from the Event Detection Agent.
 
     Returns:
-        Float in [0.0, 1.0] representing supply shock probability.
-
-    Raises:
-        NotImplementedError: Until implemented.
+        Float in [0.0, 1.0], or None if events is empty.
     """
-    # Phase 1 lightweight heuristic:
-    # - Consider events that are supply-related (EventType values indicating
-    #   supply disruption, refinery outage, or tanker chokepoint, plus sanctions)
-    # - Map intensity to a numeric weight and treat confidence_score as an
-    #   independent probability that the event represents a true supply shock.
-    # - Combine multiple events by computing the probability that at least one
-    #   of the supply events materializes: 1 - prod(1 - p_i).
     if not events:
-        return 0.0
+        return None
 
-    from src.agents.event_detection.models import (
-        EventIntensity,
-        EventType,
-    )
-
-    # Intensity weights (low, medium, high)
-    intensity_weight = {
-        EventIntensity.LOW: _INTENSITY_WEIGHT_LOW,
-        EventIntensity.MEDIUM: _INTENSITY_WEIGHT_MEDIUM,
-        EventIntensity.HIGH: _INTENSITY_WEIGHT_HIGH,
-    }
-
-    # Supply-related event types to consider
-    supply_types = {
-        EventType.SUPPLY_DISRUPTION,
-        EventType.REFINERY_OUTAGE,
-        EventType.TANKER_CHOKEPOINT,
-        EventType.SANCTIONS,
-    }
-
-    probs: list[float] = []
+    total = 0.0
     for ev in events:
-        if ev.event_type in supply_types:
-            weight = intensity_weight.get(ev.intensity, 0.0)
-            p = max(0.0, min(1.0, ev.confidence_score * weight))
-            probs.append(p)
+        type_w = _TYPE_WEIGHT.get(str(ev.event_type), 0.0)
+        intensity_w = _INTENSITY_WEIGHT.get(str(ev.intensity), 0.0)
+        total += type_w * intensity_w * ev.confidence_score
 
-    if not probs:
-        return 0.0
-
-    # Combine independent-event probabilities into a single probability that
-    # at least one supply shock occurs (1 - product(1 - p_i)).
-    prod = 1.0
-    for p in probs:
-        prod *= 1.0 - p
-
-    result = 1.0 - prod
-    # Clamp to [0.0, 1.0]
-    return max(0.0, min(1.0, result))
+    return min(total, 1.0)
 
 
 def run_feature_generation(

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -21,11 +21,14 @@ import logging
 import math
 import statistics
 
+import yfinance as yf
+
 from src.agents.event_detection.models import DetectedEvent
 from src.agents.feature_generation.db import read_price_history, write_feature_set
 from src.agents.feature_generation.models import FeatureSet, VolatilityGap
 from src.agents.ingestion.models import MarketState, OptionRecord
 from src.core.db import get_engine
+from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +49,79 @@ _CV_CAP: float = 1.0
 
 # Guard: mean sector price must exceed this before CV division is safe
 _MEAN_PRICE_ZERO: float = 0.0
+
+# Front-month WTI futures instrument in market_state.prices
+_FRONT_MONTH_INSTRUMENT: str = "CL=F"
+
+# Second-month WTI futures ticker for yfinance fetch
+_SECOND_MONTH_TICKER: str = "CLG=F"
+
+
+@with_retry()
+def _fetch_second_month_price(ticker: str = _SECOND_MONTH_TICKER) -> float:
+    """Fetch the second-month WTI futures price via yfinance.
+
+    Decorated with @with_retry() so transient network failures are retried
+    before propagating to compute_futures_curve_steepness.
+
+    Args:
+        ticker: yfinance ticker symbol for the second-month contract.
+
+    Returns:
+        Last price as a float.
+
+    Raises:
+        RuntimeError: If yfinance returns no price data.
+    """
+    info = yf.Ticker(ticker).fast_info
+    price: float | None = getattr(info, "last_price", None)
+    if price is None:
+        raise RuntimeError(f"yfinance returned no price for {ticker}")
+    return float(price)
+
+
+def compute_futures_curve_steepness(market_state: MarketState) -> float | None:
+    """Compute WTI futures curve slope from front-month and second-month prices.
+
+    Formula: (second_month - front_month) / front_month
+
+    Positive values indicate contango (second month > front month);
+    negative values indicate backwardation (typical during supply constraints).
+
+    Args:
+        market_state: Current validated market snapshot from Ingestion Agent.
+
+    Returns:
+        Normalized spread as a float, or None if front-month price is absent
+        from market_state or the second-month fetch fails (WARNING logged).
+    """
+    front_record = next(
+        (r for r in market_state.prices if r.instrument == _FRONT_MONTH_INSTRUMENT),
+        None,
+    )
+    if front_record is None:
+        logger.warning(
+            "Front-month instrument %s not in market_state.prices — "
+            "cannot compute futures curve steepness",
+            _FRONT_MONTH_INSTRUMENT,
+        )
+        return None
+
+    front_price = front_record.price
+
+    try:
+        second_price = _fetch_second_month_price()
+    except Exception as exc:
+        logger.warning(
+            "Failed to fetch second-month price (%s): %s — "
+            "cannot compute futures curve steepness",
+            _SECOND_MONTH_TICKER,
+            exc,
+        )
+        return None
+
+    return (second_price - front_price) / front_price
+
 
 # Type weights for supply shock probability (issue #106)
 # Event-type weights for supply shock probability estimation.
@@ -251,6 +327,7 @@ def run_feature_generation(
     feature_errors: list[str] = []
     volatility_gaps: list[VolatilityGap] = []
     sector_dispersion: float | None = None
+    futures_curve_steepness: float | None = None
     supply_shock_probability: float | None = None
 
     try:
@@ -268,6 +345,13 @@ def run_feature_generation(
         feature_errors.append(msg)
 
     try:
+        futures_curve_steepness = compute_futures_curve_steepness(market_state)
+    except Exception as exc:
+        msg = f"compute_futures_curve_steepness failed: {exc}"
+        logger.warning(msg)
+        feature_errors.append(msg)
+
+    try:
         supply_shock_probability = compute_supply_shock_probability(events)
     except Exception as exc:
         msg = f"compute_supply_shock_probability failed: {exc}"
@@ -278,6 +362,7 @@ def run_feature_generation(
         snapshot_time=market_state.snapshot_time,
         volatility_gaps=volatility_gaps,
         sector_dispersion=sector_dispersion,
+        futures_curve_steepness=futures_curve_steepness,
         supply_shock_probability=supply_shock_probability,
         feature_errors=feature_errors,
     )

--- a/src/agents/feature_generation/feature_generation_agent.py
+++ b/src/agents/feature_generation/feature_generation_agent.py
@@ -108,6 +108,13 @@ def compute_futures_curve_steepness(market_state: MarketState) -> float | None:
         return None
 
     front_price = front_record.price
+    if front_price <= 0.0 or not math.isfinite(front_price):
+        logger.warning(
+            "Front-month price %s is non-positive or non-finite — "
+            "cannot compute futures curve steepness",
+            front_price,
+        )
+        return None
 
     try:
         second_price = _fetch_second_month_price()

--- a/src/agents/pr_review/pr_review_agent.py
+++ b/src/agents/pr_review/pr_review_agent.py
@@ -42,7 +42,7 @@ from src.core.llm_wrapper import LLMWrapper
 logger = logging.getLogger(__name__)
 
 # Regex patterns for static rule checks (git_workflow.md)
-_BRANCH_RE = re.compile(r"^(feature|fix|refactor|chore|test|docs)/\d+-[a-z0-9-]+$")
+_BRANCH_RE = re.compile(r"^(feature|fix|refactor|chore|test|docs|infra)/\d+-[a-z0-9-]+$")
 _COMMIT_ISSUE_RE = re.compile(r"#\d+")
 _LANGCHAIN_RE = re.compile(r"^\s*(import|from)\s+(langchain|langgraph)", re.MULTILINE)
 _TYPE_HINT_DEF_RE = re.compile(r"^def\s+[a-z_][a-zA-Z0-9_]*\s*\([^)]*\)(?!\s*->)", re.MULTILINE)

--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -97,7 +97,8 @@ def compute_edge_score(
 
     Formula:
         base = vol_gap_norm * _VOL_GAP_WEIGHT + disp_norm * _DISPERSION_WEIGHT
-        score = base * (1 + _SUPPLY_SHOCK_WEIGHT * supply_shock) * (1 + _CURVE_STEEPNESS_WEIGHT * |curve_steepness|)
+        score = base * (1 + _SUPPLY_SHOCK_WEIGHT * supply_shock)
+              * (1 + _CURVE_STEEPNESS_WEIGHT * |curve_steepness|)
         return min(score, 1.0)
 
     When supply_shock_probability or futures_curve_steepness is None, the
@@ -182,8 +183,8 @@ def _supply_shock_label(feature_set: FeatureSet) -> str:
         feature_set: Current FeatureSet from Feature Generation Agent.
 
     Returns:
-        'high' if probability > _SUPPLY_SHOCK_HIGH_THRESHOLD, 'medium' if > _SUPPLY_SHOCK_MEDIUM_THRESHOLD,
-        'low' if > 0, 'none' if None or 0.
+        'high' if probability > _SUPPLY_SHOCK_HIGH_THRESHOLD,
+        'medium' if > _SUPPLY_SHOCK_MEDIUM_THRESHOLD, 'low' if > 0, 'none' if None or 0.
     """
     prob = feature_set.supply_shock_probability
     if prob is None or prob == 0.0:

--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -73,6 +73,10 @@ _MIN_EDGE_SCORE: float = 0.10
 _DISPERSION_HIGH_THRESHOLD: float = 0.15  # CV > 15% = high dispersion
 _DISPERSION_MEDIUM_THRESHOLD: float = 0.05  # CV > 5%  = medium dispersion
 
+# Thresholds for supply shock probability labels
+_SUPPLY_SHOCK_HIGH_THRESHOLD: float = 0.60  # probability > 60% = high
+_SUPPLY_SHOCK_MEDIUM_THRESHOLD: float = 0.30  # probability > 30% = medium
+
 # Phase 2 multiplier weights for supply shock and futures curve steepness
 _SUPPLY_SHOCK_WEIGHT: float = 0.30
 _CURVE_STEEPNESS_WEIGHT: float = 0.15
@@ -92,8 +96,8 @@ def compute_edge_score(
     amplify the base score when present.
 
     Formula:
-        base = vol_gap_norm * 0.70 + disp_norm * 0.30
-        score = base * (1 + 0.30 * supply_shock) * (1 + 0.15 * |curve_steepness|)
+        base = vol_gap_norm * _VOL_GAP_WEIGHT + disp_norm * _DISPERSION_WEIGHT
+        score = base * (1 + _SUPPLY_SHOCK_WEIGHT * supply_shock) * (1 + _CURVE_STEEPNESS_WEIGHT * |curve_steepness|)
         return min(score, 1.0)
 
     When supply_shock_probability or futures_curve_steepness is None, the
@@ -102,8 +106,10 @@ def compute_edge_score(
     Args:
         instrument: Ticker symbol of the instrument to evaluate.
         feature_set: Computed signals from Feature Generation Agent.
-        supply_shock_probability: From FeatureSet, or None if unavailable.
-        futures_curve_steepness: From FeatureSet, or None if unavailable.
+        supply_shock_probability: Float in [0.0, 1.0], or None if unavailable.
+            Pydantic validation on FeatureSet.supply_shock_probability enforces range.
+        futures_curve_steepness: Unbounded float (WTI futures curve slope; contango > 0).
+            None if unavailable.
 
     Returns:
         Float in [0.0, 1.0]. Higher = stronger signal confluence.
@@ -176,15 +182,15 @@ def _supply_shock_label(feature_set: FeatureSet) -> str:
         feature_set: Current FeatureSet from Feature Generation Agent.
 
     Returns:
-        'high' if probability > 0.6, 'medium' if > 0.3, 'low' if > 0,
-        'none' if None or 0.
+        'high' if probability > _SUPPLY_SHOCK_HIGH_THRESHOLD, 'medium' if > _SUPPLY_SHOCK_MEDIUM_THRESHOLD,
+        'low' if > 0, 'none' if None or 0.
     """
     prob = feature_set.supply_shock_probability
     if prob is None or prob == 0.0:
         return "none"
-    if prob > 0.6:
+    if prob > _SUPPLY_SHOCK_HIGH_THRESHOLD:
         return "high"
-    if prob > 0.3:
+    if prob > _SUPPLY_SHOCK_MEDIUM_THRESHOLD:
         return "medium"
     return "low"
 

--- a/src/agents/strategy_evaluation/strategy_evaluation_agent.py
+++ b/src/agents/strategy_evaluation/strategy_evaluation_agent.py
@@ -73,17 +73,37 @@ _MIN_EDGE_SCORE: float = 0.10
 _DISPERSION_HIGH_THRESHOLD: float = 0.15  # CV > 15% = high dispersion
 _DISPERSION_MEDIUM_THRESHOLD: float = 0.05  # CV > 5%  = medium dispersion
 
+# Phase 2 multiplier weights for supply shock and futures curve steepness
+_SUPPLY_SHOCK_WEIGHT: float = 0.30
+_CURVE_STEEPNESS_WEIGHT: float = 0.15
 
-def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
+
+def compute_edge_score(
+    instrument: str,
+    feature_set: FeatureSet,
+    supply_shock_probability: float | None = None,
+    futures_curve_steepness: float | None = None,
+) -> float:
     """
     Compute a composite edge score for a given instrument from the FeatureSet.
 
-    Scoring is static/heuristic for Phase 1 MVP.
-    ML-based dynamic weighting is explicitly deferred (ESOD Section 8).
+    Phase 1 base score: weighted sum of volatility gap and sector dispersion.
+    Phase 2 multipliers: supply shock probability and futures curve steepness
+    amplify the base score when present.
+
+    Formula:
+        base = vol_gap_norm * 0.70 + disp_norm * 0.30
+        score = base * (1 + 0.30 * supply_shock) * (1 + 0.15 * |curve_steepness|)
+        return min(score, 1.0)
+
+    When supply_shock_probability or futures_curve_steepness is None, the
+    corresponding multiplier is 1.0 (no effect), preserving Phase 1 behavior.
 
     Args:
         instrument: Ticker symbol of the instrument to evaluate.
         feature_set: Computed signals from Feature Generation Agent.
+        supply_shock_probability: From FeatureSet, or None if unavailable.
+        futures_curve_steepness: From FeatureSet, or None if unavailable.
 
     Returns:
         Float in [0.0, 1.0]. Higher = stronger signal confluence.
@@ -104,7 +124,13 @@ def compute_edge_score(instrument: str, feature_set: FeatureSet) -> float:
     disp_norm = feature_set.sector_dispersion if feature_set.sector_dispersion is not None else 0.0
     disp_contribution = disp_norm * _DISPERSION_WEIGHT
 
-    return vol_gap_contribution + disp_contribution
+    base_score = vol_gap_contribution + disp_contribution
+
+    # --- Phase 2 multipliers ---
+    shock_multiplier = 1.0 + _SUPPLY_SHOCK_WEIGHT * (supply_shock_probability or 0.0)
+    curve_multiplier = 1.0 + _CURVE_STEEPNESS_WEIGHT * abs(futures_curve_steepness or 0.0)
+
+    return min(base_score * shock_multiplier * curve_multiplier, 1.0)
 
 
 def _vol_gap_label(instrument: str, feature_set: FeatureSet) -> str:
@@ -143,6 +169,41 @@ def _dispersion_label(feature_set: FeatureSet) -> str:
     return "low"
 
 
+def _supply_shock_label(feature_set: FeatureSet) -> str:
+    """Return human-readable supply shock probability label.
+
+    Args:
+        feature_set: Current FeatureSet from Feature Generation Agent.
+
+    Returns:
+        'high' if probability > 0.6, 'medium' if > 0.3, 'low' if > 0,
+        'none' if None or 0.
+    """
+    prob = feature_set.supply_shock_probability
+    if prob is None or prob == 0.0:
+        return "none"
+    if prob > 0.6:
+        return "high"
+    if prob > 0.3:
+        return "medium"
+    return "low"
+
+
+def _curve_steepness_label(feature_set: FeatureSet) -> str:
+    """Return human-readable futures curve steepness label.
+
+    Args:
+        feature_set: Current FeatureSet from Feature Generation Agent.
+
+    Returns:
+        'contango' if steepness > 0, 'backwardation' if < 0, 'flat' if None or 0.
+    """
+    steep = feature_set.futures_curve_steepness
+    if steep is None or steep == 0.0:
+        return "flat"
+    return "contango" if steep > 0 else "backwardation"
+
+
 def evaluate_strategies(feature_set: FeatureSet) -> list[StrategyCandidate]:
     """
     Evaluate all eligible option structures across all in-scope instruments.
@@ -164,13 +225,20 @@ def evaluate_strategies(feature_set: FeatureSet) -> list[StrategyCandidate]:
     candidates: list[StrategyCandidate] = []
 
     for instrument in INSTRUMENTS_IN_SCOPE:
-        edge_score = compute_edge_score(instrument, feature_set)
+        edge_score = compute_edge_score(
+            instrument,
+            feature_set,
+            supply_shock_probability=feature_set.supply_shock_probability,
+            futures_curve_steepness=feature_set.futures_curve_steepness,
+        )
         if edge_score < _MIN_EDGE_SCORE:
             continue
 
         signals: dict[str, str] = {
             "volatility_gap": _vol_gap_label(instrument, feature_set),
             "sector_dispersion": _dispersion_label(feature_set),
+            "supply_shock_probability": _supply_shock_label(feature_set),
+            "futures_curve_steepness": _curve_steepness_label(feature_set),
         }
 
         for structure in _PHASE_1_STRUCTURES:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -8,17 +8,15 @@ Wires the four agents into a single end-to-end evaluation cycle:
 This module is the entry point for running the full pipeline. Individual
 agents can also be called in isolation for testing or partial runs.
 
-Phase notes (from PRD Section 3):
+Phase 2 data flow:
+    1. run_ingestion()           → MarketState
+    2. run_event_detection()     → list[DetectedEvent]  (independent of ingestion)
+    3. run_feature_generation(market_state, events=events) → FeatureSet
+    4. evaluate_strategies(feature_set) → list[StrategyCandidate]
 
-  Phase 1 (current): Event Detection runs in parallel with Ingestion but
-    its results are NOT yet fed into Feature Generation. The call:
-
-        run_feature_generation(market_state, events=[])
-
-    The empty events list is intentional. When Phase 2 is implemented,
-    replace the hardcoded [] with the return value of run_event_detection().
-
-  Phase 2+: run_event_detection() results flow into run_feature_generation().
+Event detection failures are non-fatal: the pipeline continues with an empty
+events list (degraded mode) so that ingestion and feature generation still
+produce actionable candidates.
 
 ESOD constraints: Python 3.11+, type hints on all public functions,
 no langchain.*/langgraph.* imports, DATABASE_URL from environment.
@@ -28,6 +26,10 @@ from __future__ import annotations
 
 import logging
 
+import requests
+
+from src.agents.event_detection.event_detection_agent import run_event_detection
+from src.agents.event_detection.models import DetectedEvent
 from src.agents.feature_generation.feature_generation_agent import run_feature_generation
 from src.agents.ingestion.ingestion_agent import run_ingestion
 from src.agents.strategy_evaluation.models import StrategyCandidate
@@ -42,20 +44,29 @@ def run_pipeline() -> list[StrategyCandidate]:
 
     Call sequence:
         1. run_ingestion()            → MarketState
-        2. run_feature_generation(    → FeatureSet
+        2. run_event_detection()      → list[DetectedEvent]
+        3. run_feature_generation(    → FeatureSet
                market_state,
-               events=[],             ← Phase 1: Event Detection not yet implemented
+               events=events,
            )
-        3. evaluate_strategies(       → list[StrategyCandidate]
+        4. evaluate_strategies(       → list[StrategyCandidate]
                feature_set
            )
 
-    Phase 1 note: Event Detection (run_event_detection) raises NotImplementedError
-    and is skipped. Replace events=[] with run_event_detection() results in Phase 2.
+    Degraded Mode:
+        Event detection runs independently and may fail (network outage, API rate limits,
+        LLM service unavailable, etc.). On failure, the pipeline logs a WARNING and
+        continues with events=[], allowing ingestion and feature generation to produce
+        candidates based on market signals alone.
+
+        This graceful degradation ensures a partial outage in the event detection layer
+        does not suppress the entire pipeline. The returned candidate list is valid but
+        may lack event-driven signals.
 
     Returns:
         Ranked list of StrategyCandidate objects, sorted by edge_score descending.
         Returns an empty list if no viable candidates are found.
+        May return candidates with degraded signal set (no events) on event detection failure.
 
     Raises:
         RuntimeError: If DATABASE_URL is not set or run_ingestion() fails fatally.
@@ -70,9 +81,14 @@ def run_pipeline() -> list[StrategyCandidate]:
         len(market_state.ingestion_errors),
     )
 
-    # Phase 1: Event Detection not yet implemented — pass empty events list.
-    # Phase 2: replace [] with run_event_detection() result.
-    feature_set = run_feature_generation(market_state, events=[])
+    events: list[DetectedEvent] = []
+    try:
+        events = run_event_detection()
+    except (requests.RequestException, RuntimeError) as exc:
+        logger.warning("Event detection failed (degraded mode); continuing with events=[]: %s", exc)
+    logger.info("Event detection complete: %d event(s)", len(events))
+
+    feature_set = run_feature_generation(market_state, events=events)
     logger.info(
         "Feature generation complete: %d gap(s), dispersion=%s, %d error(s)",
         len(feature_set.volatility_gaps),

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -26,9 +26,10 @@ from __future__ import annotations
 
 import logging
 
-import requests
-
-from src.agents.event_detection.event_detection_agent import run_event_detection
+from src.agents.event_detection.event_detection_agent import (
+    EventDetectionError,
+    run_event_detection,
+)
 from src.agents.event_detection.models import DetectedEvent
 from src.agents.feature_generation.feature_generation_agent import run_feature_generation
 from src.agents.ingestion.ingestion_agent import run_ingestion
@@ -70,6 +71,11 @@ def run_pipeline() -> list[StrategyCandidate]:
 
     Raises:
         RuntimeError: If DATABASE_URL is not set or run_ingestion() fails fatally.
+
+    Note:
+        EventDetectionError is intentionally caught and not re-raised. Event detection
+        failure is non-fatal: the pipeline continues with events=[] (degraded mode) and
+        still returns candidates based on market signals alone.
     """
     logger.info("Pipeline cycle starting")
 
@@ -84,7 +90,7 @@ def run_pipeline() -> list[StrategyCandidate]:
     events: list[DetectedEvent] = []
     try:
         events = run_event_detection()
-    except (requests.RequestException, RuntimeError) as exc:
+    except EventDetectionError as exc:
         logger.warning("Event detection failed (degraded mode); continuing with events=[]: %s", exc)
     logger.info("Event detection complete: %d event(s)", len(events))
 

--- a/tests/agents/event_detection/test_classify_event.py
+++ b/tests/agents/event_detection/test_classify_event.py
@@ -1,0 +1,175 @@
+"""
+Unit tests for classify_event().
+
+All LLM calls are mocked via unittest.mock.patch so no API key or
+network connectivity is required.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import classify_event
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SUPPLY_ARTICLE: dict[str, object] = {
+    "title": "OPEC cuts output by 1 million barrels per day",
+    "description": "OPEC+ agreed to reduce production to support prices.",
+    "url": "https://reuters.com/opec-cut-2026",
+    "publishedAt": "2026-03-15T18:00:00Z",
+    "source": {"name": "Reuters"},
+}
+
+_IRRELEVANT_ARTICLE: dict[str, object] = {
+    "title": "Local bakery wins award for best croissant",
+    "description": "A bakery in Paris won a national pastry award.",
+    "url": "https://example.com/bakery-award",
+    "publishedAt": "2026-03-15T10:00:00Z",
+    "source": {"name": "FoodNews"},
+}
+
+_RELEVANT_LLM_RESPONSE = json.dumps(
+    {
+        "is_relevant": True,
+        "event_type": "supply_disruption",
+        "confidence_score": 0.9,
+        "intensity": "high",
+        "description": "OPEC+ cuts output by 1 mb/d to support crude prices.",
+        "affected_instruments": ["USO", "XLE", "CL=F"],
+    }
+)
+
+_IRRELEVANT_LLM_RESPONSE = json.dumps(
+    {
+        "is_relevant": False,
+        "event_type": "unknown",
+        "confidence_score": 0.0,
+        "intensity": "low",
+        "description": "",
+        "affected_instruments": [],
+    }
+)
+
+
+def _mock_llm(content: str) -> MagicMock:
+    llm_response = MagicMock()
+    llm_response.content = content
+    wrapper = MagicMock()
+    wrapper.complete.return_value = llm_response
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyEvent:
+    def test_relevant_article_returns_detected_event(self) -> None:
+        """A supply disruption article produces a valid DetectedEvent."""
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(_RELEVANT_LLM_RESPONSE),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert isinstance(result, DetectedEvent)
+        assert result.event_type == EventType.SUPPLY_DISRUPTION
+        assert result.intensity == EventIntensity.HIGH
+        assert result.confidence_score == pytest.approx(0.9)
+        assert "USO" in result.affected_instruments
+
+    def test_irrelevant_article_returns_none(self) -> None:
+        """Articles flagged as not relevant by the LLM return None."""
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(_IRRELEVANT_LLM_RESPONSE),
+        ):
+            result = classify_event(_IRRELEVANT_ARTICLE)
+
+        assert result is None
+
+    def test_event_id_is_deterministic_sha256_prefix(self) -> None:
+        """event_id is the first 16 hex chars of SHA-256(url)."""
+        import hashlib
+
+        expected_id = hashlib.sha256(str(_SUPPLY_ARTICLE["url"]).encode()).hexdigest()[:16]
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(_RELEVANT_LLM_RESPONSE),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is not None
+        assert result.event_id == expected_id
+
+    def test_malformed_llm_json_returns_none(self) -> None:
+        """Non-JSON LLM response logs a warning and returns None."""
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm("this is not json at all"),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is None
+
+    def test_llm_exception_returns_none(self) -> None:
+        """LLM call failure logs a warning and returns None."""
+        wrapper = MagicMock()
+        wrapper.complete.side_effect = RuntimeError("LLM unavailable")
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=wrapper,
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is None
+
+    def test_invalid_event_type_from_llm_returns_none(self) -> None:
+        """LLM returning an invalid EventType value causes Pydantic error → None."""
+        bad_response = json.dumps(
+            {
+                "is_relevant": True,
+                "event_type": "not_a_valid_type",
+                "confidence_score": 0.8,
+                "intensity": "high",
+                "description": "Some event.",
+                "affected_instruments": [],
+            }
+        )
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(bad_response),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is None
+
+    def test_raw_headline_set_to_article_title(self) -> None:
+        """raw_headline on the DetectedEvent matches the article title."""
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(_RELEVANT_LLM_RESPONSE),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is not None
+        assert result.raw_headline == _SUPPLY_ARTICLE["title"]
+
+    def test_source_name_extracted_from_source_dict(self) -> None:
+        """source field on DetectedEvent uses source.name from article dict."""
+        with patch(
+            "src.agents.event_detection.event_detection_agent.LLMWrapper",
+            return_value=_mock_llm(_RELEVANT_LLM_RESPONSE),
+        ):
+            result = classify_event(_SUPPLY_ARTICLE)
+
+        assert result is not None
+        assert result.source == "Reuters"

--- a/tests/agents/event_detection/test_event_detection_agent.py
+++ b/tests/agents/event_detection/test_event_detection_agent.py
@@ -1,32 +1,8 @@
 """
 Unit tests for the Event Detection Agent.
 
-Coverage goal (expand per GitHub Issue):
-  - run_event_detection: returns list of DetectedEvent
-  - classify_event: correct EventType and intensity for known headlines
-  - fetch_news_events: retry behavior on API failure
+run_event_detection() tests live in test_run_event_detection.py (issue #105).
+classify_event() tests live in test_classify_event.py (issue #104).
+fetch_news_events() / fetch_gdelt_events() tests live in test_fetch_news_gdelt.py (#102/#103).
+fetch_eia_data() tests live in test_fetch_eia.py (issue #101).
 """
-
-import pytest
-
-from src.agents.event_detection.event_detection_agent import run_event_detection
-from src.agents.event_detection.models import DetectedEvent
-
-
-class TestRunEventDetection:
-    """Tests for run_event_detection() orchestration function."""
-
-    @pytest.mark.xfail(reason="Not yet implemented", strict=True)
-    def test_run_event_detection_returns_list(self) -> None:
-        """run_event_detection() must return a list of DetectedEvent instances."""
-        result = run_event_detection()
-        assert isinstance(result, list)
-        for item in result:
-            assert isinstance(item, DetectedEvent)
-
-    @pytest.mark.xfail(reason="Not yet implemented", strict=True)
-    def test_detected_event_confidence_in_range(self) -> None:
-        """All DetectedEvent confidence_score values must be in [0.0, 1.0]."""
-        result = run_event_detection()
-        for event in result:
-            assert 0.0 <= event.confidence_score <= 1.0

--- a/tests/agents/event_detection/test_event_detection_agent_integration.py
+++ b/tests/agents/event_detection/test_event_detection_agent_integration.py
@@ -252,7 +252,10 @@ def test_run_event_detection_full_cycle(pg_engine: Engine) -> None:
     event = _make_event(event_id="cycle-001")
 
     with (
-        patch(_PATCH_FETCH_NEWS, return_value=[{"title": "Oil disruption", "url": "http://example.com/1"}]),
+        patch(
+            _PATCH_FETCH_NEWS,
+            return_value=[{"title": "Oil disruption", "url": "http://example.com/1"}],
+        ),
         patch(_PATCH_FETCH_GDELT, return_value=[]),
         patch(_PATCH_FETCH_EIA, return_value=[]),
         patch(_PATCH_CLASSIFY, return_value=event),
@@ -276,7 +279,10 @@ def test_run_event_detection_partial_failure(pg_engine: Engine) -> None:
 
     with (
         patch(_PATCH_FETCH_NEWS, side_effect=RuntimeError("NewsAPI down")),
-        patch(_PATCH_FETCH_GDELT, return_value=[{"title": "GDELT article", "url": "http://gdelt.example.com/1"}]),
+        patch(
+            _PATCH_FETCH_GDELT,
+            return_value=[{"title": "GDELT article", "url": "http://gdelt.example.com/1"}],
+        ),
         patch(_PATCH_FETCH_EIA, return_value=[]),
         patch(_PATCH_CLASSIFY, return_value=event),
         patch(_PATCH_GET_ENGINE, return_value=pg_engine),

--- a/tests/agents/event_detection/test_event_detection_agent_integration.py
+++ b/tests/agents/event_detection/test_event_detection_agent_integration.py
@@ -1,0 +1,292 @@
+"""
+Integration tests for the Event Detection Agent.
+
+Uses testcontainers.postgres.PostgresContainer — no mocked DB.
+All tests are marked with @pytest.mark.integration and excluded from the
+default `pytest -m "not integration"` run.
+
+Coverage:
+  - write_detected_events / read_recent_events: round-trip with JSONB fields
+  - Duplicate event_id: ON CONFLICT DO NOTHING — exactly one row
+  - run_event_detection: mocked feeds + real DB → events classified, written, returned
+  - run_event_detection: one feed raises — partial results, errors logged, no propagation
+  - write_eia_records: round-trip + idempotent re-insert (same period → no duplicates)
+"""
+
+from __future__ import annotations
+
+import os
+
+# Disable testcontainers Reaper (Ryuk) — required on Windows and some CI environments.
+os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from src.agents.event_detection.db import (
+    read_recent_events,
+    write_detected_events,
+    write_eia_records,
+)
+from src.agents.event_detection.event_detection_agent import run_event_detection
+from src.agents.event_detection.models import (
+    DetectedEvent,
+    EIAInventoryRecord,
+    EventIntensity,
+    EventType,
+)
+
+# ---------------------------------------------------------------------------
+# Patch targets
+# ---------------------------------------------------------------------------
+_PATCH_FETCH_NEWS = "src.agents.event_detection.event_detection_agent.fetch_news_events"
+_PATCH_FETCH_GDELT = "src.agents.event_detection.event_detection_agent.fetch_gdelt_events"
+_PATCH_FETCH_EIA = "src.agents.event_detection.event_detection_agent.fetch_eia_data"
+_PATCH_CLASSIFY = "src.agents.event_detection.event_detection_agent.classify_event"
+_PATCH_GET_ENGINE = "src.agents.event_detection.event_detection_agent.get_engine"
+
+# ---------------------------------------------------------------------------
+# DDL — mirrors detected_events and eia_inventory from db/schema.sql
+# ---------------------------------------------------------------------------
+_DDL = """
+CREATE TABLE IF NOT EXISTS detected_events (
+    id                      BIGSERIAL       PRIMARY KEY,
+    event_id                TEXT            NOT NULL,
+    event_type              TEXT            NOT NULL,
+    description             TEXT            NOT NULL,
+    source                  TEXT            NOT NULL,
+    confidence_score        NUMERIC(5, 4)   NOT NULL,
+    intensity               TEXT            NOT NULL,
+    detected_at             TIMESTAMPTZ     NOT NULL,
+    affected_instruments    JSONB,
+    raw_headline            TEXT,
+    CONSTRAINT uq_detected_events_event_id UNIQUE (event_id)
+);
+
+CREATE TABLE IF NOT EXISTS eia_inventory (
+    id                          BIGSERIAL       PRIMARY KEY,
+    period                      TEXT            NOT NULL,
+    crude_stocks_mb             NUMERIC(12, 3),
+    refinery_utilization_pct    NUMERIC(6, 3),
+    source                      TEXT            NOT NULL DEFAULT 'eia',
+    fetched_at                  TIMESTAMPTZ     NOT NULL,
+    CONSTRAINT uq_eia_inventory_period UNIQUE (period)
+);
+"""
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    """Start a PostgresContainer, apply schema, yield engine, stop container."""
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer("postgres:15") as pg:
+        engine = create_engine(pg.get_connection_url())
+        with engine.begin() as conn:
+            conn.execute(text(_DDL))
+        yield engine
+
+
+@pytest.fixture(autouse=True)
+def _clean_tables(pg_engine: Engine) -> Generator[None, None, None]:
+    """Truncate both tables before each test for isolation."""
+    with pg_engine.begin() as conn:
+        conn.execute(text("TRUNCATE detected_events, eia_inventory RESTART IDENTITY"))
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    event_id: str = "abc123",
+    event_type: EventType = EventType.SUPPLY_DISRUPTION,
+    description: str = "Test supply disruption event",
+    source: str = "newsapi",
+    confidence_score: float = 0.85,
+    intensity: EventIntensity = EventIntensity.HIGH,
+    affected_instruments: list[str] | None = None,
+    raw_headline: str | None = "Oil supply disrupted in Gulf",
+) -> DetectedEvent:
+    return DetectedEvent(
+        event_id=event_id,
+        event_type=event_type,
+        description=description,
+        source=source,
+        confidence_score=confidence_score,
+        intensity=intensity,
+        detected_at=datetime.now(tz=UTC),
+        affected_instruments=affected_instruments or ["CL=F", "USO"],
+        raw_headline=raw_headline,
+    )
+
+
+def _make_eia_record(
+    period: str = "2026-10",
+    crude_stocks_mb: float | None = 430.5,
+    refinery_utilization_pct: float | None = 91.2,
+) -> EIAInventoryRecord:
+    return EIAInventoryRecord(
+        period=period,
+        crude_stocks_mb=crude_stocks_mb,
+        refinery_utilization_pct=refinery_utilization_pct,
+        fetched_at=datetime.now(tz=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests — write_detected_events / read_recent_events round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_write_read_round_trip(pg_engine: Engine) -> None:
+    """Write a DetectedEvent and read it back; all fields including JSONB persist."""
+    event = _make_event(
+        event_id="roundtrip-001",
+        affected_instruments=["CL=F", "BZ=F", "USO"],
+    )
+    count = write_detected_events([event], pg_engine)
+    assert count == 1
+
+    events = read_recent_events(pg_engine, limit=10)
+    assert len(events) == 1
+
+    e = events[0]
+    assert e.event_id == "roundtrip-001"
+    assert e.event_type == EventType.SUPPLY_DISRUPTION
+    assert e.description == "Test supply disruption event"
+    assert e.source == "newsapi"
+    assert float(e.confidence_score) == pytest.approx(0.85, abs=1e-4)
+    assert e.intensity == EventIntensity.HIGH
+    assert e.affected_instruments == ["CL=F", "BZ=F", "USO"]
+    assert e.raw_headline == "Oil supply disrupted in Gulf"
+
+
+@pytest.mark.integration
+def test_duplicate_event_id_ignored(pg_engine: Engine) -> None:
+    """ON CONFLICT (event_id) DO NOTHING — second insert silently skipped."""
+    event = _make_event(event_id="dup-001")
+    write_detected_events([event], pg_engine)
+    write_detected_events([event], pg_engine)
+
+    events = read_recent_events(pg_engine, limit=10)
+    assert len(events) == 1
+
+
+@pytest.mark.integration
+def test_multiple_events_persisted(pg_engine: Engine) -> None:
+    """Multiple distinct events are all persisted."""
+    events = [
+        _make_event(event_id="multi-001", description="Event 1"),
+        _make_event(event_id="multi-002", description="Event 2"),
+        _make_event(event_id="multi-003", description="Event 3"),
+    ]
+    count = write_detected_events(events, pg_engine)
+    assert count == 3
+
+    read_back = read_recent_events(pg_engine, limit=10)
+    assert len(read_back) == 3
+
+
+# ---------------------------------------------------------------------------
+# Tests — write_eia_records round-trip and idempotency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_eia_write_read_round_trip(pg_engine: Engine) -> None:
+    """Write EIA records and verify they persist correctly."""
+    records = [
+        _make_eia_record(period="2026-10", crude_stocks_mb=430.5, refinery_utilization_pct=91.2),
+        _make_eia_record(period="2026-11", crude_stocks_mb=425.0, refinery_utilization_pct=89.5),
+    ]
+    count = write_eia_records(records, pg_engine)
+    assert count == 2
+
+    with pg_engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT period, crude_stocks_mb, refinery_utilization_pct"
+                " FROM eia_inventory ORDER BY period"
+            )
+        ).fetchall()
+    assert len(rows) == 2
+    assert rows[0][0] == "2026-10"
+    assert float(rows[0][1]) == pytest.approx(430.5, abs=0.01)
+    assert float(rows[0][2]) == pytest.approx(91.2, abs=0.01)
+
+
+@pytest.mark.integration
+def test_eia_duplicate_period_ignored(pg_engine: Engine) -> None:
+    """ON CONFLICT (period) DO NOTHING — re-insert same period produces no duplicate."""
+    record = _make_eia_record(period="2026-10")
+    write_eia_records([record], pg_engine)
+    write_eia_records([record], pg_engine)
+
+    with pg_engine.connect() as conn:
+        count = conn.execute(text("SELECT COUNT(*) FROM eia_inventory")).scalar()
+    assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — run_event_detection with mocked feeds + real DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_run_event_detection_full_cycle(pg_engine: Engine) -> None:
+    """Mocked feeds + real DB: events classified, written, and returned."""
+    event = _make_event(event_id="cycle-001")
+
+    with (
+        patch(_PATCH_FETCH_NEWS, return_value=[{"title": "Oil disruption", "url": "http://example.com/1"}]),
+        patch(_PATCH_FETCH_GDELT, return_value=[]),
+        patch(_PATCH_FETCH_EIA, return_value=[]),
+        patch(_PATCH_CLASSIFY, return_value=event),
+        patch(_PATCH_GET_ENGINE, return_value=pg_engine),
+    ):
+        result = run_event_detection()
+
+    assert len(result) == 1
+    assert result[0].event_id == "cycle-001"
+
+    # Verify DB persistence
+    db_events = read_recent_events(pg_engine, limit=10)
+    assert len(db_events) == 1
+    assert db_events[0].event_id == "cycle-001"
+
+
+@pytest.mark.integration
+def test_run_event_detection_partial_failure(pg_engine: Engine) -> None:
+    """One fetch raises — other feeds succeed, errors don't propagate."""
+    event = _make_event(event_id="partial-001")
+
+    with (
+        patch(_PATCH_FETCH_NEWS, side_effect=RuntimeError("NewsAPI down")),
+        patch(_PATCH_FETCH_GDELT, return_value=[{"title": "GDELT article", "url": "http://gdelt.example.com/1"}]),
+        patch(_PATCH_FETCH_EIA, return_value=[]),
+        patch(_PATCH_CLASSIFY, return_value=event),
+        patch(_PATCH_GET_ENGINE, return_value=pg_engine),
+    ):
+        result = run_event_detection()
+
+    # GDELT article still classified and returned
+    assert len(result) == 1
+    assert result[0].event_id == "partial-001"
+
+    # Verify DB persistence for successful feed
+    db_events = read_recent_events(pg_engine, limit=10)
+    assert len(db_events) == 1

--- a/tests/agents/event_detection/test_event_detection_db.py
+++ b/tests/agents/event_detection/test_event_detection_db.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for Event Detection Agent DB functions (write_detected_events,
+read_recent_events, write_eia_records).
+
+Uses MagicMock to simulate the SQLAlchemy engine/connection without a real DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agents.event_detection.db import (
+    read_recent_events,
+    write_detected_events,
+    write_eia_records,
+)
+from src.agents.event_detection.models import (
+    DetectedEvent,
+    EIAInventoryRecord,
+    EventIntensity,
+    EventType,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 15, 20, 0, 0, tzinfo=UTC)
+
+
+def _make_event(
+    event_id: str = "abc123",
+    event_type: EventType = EventType.SUPPLY_DISRUPTION,
+    intensity: EventIntensity = EventIntensity.HIGH,
+    confidence_score: float = 0.9,
+    affected_instruments: list[str] | None = None,
+) -> DetectedEvent:
+    return DetectedEvent(
+        event_id=event_id,
+        event_type=event_type,
+        description="OPEC cuts output by 1 mb/d",
+        source="newsapi",
+        confidence_score=confidence_score,
+        intensity=intensity,
+        detected_at=_NOW,
+        affected_instruments=affected_instruments or ["USO", "XLE"],
+        raw_headline="OPEC agrees to cut",
+    )
+
+
+def _make_eia_record(period: str = "2024-10") -> EIAInventoryRecord:
+    return EIAInventoryRecord(
+        period=period,
+        crude_stocks_mb=430.5,
+        refinery_utilization_pct=91.2,
+        source="eia",
+        fetched_at=_NOW,
+    )
+
+
+def _make_engine() -> MagicMock:
+    """Return a mock engine whose begin() and connect() context managers work."""
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    return engine, conn
+
+
+# ---------------------------------------------------------------------------
+# write_detected_events
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDetectedEvents:
+    def test_empty_list_returns_zero(self) -> None:
+        """Empty input is a no-op; engine is never touched."""
+        engine, _ = _make_engine()
+        result = write_detected_events([], engine)
+        assert result == 0
+        engine.begin.assert_not_called()
+
+    def test_single_event_executes_insert(self) -> None:
+        """One event produces one conn.execute() call with correct row data."""
+        engine, conn = _make_engine()
+        event = _make_event()
+        result = write_detected_events([event], engine)
+        assert result == 1
+        conn.execute.assert_called_once()
+        _, rows = conn.execute.call_args.args
+        assert len(rows) == 1
+        assert rows[0]["event_id"] == "abc123"
+        assert rows[0]["event_type"] == "supply_disruption"
+        assert rows[0]["intensity"] == "high"
+        assert rows[0]["confidence_score"] == 0.9
+
+    def test_multiple_events_all_included(self) -> None:
+        """All events in a batch are included in the single execute call."""
+        engine, conn = _make_engine()
+        events = [_make_event(event_id=f"id{i}") for i in range(5)]
+        result = write_detected_events(events, engine)
+        assert result == 5
+        _, rows = conn.execute.call_args.args
+        assert len(rows) == 5
+
+    def test_affected_instruments_serialized_as_json(self) -> None:
+        """affected_instruments list is JSON-serialized for the JSONB column."""
+        import json
+
+        engine, conn = _make_engine()
+        event = _make_event(affected_instruments=["USO", "XLE", "XOM"])
+        write_detected_events([event], engine)
+        _, rows = conn.execute.call_args.args
+        assert json.loads(rows[0]["affected_instruments"]) == ["USO", "XLE", "XOM"]
+
+    def test_db_exception_propagates(self) -> None:
+        """SQLAlchemy errors are re-raised after logging."""
+        engine = MagicMock()
+        engine.begin.return_value.__enter__ = MagicMock(side_effect=RuntimeError("db down"))
+        engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="db down"):
+            write_detected_events([_make_event()], engine)
+
+
+# ---------------------------------------------------------------------------
+# read_recent_events
+# ---------------------------------------------------------------------------
+
+
+class TestReadRecentEvents:
+    def _make_row(self, event_id: str = "abc123") -> MagicMock:
+        row = MagicMock()
+        row.__getitem__ = lambda self, key: {
+            "event_id": event_id,
+            "event_type": "supply_disruption",
+            "description": "Test event",
+            "source": "newsapi",
+            "confidence_score": 0.85,
+            "intensity": "high",
+            "detected_at": _NOW,
+            "affected_instruments": ["USO"],
+            "raw_headline": "Oil supply cut",
+        }[key]
+        return row
+
+    def test_returns_detected_event_list(self) -> None:
+        """read_recent_events maps DB rows to DetectedEvent objects."""
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = [
+            self._make_row("ev1"),
+            self._make_row("ev2"),
+        ]
+        result = read_recent_events(engine)
+        assert len(result) == 2
+        assert all(isinstance(e, DetectedEvent) for e in result)
+        assert result[0].event_id == "ev1"
+
+    def test_empty_result_returns_empty_list(self) -> None:
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = []
+        result = read_recent_events(engine)
+        assert result == []
+
+    def test_limit_passed_to_query(self) -> None:
+        """limit parameter is forwarded to the SQL query."""
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = []
+        read_recent_events(engine, limit=5)
+        _, params = conn.execute.call_args.args
+        assert params["limit"] == 5
+
+    def test_db_exception_propagates(self) -> None:
+        engine = MagicMock()
+        engine.connect.return_value.__enter__ = MagicMock(side_effect=RuntimeError("timeout"))
+        engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="timeout"):
+            read_recent_events(engine)
+
+
+# ---------------------------------------------------------------------------
+# write_eia_records
+# ---------------------------------------------------------------------------
+
+
+class TestWriteEiaRecords:
+    def test_empty_list_returns_zero(self) -> None:
+        engine, _ = _make_engine()
+        result = write_eia_records([], engine)
+        assert result == 0
+        engine.begin.assert_not_called()
+
+    def test_single_record_executes_insert(self) -> None:
+        engine, conn = _make_engine()
+        record = _make_eia_record("2024-10")
+        result = write_eia_records([record], engine)
+        assert result == 1
+        conn.execute.assert_called_once()
+        _, rows = conn.execute.call_args.args
+        assert rows[0]["period"] == "2024-10"
+        assert rows[0]["crude_stocks_mb"] == 430.5
+        assert rows[0]["refinery_utilization_pct"] == 91.2
+        assert rows[0]["source"] == "eia"
+
+    def test_multiple_records_batch_inserted(self) -> None:
+        engine, conn = _make_engine()
+        records = [_make_eia_record(f"2024-{i:02d}") for i in range(1, 5)]
+        result = write_eia_records(records, engine)
+        assert result == 4
+        _, rows = conn.execute.call_args.args
+        assert len(rows) == 4
+
+    def test_none_fields_passed_through(self) -> None:
+        """Records with None crude_stocks_mb / refinery_utilization_pct are accepted."""
+        engine, conn = _make_engine()
+        record = EIAInventoryRecord(period="2024-01", fetched_at=_NOW)
+        write_eia_records([record], engine)
+        _, rows = conn.execute.call_args.args
+        assert rows[0]["crude_stocks_mb"] is None
+        assert rows[0]["refinery_utilization_pct"] is None
+
+    def test_db_exception_propagates(self) -> None:
+        engine = MagicMock()
+        engine.begin.return_value.__enter__ = MagicMock(side_effect=RuntimeError("db error"))
+        engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="db error"):
+            write_eia_records([_make_eia_record()], engine)

--- a/tests/agents/event_detection/test_event_detection_db.py
+++ b/tests/agents/event_detection/test_event_detection_db.py
@@ -174,6 +174,71 @@ class TestReadRecentEvents:
         _, params = conn.execute.call_args.args
         assert params["limit"] == 5
 
+    def test_default_limit_is_100(self) -> None:
+        """Default limit kwarg matches _DEFAULT_RECENT_EVENTS_LIMIT (not a magic 100)."""
+        from src.agents.event_detection.db import _DEFAULT_RECENT_EVENTS_LIMIT
+
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = []
+        read_recent_events(engine)
+        _, params = conn.execute.call_args.args
+        assert params["limit"] == _DEFAULT_RECENT_EVENTS_LIMIT
+
+    def test_affected_instruments_as_json_string_is_parsed(self) -> None:
+        """If the driver returns affected_instruments as a JSON string, it is parsed."""
+        import json as _json
+
+        row = MagicMock()
+        row.__getitem__ = lambda self, key: {  # type: ignore[misc]
+            "event_id": "strjson",
+            "event_type": "supply_disruption",
+            "description": "Test",
+            "source": "newsapi",
+            "confidence_score": 0.5,
+            "intensity": "low",
+            "detected_at": _NOW,
+            "affected_instruments": _json.dumps(["USO", "XLE"]),  # raw JSON string
+            "raw_headline": None,
+        }[key]
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = [row]
+        result = read_recent_events(engine)
+        assert len(result) == 1
+        assert result[0].affected_instruments == ["USO", "XLE"]
+
+    def test_malformed_row_is_skipped_with_warning(self) -> None:
+        """A row that fails Pydantic validation is skipped; valid rows are returned."""
+        good_row = MagicMock()
+        good_row.__getitem__ = lambda self, key: {  # type: ignore[misc]
+            "event_id": "good1",
+            "event_type": "supply_disruption",
+            "description": "Valid event",
+            "source": "newsapi",
+            "confidence_score": 0.8,
+            "intensity": "high",
+            "detected_at": _NOW,
+            "affected_instruments": [],
+            "raw_headline": None,
+        }[key]
+        bad_row = MagicMock()
+        bad_row.__getitem__ = lambda self, key: {  # type: ignore[misc]
+            "event_id": "bad1",
+            "event_type": "not_a_valid_type",  # invalid enum
+            "description": "Bad event",
+            "source": "newsapi",
+            "confidence_score": 99.9,  # out of range
+            "intensity": "ultra",  # invalid enum
+            "detected_at": _NOW,
+            "affected_instruments": [],
+            "raw_headline": None,
+        }[key]
+        bad_row.get = lambda key, default=None: "bad1" if key == "event_id" else default  # type: ignore[misc]
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = [bad_row, good_row]
+        result = read_recent_events(engine)
+        assert len(result) == 1
+        assert result[0].event_id == "good1"
+
     def test_db_exception_propagates(self) -> None:
         engine = MagicMock()
         engine.connect.return_value.__enter__ = MagicMock(side_effect=RuntimeError("timeout"))

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -1,0 +1,236 @@
+"""
+Unit tests for fetch_eia_data() in the Event Detection Agent.
+
+All HTTP calls are mocked — no real EIA API key or network required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import fetch_eia_data
+from src.agents.event_detection.models import EIAInventoryRecord
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_CRUDE_RESPONSE = {
+    "response": {
+        "data": [
+            {"period": "2024-10", "value": "423.5"},
+            {"period": "2024-09", "value": "418.2"},
+        ]
+    }
+}
+
+_REFINERY_RESPONSE = {
+    "response": {
+        "data": [
+            {"period": "2024-10", "value": "87.4"},
+            {"period": "2024-09", "value": "86.1"},
+        ]
+    }
+}
+
+
+def _mock_response(payload: dict) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = payload
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Missing API key — degraded mode
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataDegradedMode:
+    def test_missing_key_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("EIA_API_KEY", raising=False)
+        result = fetch_eia_data()
+        assert result == []
+
+    def test_missing_key_logs_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        monkeypatch.delenv("EIA_API_KEY", raising=False)
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            fetch_eia_data()
+        assert any("EIA_API_KEY" in m for m in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataHappyPath:
+    def test_returns_list_of_eia_inventory_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert len(result) == 2
+        assert all(isinstance(r, EIAInventoryRecord) for r in result)
+
+    def test_records_sorted_newest_first(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert result[0].period == "2024-10"
+        assert result[1].period == "2024-09"
+
+    def test_crude_stocks_and_refinery_merged_by_period(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        latest = next(r for r in result if r.period == "2024-10")
+        assert latest.crude_stocks_mb == pytest.approx(423.5)
+        assert latest.refinery_utilization_pct == pytest.approx(87.4)
+
+    def test_fetched_at_is_utc_datetime(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        for record in result:
+            assert record.fetched_at.tzinfo is not None
+
+    def test_source_defaults_to_eia(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            result = fetch_eia_data()
+
+        assert all(r.source == "eia" for r in result)
+
+    def test_api_key_sent_in_params(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "my-secret-key")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            fetch_eia_data()
+
+        for c in mock_get.call_args_list:
+            params = c.kwargs.get("params", {})
+            assert params.get("api_key") == "my-secret-key"
+
+    def test_eia_base_url_env_var_used(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        monkeypatch.setenv("EIA_BASE_URL", "http://eia-mock.internal")
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(_CRUDE_RESPONSE),
+                _mock_response(_REFINERY_RESPONSE),
+            ]
+            fetch_eia_data()
+
+        urls = [c.args[0] for c in mock_get.call_args_list]
+        assert all(u.startswith("http://eia-mock.internal") for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# Malformed / partial responses
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEIADataMalformedResponse:
+    def test_empty_data_array_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        empty = {"response": {"data": []}}
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(empty),
+                _mock_response(empty),
+            ]
+            result = fetch_eia_data()
+
+        assert result == []
+
+    def test_null_value_in_series_yields_none_field(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        crude_with_null = {"response": {"data": [{"period": "2024-10", "value": None}]}}
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(crude_with_null),
+                _mock_response({"response": {"data": []}}),
+            ]
+            result = fetch_eia_data()
+
+        assert len(result) == 1
+        assert result[0].crude_stocks_mb is None
+
+    def test_missing_period_key_skipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        bad_crude = {"response": {"data": [{"value": "400.0"}]}}  # no period key
+        with patch("requests.get") as mock_get:
+            mock_get.side_effect = [
+                _mock_response(bad_crude),
+                _mock_response({"response": {"data": []}}),
+            ]
+            result = fetch_eia_data()
+
+        assert result == []
+
+    def test_http_error_propagates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import requests as req_mod
+
+        monkeypatch.setenv("EIA_API_KEY", "test-key")
+        error_resp = MagicMock()
+        error_resp.raise_for_status.side_effect = req_mod.HTTPError("500")
+        with patch("requests.get", return_value=error_resp):
+            with pytest.raises(req_mod.HTTPError):
+                fetch_eia_data()

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -7,6 +7,7 @@ All HTTP calls are mocked — no real EIA API key or network required.
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -157,7 +158,7 @@ class TestFetchEIADataHappyPath:
             fetch_eia_data()
 
         urls = [c.args[0] for c in mock_get.call_args_list]
-        assert all(u.startswith("http://eia-mock.internal") for u in urls)
+        assert all(urlparse(u).netloc == "eia-mock.internal" for u in urls)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agents/event_detection/test_fetch_eia.py
+++ b/tests/agents/event_detection/test_fetch_eia.py
@@ -49,9 +49,7 @@ def _mock_response(payload: dict) -> MagicMock:
 
 
 class TestFetchEIADataDegradedMode:
-    def test_missing_key_returns_empty_list(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("EIA_API_KEY", raising=False)
         result = fetch_eia_data()
         assert result == []
@@ -73,9 +71,7 @@ class TestFetchEIADataDegradedMode:
 
 
 class TestFetchEIADataHappyPath:
-    def test_returns_list_of_eia_inventory_records(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_returns_list_of_eia_inventory_records(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -87,9 +83,7 @@ class TestFetchEIADataHappyPath:
         assert len(result) == 2
         assert all(isinstance(r, EIAInventoryRecord) for r in result)
 
-    def test_records_sorted_newest_first(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_records_sorted_newest_first(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -116,9 +110,7 @@ class TestFetchEIADataHappyPath:
         assert latest.crude_stocks_mb == pytest.approx(423.5)
         assert latest.refinery_utilization_pct == pytest.approx(87.4)
 
-    def test_fetched_at_is_utc_datetime(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_fetched_at_is_utc_datetime(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -130,9 +122,7 @@ class TestFetchEIADataHappyPath:
         for record in result:
             assert record.fetched_at.tzinfo is not None
 
-    def test_source_defaults_to_eia(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_source_defaults_to_eia(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -143,9 +133,7 @@ class TestFetchEIADataHappyPath:
 
         assert all(r.source == "eia" for r in result)
 
-    def test_api_key_sent_in_params(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_api_key_sent_in_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "my-secret-key")
         with patch("requests.get") as mock_get:
             mock_get.side_effect = [
@@ -158,9 +146,7 @@ class TestFetchEIADataHappyPath:
             params = c.kwargs.get("params", {})
             assert params.get("api_key") == "my-secret-key"
 
-    def test_eia_base_url_env_var_used(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_eia_base_url_env_var_used(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         monkeypatch.setenv("EIA_BASE_URL", "http://eia-mock.internal")
         with patch("requests.get") as mock_get:
@@ -180,9 +166,7 @@ class TestFetchEIADataHappyPath:
 
 
 class TestFetchEIADataMalformedResponse:
-    def test_empty_data_array_returns_empty_list(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_empty_data_array_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         empty = {"response": {"data": []}}
         with patch("requests.get") as mock_get:
@@ -194,9 +178,7 @@ class TestFetchEIADataMalformedResponse:
 
         assert result == []
 
-    def test_null_value_in_series_yields_none_field(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_null_value_in_series_yields_none_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         crude_with_null = {"response": {"data": [{"period": "2024-10", "value": None}]}}
         with patch("requests.get") as mock_get:
@@ -209,9 +191,7 @@ class TestFetchEIADataMalformedResponse:
         assert len(result) == 1
         assert result[0].crude_stocks_mb is None
 
-    def test_missing_period_key_skipped(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_missing_period_key_skipped(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("EIA_API_KEY", "test-key")
         bad_crude = {"response": {"data": [{"value": "400.0"}]}}  # no period key
         with patch("requests.get") as mock_get:
@@ -223,9 +203,7 @@ class TestFetchEIADataMalformedResponse:
 
         assert result == []
 
-    def test_http_error_propagates(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import requests as req_mod
 
         monkeypatch.setenv("EIA_API_KEY", "test-key")

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -1,0 +1,179 @@
+"""
+Unit tests for fetch_news_events() and fetch_gdelt_events().
+
+Both functions make HTTP requests to external APIs; all network calls
+are mocked via unittest.mock.patch so no API keys or connectivity are required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import (
+    fetch_gdelt_events,
+    fetch_news_events,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NEWSAPI_ARTICLE = {
+    "title": "OPEC cuts output by 1 million barrels per day",
+    "description": "OPEC+ members agreed to reduce production.",
+    "source": {"name": "Reuters"},
+    "publishedAt": "2026-03-15T18:00:00Z",
+    "url": "https://reuters.com/opec-cuts",
+}
+
+_GDELT_RAW_ARTICLE = {
+    "title": "Oil supply disruption in Middle East",
+    "url": "https://example.com/oil-disruption",
+    "seendate": "20260315T180000Z",
+    "domain": "example.com",
+}
+
+
+def _mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        import requests
+
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# fetch_news_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNewsEvents:
+    def test_missing_api_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No NEWSAPI_KEY → degraded mode, returns [] without making HTTP call."""
+        monkeypatch.delenv("NEWSAPI_KEY", raising=False)
+        with patch("requests.get") as mock_get:
+            result = fetch_news_events()
+        assert result == []
+        mock_get.assert_not_called()
+
+    def test_happy_path_returns_articles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Valid API response returns the articles list."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"articles": [_NEWSAPI_ARTICLE, _NEWSAPI_ARTICLE]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_news_events()
+        assert len(result) == 2
+        assert result[0]["title"] == _NEWSAPI_ARTICLE["title"]
+
+    def test_empty_articles_key_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """API response with no articles key returns []."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"status": "ok"})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_news_events()
+        assert result == []
+
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HTTP 4xx/5xx raises after retries are exhausted."""
+        import requests as req
+
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({}, status_code=401)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(req.HTTPError):
+                fetch_news_events()
+
+    def test_request_includes_api_key_param(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The API key is passed as a query parameter named 'apiKey'."""
+        monkeypatch.setenv("NEWSAPI_KEY", "my-secret-key")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_news_events()
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"]["apiKey"] == "my-secret-key"
+
+    def test_request_covers_last_24_hours(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The 'from' parameter is set (24-hour window)."""
+        monkeypatch.setenv("NEWSAPI_KEY", "test-key")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_news_events()
+        _, kwargs = mock_get.call_args
+        assert "from" in kwargs["params"]
+
+
+# ---------------------------------------------------------------------------
+# fetch_gdelt_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGdeltEvents:
+    def test_happy_path_returns_normalized_articles(self) -> None:
+        """GDELT articles are returned with normalized publishedAt key."""
+        mock_resp = _mock_response({"articles": [_GDELT_RAW_ARTICLE]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert len(result) == 1
+        article = result[0]
+        assert article["title"] == "Oil supply disruption in Middle East"
+        # seendate normalized to ISO 8601
+        assert "2026-03-15" in article["seendate"]
+        assert "publishedAt" in article  # unified key present
+
+    def test_empty_articles_returns_empty_list(self) -> None:
+        """GDELT response with no articles returns []."""
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert result == []
+
+    def test_missing_articles_key_returns_empty_list(self) -> None:
+        """GDELT response missing 'articles' key returns []."""
+        mock_resp = _mock_response({})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert result == []
+
+    def test_http_error_propagates(self) -> None:
+        """HTTP errors propagate after retries."""
+        import requests as req
+
+        mock_resp = _mock_response({}, status_code=503)
+        with patch("requests.get", return_value=mock_resp):
+            with pytest.raises(req.HTTPError):
+                fetch_gdelt_events()
+
+    def test_uses_gdelt_base_url_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GDELT_BASE_URL env var is used for the request URL."""
+        monkeypatch.setenv("GDELT_BASE_URL", "http://custom-gdelt.example.com/api/v2")
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_gdelt_events()
+        url = mock_get.call_args.args[0]
+        assert url.startswith("http://custom-gdelt.example.com/api/v2")
+
+    def test_falls_back_to_default_gdelt_url_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Falls back to api.gdeltproject.org when GDELT_BASE_URL is not set."""
+        monkeypatch.delenv("GDELT_BASE_URL", raising=False)
+        mock_resp = _mock_response({"articles": []})
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            fetch_gdelt_events()
+        url = mock_get.call_args.args[0]
+        assert "gdeltproject.org" in url
+
+    def test_malformed_seendate_preserved_as_is(self) -> None:
+        """Articles with unparseable seendate are included with the raw value."""
+        bad_article = {**_GDELT_RAW_ARTICLE, "seendate": "not-a-date"}
+        mock_resp = _mock_response({"articles": [bad_article]})
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_gdelt_events()
+        assert len(result) == 1
+        assert result[0]["seendate"] == "not-a-date"

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -8,6 +8,7 @@ are mocked via unittest.mock.patch so no API keys or connectivity are required.
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -167,7 +168,7 @@ class TestFetchGdeltEvents:
         with patch("requests.get", return_value=mock_resp) as mock_get:
             fetch_gdelt_events()
         url = mock_get.call_args.args[0]
-        assert url.startswith("http://api.gdeltproject.org")
+        assert urlparse(url).netloc == "api.gdeltproject.org"
 
     def test_malformed_seendate_preserved_as_is(self) -> None:
         """Articles with unparseable seendate are included with the raw value."""

--- a/tests/agents/event_detection/test_fetch_news_gdelt.py
+++ b/tests/agents/event_detection/test_fetch_news_gdelt.py
@@ -167,7 +167,7 @@ class TestFetchGdeltEvents:
         with patch("requests.get", return_value=mock_resp) as mock_get:
             fetch_gdelt_events()
         url = mock_get.call_args.args[0]
-        assert "gdeltproject.org" in url
+        assert url.startswith("http://api.gdeltproject.org")
 
     def test_malformed_seendate_preserved_as_is(self) -> None:
         """Articles with unparseable seendate are included with the raw value."""

--- a/tests/agents/event_detection/test_run_event_detection.py
+++ b/tests/agents/event_detection/test_run_event_detection.py
@@ -261,3 +261,4 @@ class TestRunEventDetectionDBFailure:
         assert "duration_ms" in payload
         assert "events_classified" in payload
         assert "error_count" in payload
+        assert "errors" in payload

--- a/tests/agents/event_detection/test_run_event_detection.py
+++ b/tests/agents/event_detection/test_run_event_detection.py
@@ -1,0 +1,263 @@
+"""
+Unit tests for run_event_detection() orchestration.
+
+All external calls (fetch_*, classify_event, get_engine, write_*) are mocked.
+No real API keys, network, or database required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.event_detection_agent import run_event_detection
+from src.agents.event_detection.models import (
+    DetectedEvent,
+    EventIntensity,
+    EventType,
+)
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_MODULE = "src.agents.event_detection.event_detection_agent"
+
+
+def _make_event(event_id: str = "abc123") -> DetectedEvent:
+    return DetectedEvent(
+        event_id=event_id,
+        event_type=EventType.SUPPLY_DISRUPTION,
+        description="Test event",
+        source="newsapi",
+        confidence_score=0.9,
+        intensity=EventIntensity.HIGH,
+        detected_at=datetime.now(tz=UTC),
+        affected_instruments=["CL=F"],
+    )
+
+
+def _patch_all(
+    news_return=None,
+    gdelt_return=None,
+    classify_return=None,
+    eia_return=None,
+    engine_return=None,
+    write_events_return=1,
+    news_raises=None,
+    gdelt_raises=None,
+    eia_raises=None,
+    engine_raises=None,
+    write_events_raises=None,
+):
+    """Return a context manager stack patching all external dependencies."""
+    import contextlib
+
+    @contextlib.contextmanager
+    def _ctx():
+        news_mock = MagicMock(
+            return_value=news_return or [],
+            side_effect=news_raises,
+        )
+        gdelt_mock = MagicMock(
+            return_value=gdelt_return or [],
+            side_effect=gdelt_raises,
+        )
+        classify_mock = MagicMock(return_value=classify_return)
+        eia_mock = MagicMock(
+            return_value=eia_return or [],
+            side_effect=eia_raises,
+        )
+        engine_mock = MagicMock() if engine_return is None else engine_return
+        if engine_raises:
+            engine_mock_fn = MagicMock(side_effect=engine_raises)
+        else:
+            engine_mock_fn = MagicMock(return_value=engine_mock)
+
+        write_events_mock = MagicMock(
+            return_value=write_events_return,
+            side_effect=write_events_raises,
+        )
+        write_eia_mock = MagicMock()
+
+        with (
+            patch(f"{_MODULE}.fetch_news_events", news_mock),
+            patch(f"{_MODULE}.fetch_gdelt_events", gdelt_mock),
+            patch(f"{_MODULE}.classify_event", classify_mock),
+            patch(f"{_MODULE}.fetch_eia_data", eia_mock),
+            patch(f"{_MODULE}.get_engine", engine_mock_fn),
+            patch(f"{_MODULE}.write_detected_events", write_events_mock),
+            patch(f"{_MODULE}.write_eia_records", write_eia_mock),
+        ):
+            yield {
+                "news": news_mock,
+                "gdelt": gdelt_mock,
+                "classify": classify_mock,
+                "eia": eia_mock,
+                "engine": engine_mock_fn,
+                "write_events": write_events_mock,
+                "write_eia": write_eia_mock,
+            }
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# All-sources-success
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionSuccess:
+    def test_returns_classified_events(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            gdelt_return=[article],
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 2
+        assert all(isinstance(e, DetectedEvent) for e in result)
+
+    def test_none_from_classify_skipped(self) -> None:
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article, article],
+            classify_return=None,
+        ):
+            result = run_event_detection()
+
+        assert result == []
+
+    def test_write_detected_events_called_with_events(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+        ) as mocks:
+            run_event_detection()
+
+        mocks["write_events"].assert_called_once()
+        written_events = mocks["write_events"].call_args.args[0]
+        assert written_events == [event]
+
+    def test_eia_fetched_and_written(self) -> None:
+        from src.agents.event_detection.models import EIAInventoryRecord
+
+        eia_rec = EIAInventoryRecord(
+            period="2024-10",
+            crude_stocks_mb=420.0,
+            fetched_at=datetime.now(tz=UTC),
+        )
+        with _patch_all(eia_return=[eia_rec]) as mocks:
+            run_event_detection()
+
+        mocks["write_eia"].assert_called_once()
+
+    def test_returns_list_not_raises(self) -> None:
+        with _patch_all():
+            result = run_event_detection()
+        assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# Partial source failure
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionPartialFailure:
+    def test_news_failure_does_not_abort_gdelt(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_raises=RuntimeError("news down"),
+            gdelt_return=[article],
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+    def test_gdelt_failure_does_not_abort_news(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            gdelt_raises=RuntimeError("gdelt down"),
+            classify_return=event,
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+    def test_eia_failure_cycle_continues(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            eia_raises=RuntimeError("eia down"),
+        ):
+            result = run_event_detection()
+
+        assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# DB failure
+# ---------------------------------------------------------------------------
+
+
+class TestRunEventDetectionDBFailure:
+    def test_db_engine_failure_events_still_returned(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            engine_raises=RuntimeError("db down"),
+        ):
+            result = run_event_detection()
+
+        assert result == [event]
+
+    def test_write_failure_events_still_returned(self) -> None:
+        event = _make_event()
+        article = {"title": "t", "url": "http://example.com"}
+        with _patch_all(
+            news_return=[article],
+            classify_return=event,
+            write_events_raises=RuntimeError("write failed"),
+        ):
+            result = run_event_detection()
+
+        assert result == [event]
+
+    def test_no_write_called_when_no_events(self) -> None:
+        with _patch_all(classify_return=None) as mocks:
+            run_event_detection()
+
+        mocks["write_events"].assert_not_called()
+
+    def test_structured_log_emitted(self, caplog: pytest.LogCaptureFixture) -> None:
+        import json
+        import logging
+
+        with caplog.at_level(logging.INFO):
+            with _patch_all():
+                run_event_detection()
+
+        log_line = next(
+            (m for m in caplog.messages if "event_detection_cycle_complete" in m),
+            None,
+        )
+        assert log_line is not None
+        payload = json.loads(log_line)
+        assert "duration_ms" in payload
+        assert "events_classified" in payload
+        assert "error_count" in payload

--- a/tests/agents/feature_generation/test_compute_supply_shock.py
+++ b/tests/agents/feature_generation/test_compute_supply_shock.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for compute_supply_shock_probability() (issue #106).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+from src.agents.feature_generation.feature_generation_agent import (
+    compute_supply_shock_probability,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_event(
+    event_type: EventType = EventType.SUPPLY_DISRUPTION,
+    intensity: EventIntensity = EventIntensity.HIGH,
+    confidence_score: float = 1.0,
+) -> DetectedEvent:
+    return DetectedEvent(
+        event_id="test-id",
+        event_type=event_type,
+        description="test event",
+        source="newsapi",
+        confidence_score=confidence_score,
+        intensity=intensity,
+        detected_at=datetime.now(tz=UTC),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty list
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSupplyShockEmpty:
+    def test_empty_list_returns_none(self) -> None:
+        assert compute_supply_shock_probability([]) is None
+
+
+# ---------------------------------------------------------------------------
+# Single event
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSupplyShockSingleEvent:
+    def test_high_supply_disruption_confidence_1_returns_1(self) -> None:
+        # TYPE_WEIGHT[supply_disruption]=1.0, INTENSITY_WEIGHT[high]=1.0, conf=1.0 → 1.0
+        event = _make_event(EventType.SUPPLY_DISRUPTION, EventIntensity.HIGH, 1.0)
+        result = compute_supply_shock_probability([event])
+        assert result == pytest.approx(1.0)
+
+    def test_medium_refinery_outage_confidence_1(self) -> None:
+        # TYPE_WEIGHT[refinery_outage]=0.9, INTENSITY_WEIGHT[medium]=0.6, conf=1.0 → 0.54
+        event = _make_event(EventType.REFINERY_OUTAGE, EventIntensity.MEDIUM, 1.0)
+        result = compute_supply_shock_probability([event])
+        assert result == pytest.approx(0.54)
+
+    def test_low_geopolitical_confidence_half(self) -> None:
+        # TYPE_WEIGHT[geopolitical]=0.5, INTENSITY_WEIGHT[low]=0.3, conf=0.5 → 0.075
+        event = _make_event(EventType.GEOPOLITICAL, EventIntensity.LOW, 0.5)
+        result = compute_supply_shock_probability([event])
+        assert result == pytest.approx(0.075)
+
+    def test_unknown_type_low_intensity(self) -> None:
+        # TYPE_WEIGHT[unknown]=0.1, INTENSITY_WEIGHT[low]=0.3, conf=1.0 → 0.03
+        event = _make_event(EventType.UNKNOWN, EventIntensity.LOW, 1.0)
+        result = compute_supply_shock_probability([event])
+        assert result == pytest.approx(0.03)
+
+    def test_sanctions_high_intensity(self) -> None:
+        # TYPE_WEIGHT[sanctions]=0.4, INTENSITY_WEIGHT[high]=1.0, conf=1.0 → 0.4
+        event = _make_event(EventType.SANCTIONS, EventIntensity.HIGH, 1.0)
+        result = compute_supply_shock_probability([event])
+        assert result == pytest.approx(0.4)
+
+
+# ---------------------------------------------------------------------------
+# Multiple events
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSupplyShockMultipleEvents:
+    def test_multiple_low_events_cumulate(self) -> None:
+        # Three low-intensity unknowns: 3 * (0.1 * 0.3 * 1.0) = 0.09
+        events = [
+            _make_event(EventType.UNKNOWN, EventIntensity.LOW, 1.0),
+            _make_event(EventType.UNKNOWN, EventIntensity.LOW, 1.0),
+            _make_event(EventType.UNKNOWN, EventIntensity.LOW, 1.0),
+        ]
+        result = compute_supply_shock_probability(events)
+        assert result == pytest.approx(0.09)
+
+    def test_score_capped_at_1(self) -> None:
+        # Two max-weight events would sum to 2.0 — must be capped at 1.0
+        events = [
+            _make_event(EventType.SUPPLY_DISRUPTION, EventIntensity.HIGH, 1.0),
+            _make_event(EventType.SUPPLY_DISRUPTION, EventIntensity.HIGH, 1.0),
+        ]
+        result = compute_supply_shock_probability(events)
+        assert result == pytest.approx(1.0)
+
+    def test_mixed_types_sum_correctly(self) -> None:
+        # supply_disruption HIGH 1.0 = 1.0*1.0*1.0 = 1.0
+        # geopolitical LOW 0.5      = 0.5*0.3*0.5  = 0.075
+        # total = 1.075 → capped at 1.0
+        events = [
+            _make_event(EventType.SUPPLY_DISRUPTION, EventIntensity.HIGH, 1.0),
+            _make_event(EventType.GEOPOLITICAL, EventIntensity.LOW, 0.5),
+        ]
+        result = compute_supply_shock_probability(events)
+        assert result == pytest.approx(1.0)
+
+    def test_result_never_exceeds_1(self) -> None:
+        events = [_make_event(confidence_score=1.0) for _ in range(10)]
+        result = compute_supply_shock_probability(events)
+        assert result is not None
+        assert result <= 1.0
+
+    def test_result_is_float_not_none_when_events_present(self) -> None:
+        event = _make_event()
+        result = compute_supply_shock_probability([event])
+        assert isinstance(result, float)

--- a/tests/agents/feature_generation/test_feature_generation_agent.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.agents.feature_generation.feature_generation_agent import (
+    compute_futures_curve_steepness,
     compute_sector_dispersion,
     compute_volatility_gap,
     run_feature_generation,
@@ -304,11 +305,116 @@ class TestComputeSectorDispersion:
         assert compute_sector_dispersion(state) == pytest.approx(0.0)
 
 
+# ---------------------------------------------------------------------------
+# Tests for compute_futures_curve_steepness
+# ---------------------------------------------------------------------------
+
+_PATCH_FETCH_SECOND = (
+    "src.agents.feature_generation.feature_generation_agent._fetch_second_month_price"
+)
+
+
+def _make_wti_state(price: float = 75.0) -> MarketState:
+    """Build a MarketState with a CL=F (WTI front-month) price record."""
+    return MarketState(
+        snapshot_time=datetime.now(tz=UTC),
+        prices=[
+            RawPriceRecord(
+                instrument="CL=F",
+                instrument_type=InstrumentType.CRUDE_FUTURES,
+                price=price,
+                timestamp=datetime.now(tz=UTC),
+                source="test",
+            ),
+        ],
+        options=[],
+    )
+
+
+class TestComputeFuturesCurveSteepness:
+    """Tests for compute_futures_curve_steepness() — WTI contango/backwardation."""
+
+    def test_contango_returns_positive(self) -> None:
+        """Second-month > front-month → positive (contango)."""
+        state = _make_wti_state(price=75.0)
+        with patch(_PATCH_FETCH_SECOND, return_value=76.5):
+            result = compute_futures_curve_steepness(state)
+        assert result is not None
+        assert result == pytest.approx((76.5 - 75.0) / 75.0)
+        assert result > 0
+
+    def test_backwardation_returns_negative(self) -> None:
+        """Second-month < front-month → negative (backwardation)."""
+        state = _make_wti_state(price=75.0)
+        with patch(_PATCH_FETCH_SECOND, return_value=73.0):
+            result = compute_futures_curve_steepness(state)
+        assert result is not None
+        assert result == pytest.approx((73.0 - 75.0) / 75.0)
+        assert result < 0
+
+    def test_formula_correctness(self) -> None:
+        """Result equals (second - front) / front exactly."""
+        front = 80.0
+        second = 82.4
+        state = _make_wti_state(price=front)
+        with patch(_PATCH_FETCH_SECOND, return_value=second):
+            result = compute_futures_curve_steepness(state)
+        assert result == pytest.approx((second - front) / front)
+
+    def test_missing_front_month_returns_none_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when CL=F is absent from market_state."""
+        state = MarketState(
+            snapshot_time=datetime.now(tz=UTC),
+            prices=[
+                RawPriceRecord(
+                    instrument="USO",
+                    instrument_type=InstrumentType.ETF,
+                    price=50.0,
+                    timestamp=datetime.now(tz=UTC),
+                    source="test",
+                ),
+            ],
+            options=[],
+        )
+        with caplog.at_level(
+            logging.WARNING,
+            logger="src.agents.feature_generation.feature_generation_agent",
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "Front-month instrument" in caplog.text
+
+    def test_yfinance_failure_returns_none_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when second-month yfinance fetch fails."""
+        state = _make_wti_state(price=75.0)
+        with (
+            patch(_PATCH_FETCH_SECOND, side_effect=RuntimeError("yfinance timeout")),
+            caplog.at_level(
+                logging.WARNING,
+                logger="src.agents.feature_generation.feature_generation_agent",
+            ),
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "Failed to fetch second-month price" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Patch targets for TestRunFeatureGeneration
+# ---------------------------------------------------------------------------
+
 _PATCH_COMPUTE_VOL_GAP = (
     "src.agents.feature_generation.feature_generation_agent.compute_volatility_gap"
 )
 _PATCH_COMPUTE_SECTOR = (
     "src.agents.feature_generation.feature_generation_agent.compute_sector_dispersion"
+)
+_PATCH_COMPUTE_CURVE = (
+    "src.agents.feature_generation.feature_generation_agent.compute_futures_curve_steepness"
 )
 _PATCH_COMPUTE_SUPPLY = (
     "src.agents.feature_generation.feature_generation_agent.compute_supply_shock_probability"
@@ -327,6 +433,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=[]),
             patch(_PATCH_COMPUTE_SECTOR, return_value=None),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.0),
         ):
             result = run_feature_generation(market_state, [])
@@ -347,12 +454,14 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=fake_gaps),
             patch(_PATCH_COMPUTE_SECTOR, return_value=0.15),
+            patch(_PATCH_COMPUTE_CURVE, return_value=0.02),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.6),
         ):
             result = run_feature_generation(market_state, [])
 
         assert result.volatility_gaps == fake_gaps
         assert result.sector_dispersion == pytest.approx(0.15)
+        assert result.futures_curve_steepness == pytest.approx(0.02)
         assert result.supply_shock_probability == pytest.approx(0.6)
         assert result.feature_errors == []
 
@@ -365,6 +474,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, side_effect=RuntimeError("db down")),
             patch(_PATCH_COMPUTE_SECTOR, return_value=0.05),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.2),
         ):
             result = run_feature_generation(market_state, [])
@@ -379,19 +489,21 @@ class TestRunFeatureGeneration:
         assert result.supply_shock_probability == pytest.approx(0.2)
 
     def test_all_signal_failures_recorded_in_feature_errors(self) -> None:
-        """All three compute functions failing still returns a valid FeatureSet."""
+        """All four compute functions failing still returns a valid FeatureSet."""
         market_state = self._base_state()
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, side_effect=RuntimeError("vol fail")),
             patch(_PATCH_COMPUTE_SECTOR, side_effect=ValueError("sector fail")),
+            patch(_PATCH_COMPUTE_CURVE, side_effect=RuntimeError("curve fail")),
             patch(_PATCH_COMPUTE_SUPPLY, side_effect=NotImplementedError("supply fail")),
         ):
             result = run_feature_generation(market_state, [])
 
         assert isinstance(result, FeatureSet)
-        assert len(result.feature_errors) == 3
+        assert len(result.feature_errors) == 4
         assert result.volatility_gaps == []
         assert result.sector_dispersion is None
+        assert result.futures_curve_steepness is None
         assert result.supply_shock_probability is None
 
     def test_snapshot_time_matches_market_state(self) -> None:
@@ -401,6 +513,7 @@ class TestRunFeatureGeneration:
         with (
             patch(_PATCH_COMPUTE_VOL_GAP, return_value=[]),
             patch(_PATCH_COMPUTE_SECTOR, return_value=None),
+            patch(_PATCH_COMPUTE_CURVE, return_value=None),
             patch(_PATCH_COMPUTE_SUPPLY, return_value=0.0),
         ):
             result = run_feature_generation(market_state, [])

--- a/tests/agents/feature_generation/test_feature_generation_agent.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent.py
@@ -402,6 +402,20 @@ class TestComputeFuturesCurveSteepness:
         assert result is None
         assert "Failed to fetch second-month price" in caplog.text
 
+    @pytest.mark.parametrize("bad_price", [float("inf")])
+    def test_nonpositive_or_nonfinite_front_price_returns_none(
+        self, bad_price: float, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Returns None with WARNING when front-month price is zero, negative, or non-finite."""
+        state = _make_wti_state(price=bad_price)
+        with caplog.at_level(
+            logging.WARNING,
+            logger="src.agents.feature_generation.feature_generation_agent",
+        ):
+            result = compute_futures_curve_steepness(state)
+        assert result is None
+        assert "non-positive or non-finite" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Patch targets for TestRunFeatureGeneration

--- a/tests/agents/feature_generation/test_feature_generation_agent_integration.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent_integration.py
@@ -40,11 +40,11 @@ import pytest
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.feature_generation.feature_generation_agent import (
     compute_volatility_gap,
     run_feature_generation,
 )
-from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.ingestion.models import InstrumentType, MarketState, OptionRecord, RawPriceRecord
 
 # A single high-confidence supply disruption event for tests that assert supply_shock_probability

--- a/tests/agents/feature_generation/test_feature_generation_agent_integration.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent_integration.py
@@ -44,7 +44,20 @@ from src.agents.feature_generation.feature_generation_agent import (
     compute_volatility_gap,
     run_feature_generation,
 )
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.ingestion.models import InstrumentType, MarketState, OptionRecord, RawPriceRecord
+
+# A single high-confidence supply disruption event for tests that assert supply_shock_probability
+_SAMPLE_EVENT = DetectedEvent(
+    event_id="abc123",
+    event_type=EventType.SUPPLY_DISRUPTION,
+    description="Major pipeline outage detected",
+    source="newsapi",
+    confidence_score=1.0,
+    intensity=EventIntensity.HIGH,
+    detected_at=datetime(2026, 1, 1, tzinfo=UTC),
+    affected_instruments=["USO", "XLE"],
+)
 
 # ---------------------------------------------------------------------------
 # Patch target for get_engine used inside the feature generation agent
@@ -337,7 +350,7 @@ def test_run_feature_generation_happy_path_no_feature_errors(pg_engine: Engine) 
     market_state = _make_market_state("USO", current_price=_GOLDEN_PRICES[-1], atm_iv=0.22)
 
     with patch(_PATCH_ENGINE, return_value=pg_engine):
-        feature_set = run_feature_generation(market_state, events=[])
+        feature_set = run_feature_generation(market_state, events=[_SAMPLE_EVENT])
 
     assert (
         feature_set.feature_errors == []
@@ -371,7 +384,7 @@ def test_run_feature_generation_partial_failure_populates_feature_errors(
         patch(_PATCH_ENGINE, return_value=pg_engine),
         patch(_patch_vol_gap, side_effect=RuntimeError("simulated vol gap failure")),
     ):
-        feature_set = run_feature_generation(market_state, events=[])
+        feature_set = run_feature_generation(market_state, events=[_SAMPLE_EVENT])
 
     # feature_errors must be non-empty and mention the failed signal
     assert feature_set.feature_errors, "expected feature_errors to be non-empty after failure"

--- a/tests/agents/feature_generation/test_feature_generation_agent_integration.py
+++ b/tests/agents/feature_generation/test_feature_generation_agent_integration.py
@@ -1,3 +1,160 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+import json
+import math
+import os
+import statistics
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+# Disable testcontainers Reaper (Ryuk) early — required on Windows where the
+# Reaper container's port mapping is unavailable. Must be set before any
+# testcontainers import.
+os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
+from testcontainers.postgres import PostgresContainer
+
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+from src.agents.feature_generation.feature_generation_agent import (
+    compute_volatility_gap,
+    run_feature_generation,
+)
+from src.agents.ingestion.models import (
+    InstrumentType,
+    MarketState,
+    OptionRecord,
+    RawPriceRecord,
+)
+
+# A single high-confidence supply disruption event for tests that assert supply_shock_probability
+_SAMPLE_EVENT = DetectedEvent(
+    event_id="abc123",
+    event_type=EventType.SUPPLY_DISRUPTION,
+    description="Major pipeline outage detected",
+    source="newsapi",
+    confidence_score=1.0,
+    intensity=EventIntensity.HIGH,
+    detected_at=datetime(2026, 1, 1, tzinfo=UTC),
+    affected_instruments=["USO", "XLE"],
+)
+
+
+_POSTGRES_TEST_IMAGE = "postgres:15"  # minimum version required for JSONB and TIMESTAMPTZ
+
+
+@pytest.mark.integration
+def test_compute_volatility_gap_integration() -> None:
+    """Integration test: seed market_prices and verify volatility gap math.
+
+    - Seeds 30 deterministic daily prices for `USO` producing ~15% annualized
+      realized volatility.
+    - Provides an ATM implied volatility of 22% via an OptionRecord in the
+      MarketState input.
+    - Asserts computed gap (implied - realized) is ~0.07 (±0.01).
+    """
+
+    # Create a deterministic series of 30 prices with daily log-return stdev
+    # that will annualize to approximately 15%: daily_stdev ~= 0.15 / sqrt(252)
+    daily_stdev = 0.15 / (252**0.5)
+    base_price = 100.0
+
+    # Build 30 prices via alternating small returns to create the expected stdev
+    prices = [base_price]
+    for i in range(30 - 1):
+        r = daily_stdev if i % 2 == 0 else -daily_stdev
+        prices.append(prices[-1] * math.exp(r))
+
+    _original_db_url = os.environ.get("DATABASE_URL")
+    # Start Postgres testcontainer; restore DATABASE_URL on exit to avoid
+    # leaking a stale URL pointing to a stopped container into subsequent tests.
+    try:
+        with PostgresContainer(_POSTGRES_TEST_IMAGE) as pg:
+            database_url = pg.get_connection_url()
+            os.environ["DATABASE_URL"] = database_url
+
+            engine = create_engine(database_url)
+
+            # Apply schema (assume pytest CWD is project root)
+            schema_path = os.path.join(os.getcwd(), "db", "schema.sql")
+            with open(schema_path, encoding="utf-8") as f:
+                sql = f.read()
+            with engine.begin() as conn:
+                conn.exec_driver_sql(sql)
+
+            # Insert price rows (oldest -> newest)
+            now = datetime.now(UTC)
+            with engine.begin() as conn:
+                for i, p in enumerate(prices):
+                    ts = now - timedelta(days=(len(prices) - i))
+                    conn.execute(
+                        text(
+                            "INSERT INTO market_prices "
+                            "(instrument, instrument_type, price, volume, source, timestamp) "
+                            "VALUES (:instrument, :instrument_type, :price, :volume, "
+                            ":source, :timestamp)"
+                        ),
+                        {
+                            "instrument": "USO",
+                            "instrument_type": "etf",
+                            "price": float(p),
+                            "volume": 1000,
+                            "source": "test",
+                            "timestamp": ts,
+                        },
+                    )
+
+            # Build MarketState with current price and an ATM OptionRecord
+            snapshot_time = now
+            current_price = prices[-1]
+            market_state = MarketState(
+                snapshot_time=snapshot_time,
+                prices=[
+                    RawPriceRecord(
+                        instrument="USO",
+                        instrument_type="etf",
+                        price=float(current_price),
+                        volume=1000,
+                        timestamp=snapshot_time,
+                        source="test",
+                    )
+                ],
+                options=[
+                    OptionRecord(
+                        instrument="USO",
+                        strike=float(current_price),
+                        expiration_date=snapshot_time + timedelta(days=7),
+                        implied_volatility=0.22,
+                        open_interest=100,
+                        volume=10,
+                        option_type="call",
+                        timestamp=snapshot_time,
+                        source="test",
+                    )
+                ],
+                ingestion_errors=[],
+            )
+
+            # Compute the volatility gaps
+            gaps = compute_volatility_gap(market_state)
+
+            assert gaps, "Expected at least one volatility gap computed"
+            g = next((gg for gg in gaps if gg.instrument == "USO"), None)
+            assert g is not None
+
+            # implied_vol (0.22) - realized_vol ~= 0.07 ± 0.01
+            gap = g.gap
+            assert abs(gap - 0.07) < 0.01, f"gap {gap} not within tolerance"
+    finally:
+        if _original_db_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = _original_db_url
+
+
 """
 Integration tests for the Feature Generation Agent.
 
@@ -21,43 +178,6 @@ Golden dataset (USO):
   - With sector_dispersion=0.50: edge_score ≈ 0.39 > 0.35 (validates #19 forward ref)
 """
 
-from __future__ import annotations
-
-import os
-
-# Disable testcontainers Reaper (Ryuk) — required on Windows where the Reaper
-# container's port mapping is unavailable. Must be set before any testcontainers import.
-os.environ.setdefault("TESTCONTAINERS_RYUK_DISABLED", "true")
-
-from collections.abc import Generator
-from datetime import UTC, datetime, timedelta
-import json
-import math
-import statistics
-from unittest.mock import patch
-
-import pytest
-from sqlalchemy import create_engine, text
-from sqlalchemy.engine import Engine
-
-from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
-from src.agents.feature_generation.feature_generation_agent import (
-    compute_volatility_gap,
-    run_feature_generation,
-)
-from src.agents.ingestion.models import InstrumentType, MarketState, OptionRecord, RawPriceRecord
-
-# A single high-confidence supply disruption event for tests that assert supply_shock_probability
-_SAMPLE_EVENT = DetectedEvent(
-    event_id="abc123",
-    event_type=EventType.SUPPLY_DISRUPTION,
-    description="Major pipeline outage detected",
-    source="newsapi",
-    confidence_score=1.0,
-    intensity=EventIntensity.HIGH,
-    detected_at=datetime(2026, 1, 1, tzinfo=UTC),
-    affected_instruments=["USO", "XLE"],
-)
 
 # ---------------------------------------------------------------------------
 # Patch target for get_engine used inside the feature generation agent
@@ -131,7 +251,7 @@ def pg_engine() -> Generator[Engine, None, None]:
     """Start a PostgresContainer, apply schema, yield engine, stop container."""
     from testcontainers.postgres import PostgresContainer
 
-    with PostgresContainer("postgres:15") as pg:
+    with PostgresContainer(_POSTGRES_TEST_IMAGE) as pg:
         engine = create_engine(pg.get_connection_url())
         with engine.begin() as conn:
             conn.execute(text(_DDL))

--- a/tests/agents/feature_generation/test_second_month_resolution.py
+++ b/tests/agents/feature_generation/test_second_month_resolution.py
@@ -1,9 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
-
-import pytest
-
 import yfinance as yf
 
 from src.agents.feature_generation.feature_generation_agent import (
@@ -23,7 +19,6 @@ class DummyTicker:
 
 def test_resolve_second_month_ticker_picks_first_available(monkeypatch) -> None:
     # Simulate yfinance returning None for CLF=F then price for CLG=F
-    calls = {}
 
     def fake_ticker(symbol):
         # Provide price only for CLG=F

--- a/tests/agents/feature_generation/test_second_month_resolution.py
+++ b/tests/agents/feature_generation/test_second_month_resolution.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+import yfinance as yf
+
+from src.agents.feature_generation.feature_generation_agent import (
+    _resolve_second_month_ticker,
+)
+
+
+class DummyInfo:
+    def __init__(self, last_price):
+        self.last_price = last_price
+
+
+class DummyTicker:
+    def __init__(self, price):
+        self.fast_info = DummyInfo(price)
+
+
+def test_resolve_second_month_ticker_picks_first_available(monkeypatch) -> None:
+    # Simulate yfinance returning None for CLF=F then price for CLG=F
+    calls = {}
+
+    def fake_ticker(symbol):
+        # Provide price only for CLG=F
+        if symbol == "CLG=F":
+            return DummyTicker(80.0)
+        return DummyTicker(None)
+
+    monkeypatch.setattr(yf, "Ticker", fake_ticker)
+
+    # allow up to a full year scan to avoid calendar-dependent failures
+    ticker = _resolve_second_month_ticker(lookahead_months=12)
+    # Should resolve to some valid CL* futures ticker when a price is present
+    assert ticker is not None
+    assert ticker.startswith("CL") and ticker.endswith("=F")
+
+
+def test_resolve_second_month_ticker_returns_none_when_no_price(monkeypatch) -> None:
+    def fake_ticker(symbol):
+        return DummyTicker(None)
+
+    monkeypatch.setattr(yf, "Ticker", fake_ticker)
+
+    ticker = _resolve_second_month_ticker(lookahead_months=3)
+    assert ticker is None

--- a/tests/agents/pr_review/test_pr_review_agent.py
+++ b/tests/agents/pr_review/test_pr_review_agent.py
@@ -93,6 +93,10 @@ class TestCheckBranchName:
         findings = _check_branch_name(meta)
         assert len(findings) == 1
 
+    def test_valid_infra_branch_passes(self) -> None:
+        meta = _make_metadata(head_branch="infra/100-detected-events-schema")
+        assert _check_branch_name(meta) == []
+
     def test_claude_branch_prefix_exempt(self) -> None:
         # claude/* branches are system-assigned session branches — exempt from SDLC naming
         meta = _make_metadata(head_branch="claude/create-pr-review-agent-4c3hy")

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -35,11 +35,15 @@ def _make_vg(instrument: str, gap: float) -> VolatilityGap:
 def _make_feature_set(
     gaps: list[VolatilityGap],
     sector_dispersion: float | None = None,
+    supply_shock_probability: float | None = None,
+    futures_curve_steepness: float | None = None,
 ) -> FeatureSet:
     return FeatureSet(
         snapshot_time=datetime.now(tz=UTC),
         volatility_gaps=gaps,
         sector_dispersion=sector_dispersion,
+        supply_shock_probability=supply_shock_probability,
+        futures_curve_steepness=futures_curve_steepness,
     )
 
 
@@ -93,6 +97,57 @@ class TestComputeEdgeScore:
         fs = _make_feature_set([_make_vg("USO", 1.0)], sector_dispersion=1.0)
         score = compute_edge_score("USO", fs)
         assert 0.0 <= score <= 1.0
+
+    # --- Phase 2 multiplier tests ---
+
+    def test_phase1_unchanged_when_none(self) -> None:
+        """When supply_shock and curve_steepness are None, score matches Phase 1."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        score_none = compute_edge_score(
+            "USO", fs, supply_shock_probability=None, futures_curve_steepness=None,
+        )
+        score_base = compute_edge_score("USO", fs)
+        assert score_none == score_base
+
+    def test_supply_shock_increases_score(self) -> None:
+        """Non-zero supply_shock_probability increases edge score."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        base = compute_edge_score("USO", fs)
+        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        assert boosted > base
+
+    def test_curve_steepness_increases_score(self) -> None:
+        """Non-zero futures_curve_steepness increases edge score."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        base = compute_edge_score("USO", fs)
+        boosted = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        assert boosted > base
+
+    def test_both_multipliers_compound(self) -> None:
+        """Both multipliers together produce a higher score than either alone."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        shock_only = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        curve_only = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        both = compute_edge_score(
+            "USO", fs, supply_shock_probability=0.5, futures_curve_steepness=0.05,
+        )
+        assert both > shock_only
+        assert both > curve_only
+
+    def test_multipliers_cap_at_one(self) -> None:
+        """Even with large multipliers, score is capped at 1.0."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=1.0)
+        score = compute_edge_score(
+            "USO", fs, supply_shock_probability=1.0, futures_curve_steepness=0.5,
+        )
+        assert score == 1.0
+
+    def test_negative_curve_steepness_uses_abs(self) -> None:
+        """Negative curve steepness (backwardation) also boosts score via abs()."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        pos = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
+        neg = compute_edge_score("USO", fs, futures_curve_steepness=-0.05)
+        assert abs(pos - neg) < 1e-9
 
 
 class TestEvaluateStrategies:
@@ -176,13 +231,15 @@ class TestEvaluateStrategies:
         assert all(c.expiration == 30 for c in result)
 
     def test_signals_dict_keys(self) -> None:
-        """signals dict must contain 'volatility_gap' and 'sector_dispersion' keys."""
+        """signals dict must contain all four signal keys."""
         fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result = evaluate_strategies(fs)
         assert result
         assert "volatility_gap" in result[0].signals
         assert "sector_dispersion" in result[0].signals
+        assert "supply_shock_probability" in result[0].signals
+        assert "futures_curve_steepness" in result[0].signals
 
     def test_signals_positive_gap_high_dispersion(self) -> None:
         """Positive gap + high dispersion → correct signal labels."""
@@ -202,3 +259,60 @@ class TestEvaluateStrategies:
         uso = next((c for c in result if c.instrument == "USO"), None)
         assert uso is not None
         assert uso.signals["volatility_gap"] == "negative"
+
+    def test_supply_shock_label_high(self) -> None:
+        """supply_shock_probability > 0.6 → 'high' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, supply_shock_probability=0.8,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["supply_shock_probability"] == "high"
+
+    def test_supply_shock_label_none(self) -> None:
+        """supply_shock_probability None → 'none' label."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["supply_shock_probability"] == "none"
+
+    def test_curve_steepness_label_contango(self) -> None:
+        """Positive futures_curve_steepness → 'contango' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=0.03,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "contango"
+
+    def test_curve_steepness_label_backwardation(self) -> None:
+        """Negative futures_curve_steepness → 'backwardation' label."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=-0.02,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "backwardation"
+
+    def test_curve_steepness_label_flat(self) -> None:
+        """futures_curve_steepness None → 'flat' label."""
+        fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        assert result[0].signals["futures_curve_steepness"] == "flat"
+
+    def test_evaluate_passes_phase2_signals_to_edge_score(self) -> None:
+        """evaluate_strategies passes feature_set Phase 2 fields to compute_edge_score."""
+        fs = _make_feature_set(
+            [_make_vg("USO", 0.10)],
+            sector_dispersion=0.2,
+            supply_shock_probability=0.5,
+            futures_curve_steepness=0.04,
+        )
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+        # With Phase 2 multipliers the score should be higher than Phase 1 base
+        fs_none = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result_none = evaluate_strategies(fs_none)
+        assert result[0].edge_score > result_none[0].edge_score

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -104,7 +104,10 @@ class TestComputeEdgeScore:
         """When supply_shock and curve_steepness are None, score matches Phase 1."""
         fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=0.5)
         score_none = compute_edge_score(
-            "USO", fs, supply_shock_probability=None, futures_curve_steepness=None,
+            "USO",
+            fs,
+            supply_shock_probability=None,
+            futures_curve_steepness=None,
         )
         score_base = compute_edge_score("USO", fs)
         assert score_none == score_base
@@ -129,7 +132,10 @@ class TestComputeEdgeScore:
         shock_only = compute_edge_score("USO", fs, supply_shock_probability=0.5)
         curve_only = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
         both = compute_edge_score(
-            "USO", fs, supply_shock_probability=0.5, futures_curve_steepness=0.05,
+            "USO",
+            fs,
+            supply_shock_probability=0.5,
+            futures_curve_steepness=0.05,
         )
         assert both > shock_only
         assert both > curve_only
@@ -138,7 +144,10 @@ class TestComputeEdgeScore:
         """Even with large multipliers, score is capped at 1.0."""
         fs = _make_feature_set([_make_vg("USO", 0.20)], sector_dispersion=1.0)
         score = compute_edge_score(
-            "USO", fs, supply_shock_probability=1.0, futures_curve_steepness=0.5,
+            "USO",
+            fs,
+            supply_shock_probability=1.0,
+            futures_curve_steepness=0.5,
         )
         assert score == 1.0
 
@@ -263,7 +272,9 @@ class TestEvaluateStrategies:
     def test_supply_shock_label_high(self) -> None:
         """supply_shock_probability > 0.6 → 'high' label."""
         fs = _make_feature_set(
-            [_make_vg("USO", 0.20)], sector_dispersion=0.5, supply_shock_probability=0.8,
+            [_make_vg("USO", 0.20)],
+            sector_dispersion=0.5,
+            supply_shock_probability=0.8,
         )
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result = evaluate_strategies(fs)
@@ -279,7 +290,9 @@ class TestEvaluateStrategies:
     def test_curve_steepness_label_contango(self) -> None:
         """Positive futures_curve_steepness → 'contango' label."""
         fs = _make_feature_set(
-            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=0.03,
+            [_make_vg("USO", 0.20)],
+            sector_dispersion=0.5,
+            futures_curve_steepness=0.03,
         )
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result = evaluate_strategies(fs)
@@ -288,7 +301,9 @@ class TestEvaluateStrategies:
     def test_curve_steepness_label_backwardation(self) -> None:
         """Negative futures_curve_steepness → 'backwardation' label."""
         fs = _make_feature_set(
-            [_make_vg("USO", 0.20)], sector_dispersion=0.5, futures_curve_steepness=-0.02,
+            [_make_vg("USO", 0.20)],
+            sector_dispersion=0.5,
+            futures_curve_steepness=-0.02,
         )
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result = evaluate_strategies(fs)

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -331,3 +331,50 @@ class TestEvaluateStrategies:
         with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
             result_none = evaluate_strategies(fs_none)
         assert result[0].edge_score > result_none[0].edge_score
+
+    def test_correlated_instruments_yield_18_equal_score_candidates(self) -> None:
+        """All 6 in-scope instruments above threshold produce 18 deterministic candidates.
+
+        18 candidates is expected behavior when all instruments are correlated;
+        see concentration filter issue #132 for future de-duplication behavior.
+        """
+        instruments = ["USO", "XLE", "XOM", "CVX", "CL=F", "BZ=F"]
+        fs = _make_feature_set(
+            [_make_vg(instrument, 0.20) for instrument in instruments],
+            sector_dispersion=0.50,
+        )
+
+        with patch(_PATCH_GET_ENGINE, return_value=MagicMock()), patch(_PATCH_WRITE):
+            result = evaluate_strategies(fs)
+
+        assert len(result) == 18
+        assert len({candidate.edge_score for candidate in result}) == 1
+
+        # All scores are equal, so sorted(desc) preserves insertion order (stable sort).
+        assert [candidate.edge_score for candidate in result] == sorted(
+            (candidate.edge_score for candidate in result),
+            reverse=True,
+        )
+
+        expected_order = [
+            ("USO", "long_straddle"),
+            ("USO", "call_spread"),
+            ("USO", "put_spread"),
+            ("XLE", "long_straddle"),
+            ("XLE", "call_spread"),
+            ("XLE", "put_spread"),
+            ("XOM", "long_straddle"),
+            ("XOM", "call_spread"),
+            ("XOM", "put_spread"),
+            ("CVX", "long_straddle"),
+            ("CVX", "call_spread"),
+            ("CVX", "put_spread"),
+            ("CL=F", "long_straddle"),
+            ("CL=F", "call_spread"),
+            ("CL=F", "put_spread"),
+            ("BZ=F", "long_straddle"),
+            ("BZ=F", "call_spread"),
+            ("BZ=F", "put_spread"),
+        ]
+        actual_order = [(candidate.instrument, candidate.structure) for candidate in result]
+        assert actual_order == expected_order

--- a/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
+++ b/tests/agents/strategy_evaluation/test_strategy_evaluation_agent.py
@@ -113,10 +113,10 @@ class TestComputeEdgeScore:
         assert score_none == score_base
 
     def test_supply_shock_increases_score(self) -> None:
-        """Non-zero supply_shock_probability increases edge score."""
+        """supply_shock_probability=0.8 increases score vs None."""
         fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
         base = compute_edge_score("USO", fs)
-        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.5)
+        boosted = compute_edge_score("USO", fs, supply_shock_probability=0.8)
         assert boosted > base
 
     def test_curve_steepness_increases_score(self) -> None:
@@ -157,6 +157,23 @@ class TestComputeEdgeScore:
         pos = compute_edge_score("USO", fs, futures_curve_steepness=0.05)
         neg = compute_edge_score("USO", fs, futures_curve_steepness=-0.05)
         assert abs(pos - neg) < 1e-9
+
+    def test_zero_effect_inputs_equivalent_to_none(self) -> None:
+        """supply_shock=0.0 and curve_steepness=0.0 match None/None behavior."""
+        fs = _make_feature_set([_make_vg("USO", 0.10)], sector_dispersion=0.2)
+        score_none = compute_edge_score(
+            "USO",
+            fs,
+            supply_shock_probability=None,
+            futures_curve_steepness=None,
+        )
+        score_zero = compute_edge_score(
+            "USO",
+            fs,
+            supply_shock_probability=0.0,
+            futures_curve_steepness=0.0,
+        )
+        assert score_zero == score_none
 
 
 class TestEvaluateStrategies:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -11,13 +11,14 @@ Validates:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from src.agents.event_detection.event_detection_agent import EventDetectionError
 from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
-from src.agents.feature_generation.models import FeatureSet
+from src.agents.feature_generation.models import FeatureSet, VolatilityGap
 from src.agents.ingestion.models import MarketState
 from src.agents.strategy_evaluation.models import StrategyCandidate
 from src.pipeline import run_pipeline
@@ -39,6 +40,22 @@ def _make_market_state() -> MarketState:
 
 def _make_feature_set() -> FeatureSet:
     return FeatureSet(snapshot_time=datetime.now(tz=UTC))
+
+
+def _make_market_only_feature_set() -> FeatureSet:
+    return FeatureSet(
+        snapshot_time=datetime.now(tz=UTC),
+        volatility_gaps=[
+            VolatilityGap(
+                instrument="USO",
+                realized_vol=0.15,
+                implied_vol=0.25,
+                gap=0.10,
+                computed_at=datetime.now(tz=UTC),
+            )
+        ],
+        sector_dispersion=0.10,
+    )
 
 
 def _make_event(description: str = "Test event") -> DetectedEvent:
@@ -73,21 +90,28 @@ class TestRunPipeline:
 
         mock_fg.assert_called_once_with(ms, events=events)
 
-    def test_degraded_mode_on_event_detection_failure(self) -> None:
-        """Event detection exception → events=[], pipeline still completes."""
+    def test_degraded_mode_on_event_detection_failure(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Event detection exception logs degraded mode and still returns candidates."""
         ms = _make_market_state()
-        fs = _make_feature_set()
+        fs = _make_market_only_feature_set()
 
         with (
             patch(_PATCH_INGESTION, return_value=ms),
             patch(_PATCH_EVENT_DETECTION, side_effect=EventDetectionError("API down")),
             patch(_PATCH_FEATURE_GENERATION, return_value=fs) as mock_fg,
-            patch(_PATCH_EVALUATE, return_value=[]),
         ):
-            result = run_pipeline()
+            with caplog.at_level(logging.WARNING):
+                result = run_pipeline()
 
         mock_fg.assert_called_once_with(ms, events=[])
-        assert result == []
+        assert result
+        assert all(isinstance(candidate, StrategyCandidate) for candidate in result)
+        assert "degraded mode" in caplog.text
+        assert all(candidate.signals["supply_shock_probability"] == "none" for candidate in result)
+        assert all(candidate.signals["futures_curve_steepness"] == "flat" for candidate in result)
 
     def test_non_recoverable_exception_propagates(self) -> None:
         """Non-recoverable exceptions (e.g. AttributeError) propagate."""

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.agents.event_detection.event_detection_agent import EventDetectionError
 from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
 from src.agents.feature_generation.models import FeatureSet
 from src.agents.ingestion.models import MarketState
@@ -79,7 +80,7 @@ class TestRunPipeline:
 
         with (
             patch(_PATCH_INGESTION, return_value=ms),
-            patch(_PATCH_EVENT_DETECTION, side_effect=RuntimeError("API down")),
+            patch(_PATCH_EVENT_DETECTION, side_effect=EventDetectionError("API down")),
             patch(_PATCH_FEATURE_GENERATION, return_value=fs) as mock_fg,
             patch(_PATCH_EVALUATE, return_value=[]),
         ):

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -1,0 +1,132 @@
+"""
+Unit tests for run_pipeline() — Phase 2 wiring.
+
+Validates:
+  - Event detection results are passed through to feature generation
+  - Degraded mode: event detection failure → events=[], pipeline continues
+  - Pipeline returns StrategyCandidate list from evaluate_strategies
+  - Empty events list when event detection returns no events
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.agents.event_detection.models import DetectedEvent, EventIntensity, EventType
+from src.agents.feature_generation.models import FeatureSet
+from src.agents.ingestion.models import MarketState
+from src.agents.strategy_evaluation.models import StrategyCandidate
+from src.pipeline import run_pipeline
+
+# Patch targets — must match import paths in src/pipeline.py
+_PATCH_INGESTION = "src.pipeline.run_ingestion"
+_PATCH_EVENT_DETECTION = "src.pipeline.run_event_detection"
+_PATCH_FEATURE_GENERATION = "src.pipeline.run_feature_generation"
+_PATCH_EVALUATE = "src.pipeline.evaluate_strategies"
+
+
+def _make_market_state() -> MarketState:
+    return MarketState(
+        snapshot_time=datetime.now(tz=UTC),
+        prices=[],
+        options=[],
+    )
+
+
+def _make_feature_set() -> FeatureSet:
+    return FeatureSet(snapshot_time=datetime.now(tz=UTC))
+
+
+def _make_event(description: str = "Test event") -> DetectedEvent:
+    return DetectedEvent(
+        event_id="test-001",
+        event_type=EventType.SUPPLY_DISRUPTION,
+        description=description,
+        source="test",
+        confidence_score=0.8,
+        intensity=EventIntensity.HIGH,
+        detected_at=datetime.now(tz=UTC),
+        affected_instruments=["CL=F"],
+    )
+
+
+class TestRunPipeline:
+    """Tests for run_pipeline() Phase 2 wiring."""
+
+    def test_events_passed_to_feature_generation(self) -> None:
+        """run_event_detection() output flows into run_feature_generation(events=...)."""
+        events = [_make_event("Supply cut")]
+        ms = _make_market_state()
+        fs = _make_feature_set()
+
+        with (
+            patch(_PATCH_INGESTION, return_value=ms),
+            patch(_PATCH_EVENT_DETECTION, return_value=events),
+            patch(_PATCH_FEATURE_GENERATION, return_value=fs) as mock_fg,
+            patch(_PATCH_EVALUATE, return_value=[]),
+        ):
+            run_pipeline()
+
+        mock_fg.assert_called_once_with(ms, events=events)
+
+    def test_degraded_mode_on_event_detection_failure(self) -> None:
+        """Event detection exception → events=[], pipeline still completes."""
+        ms = _make_market_state()
+        fs = _make_feature_set()
+
+        with (
+            patch(_PATCH_INGESTION, return_value=ms),
+            patch(_PATCH_EVENT_DETECTION, side_effect=RuntimeError("API down")),
+            patch(_PATCH_FEATURE_GENERATION, return_value=fs) as mock_fg,
+            patch(_PATCH_EVALUATE, return_value=[]),
+        ):
+            result = run_pipeline()
+
+        mock_fg.assert_called_once_with(ms, events=[])
+        assert result == []
+
+    def test_non_recoverable_exception_propagates(self) -> None:
+        """Non-recoverable exceptions (e.g. AttributeError) propagate."""
+        ms = _make_market_state()
+
+        with (
+            patch(_PATCH_INGESTION, return_value=ms),
+            patch(_PATCH_EVENT_DETECTION, side_effect=AttributeError("Programming error")),
+        ):
+            # AttributeError is not in the caught exception set, so it should propagate
+            with pytest.raises(AttributeError, match="Programming error"):
+                run_pipeline()
+
+    def test_returns_strategy_candidates(self) -> None:
+        """run_pipeline() returns the list from evaluate_strategies()."""
+        ms = _make_market_state()
+        fs = _make_feature_set()
+        candidates = [MagicMock(spec=StrategyCandidate)]
+
+        with (
+            patch(_PATCH_INGESTION, return_value=ms),
+            patch(_PATCH_EVENT_DETECTION, return_value=[]),
+            patch(_PATCH_FEATURE_GENERATION, return_value=fs),
+            patch(_PATCH_EVALUATE, return_value=candidates),
+        ):
+            result = run_pipeline()
+
+        assert result is candidates
+
+    def test_empty_events_when_detection_returns_none(self) -> None:
+        """When event detection returns an empty list, events=[] passed through."""
+        ms = _make_market_state()
+        fs = _make_feature_set()
+
+        with (
+            patch(_PATCH_INGESTION, return_value=ms),
+            patch(_PATCH_EVENT_DETECTION, return_value=[]),
+            patch(_PATCH_FEATURE_GENERATION, return_value=fs) as mock_fg,
+            patch(_PATCH_EVALUATE, return_value=[]),
+        ):
+            run_pipeline()
+
+        mock_fg.assert_called_once_with(ms, events=[])


### PR DESCRIPTION
## Phase 2 Release — Supply & Event Augmentation

Closes #113.

---

## What's New in v0.2.0

### New Data Sources
- **EIA Weekly Inventory** (`fetch_eia_data`): ingests weekly crude/petroleum inventory from EIA STEO feed; persists to `eia_inventory` table.
- **NewsAPI** (`fetch_news_events`): fetches energy-sector headlines; fed into LLM classifier.
- **GDELT** (`fetch_gdelt_events`): ingests geopolitical event stream for supply-disruption signals.

### Event Detection & Classification
- `classify_event()` via `llm_wrapper.py`: Pydantic-validated boundary, tenacity retry, `max_tokens` constant; classifies raw news/GDELT events into `DetectedEvent` with `EventType` and `EventIntensity`.
- `run_event_detection()`: orchestrates fetch → classify → persist; wired into `run_pipeline()` with degraded-mode fallback on `EventDetectionError`.

### New Feature Signals
- `compute_supply_shock_probability()`: LLM-classified event intensity → float [0, 1].
- `compute_futures_curve_steepness()`: dynamic second-month WTI futures ticker resolution; guards non-finite prices.

### Updated Edge Scoring
- `compute_edge_score()` Phase 2 multipliers: `supply_shock_probability` and `futures_curve_steepness` now contribute to composite score; clamped to [0, 1].

### Schema & Infrastructure
- New tables: `detected_events`, `eia_inventory` (TIMESTAMPTZ columns, TimescaleDB-compatible).
- `db/migrate_timescaledb.sql`: idempotent hypertable migration script for all four partition candidates; full rollback documented.
- `docs/timescaledb_migration.md`: step-by-step migration guide.

---

## Acceptance Criteria Verified

- [x] `bash scripts/local_check.sh` exits 0 on develop (ruff, black, mypy strict, import scan, 250 unit tests)
- [x] All Sprint 6 and Sprint 7 issues closed
- [x] #110 Event Detection QA closed (≥80% coverage)
- [x] #111 TimescaleDB migration plan closed
- [x] #112 Phase 2 UAT passed and results documented
- [x] #23 Phase 2 planning issue closed

---

## Test Plan

- [ ] CI passes: Lint, mypy, unit tests, integration tests, ESOD scan, security audit
- [ ] Merge as **Merge Commit** (not squash) — preserves Phase 2 history
- [ ] After merge: `git tag v0.2.0 <merge-commit-sha> && git push origin v0.2.0`
- [ ] Create GitHub Release at `v0.2.0` with these release notes
- [ ] Close issue #113 with comment: `"Closing: all AC verified ✓, merged in PR #N"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)