### PR TITLE
feat(backtest): backtest_candidates and backtest_outcomes DB migration (#172)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -370,3 +370,21 @@ Human lead approved 2026-03-21.
 - #172 — DB migration: backtest_candidates + backtest_outcomes tables
 - #166 — Backtesting harness (HistoricalLoader, run_backtest_pipeline, BacktestReport)
 - #164 — Outcome tracking
+
+## Sprint Notes (2026-03-21, session 2)
+
+**#172 IN REVIEW** — DB migration and backtest DB layer implemented. PR opened.
+
+Two-table isolation design complete:
+- `db/migrations/add_backtest_tables.sql` — backtest_candidates (UUID PK, snapshot_time, edge_score,
+  signals JSONB) + backtest_outcomes (UUID PK, FK→backtest_candidates, profitable BOOL nullable).
+  Migration idempotent (IF NOT EXISTS); pgcrypto extension included.
+- `src/backtest/backtest.py` — write_backtest_candidate() returns DB-assigned UUID;
+  record_outcome() supports profitable=None audit row (yfinance data gap).
+- `src/backtest/models.py` — BacktestCandidate and BacktestOutcome Pydantic boundary models.
+- `tests/integration/test_backtest_integration.py` — 5 testcontainers tests covering both tables,
+  FK constraint, idempotent migration, and profitable=None audit row.
+- All 5 local_check.sh stages pass (ruff, black, mypy, import scan, 250 unit tests).
+
+**HUMAN SIGN-OFF REQUIRED before running migration on any live DB (ESOD Hard Stop).**
+Next unblocked: #166 (HistoricalLoader) — depends on #172 merged.

--- a/db/migrations/add_backtest_tables.sql
+++ b/db/migrations/add_backtest_tables.sql
@@ -1,0 +1,99 @@
+-- =============================================================================
+-- db/migrations/add_backtest_tables.sql
+-- Issue #172 — Sprint 9 Phase 3 Backtesting Core
+-- =============================================================================
+--
+-- Creates two tables that isolate backtest data from the live production tables:
+--
+--   backtest_candidates  — historical candidates generated during pipeline replay
+--   backtest_outcomes    — actual underlying close at expiration + P&L verdict
+--
+-- Isolation rationale:
+--   run_backtest_pipeline() calls compute_* functions directly (not
+--   run_feature_generation) to avoid writing to live feature_sets.
+--   backtest_candidates is likewise isolated from strategy_candidates so that
+--   historical replay rows never appear in production reporting queries.
+--
+-- profitable=NULL (not a skipped row) when yfinance returns no data — the row
+-- is still inserted for audit purposes with profitable left NULL.
+--
+-- entry_premium, upper_strike, lower_strike are nullable:
+--   - NULL for long_straddle (only underlying_close is needed for P&L)
+--   - populated for call_spread / put_spread
+--   - calendar_spread deferred (post-Sprint-A issue)
+--
+-- HUMAN SIGN-OFF REQUIRED before running against any live DB.
+-- Apply: psql $DATABASE_URL -f db/migrations/add_backtest_tables.sql
+-- Verify: \d backtest_candidates   \d backtest_outcomes
+-- =============================================================================
+
+-- Enable pgcrypto for gen_random_uuid() if not already enabled.
+-- NOTE: On RDS / managed Postgres, this extension may already be present.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- -----------------------------------------------------------------------------
+-- backtest_candidates
+--
+-- One row per strategy candidate produced during a backtest replay slice.
+-- snapshot_time is the point-in-time of the historical market data slice used
+-- to generate this candidate (not the wall-clock time the row was written).
+--
+-- Structure values must match the live strategy_candidates CHECK constraint.
+-- TIMESTAMPTZ ensures TimescaleDB hypertable conversion requires zero changes.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS backtest_candidates (
+    id            UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    instrument    VARCHAR(20)  NOT NULL,
+    structure     VARCHAR(50)  NOT NULL
+                      CHECK (structure IN ('long_straddle','call_spread','put_spread','calendar_spread')),
+    snapshot_time TIMESTAMPTZ  NOT NULL,
+    edge_score    NUMERIC(6,4) NOT NULL CHECK (edge_score BETWEEN 0 AND 1),
+    signals       JSONB        NOT NULL,
+    generated_at  TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_backtest_candidates_snapshot_time
+    ON backtest_candidates (snapshot_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_backtest_candidates_instrument_edge
+    ON backtest_candidates (instrument, edge_score DESC);
+
+-- -----------------------------------------------------------------------------
+-- backtest_outcomes
+--
+-- One row per (candidate, expiration) pair after the outcome has been resolved
+-- by OutcomeTracker using yfinance history().
+--
+-- candidate_id FK to backtest_candidates.id (not strategy_candidates) —
+-- live and backtest data never share FK relationships.
+--
+-- For long_straddle:
+--   profitable = TRUE  if abs(underlying_close - entry_premium) > entry_premium
+--   profitable = FALSE otherwise
+--   profitable = NULL  if yfinance returned no data for the expiration date
+--
+-- For call_spread / put_spread (post-Sprint-A):
+--   entry_premium, upper_strike, lower_strike are populated.
+--   spread P&L formula deferred to the Sprint A follow-up / Sprint B extension.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS backtest_outcomes (
+    id               UUID          PRIMARY KEY DEFAULT gen_random_uuid(),
+    candidate_id     UUID          NOT NULL REFERENCES backtest_candidates(id),
+    structure        VARCHAR(50)   NOT NULL
+                         CHECK (structure IN ('long_straddle','call_spread','put_spread','calendar_spread')),
+    expiration       TIMESTAMPTZ   NOT NULL,
+    underlying_close NUMERIC(12,4) NOT NULL,
+    -- Spread P&L fields (nullable — NULL for long_straddle)
+    entry_premium    NUMERIC(12,4),
+    upper_strike     NUMERIC(12,4),
+    lower_strike     NUMERIC(12,4),
+    -- NULL means outcome could not be determined (yfinance gap); row still inserted
+    profitable       BOOLEAN,
+    recorded_at      TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_backtest_outcomes_candidate_id
+    ON backtest_outcomes (candidate_id);
+
+CREATE INDEX IF NOT EXISTS idx_backtest_outcomes_expiration
+    ON backtest_outcomes (expiration DESC);

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting the structured output it produces.
+> **Version 1.0 • March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting its output. It assumes you are comfortable with Python 3 and a Unix-style command line.
 
 ---
 
@@ -18,31 +18,29 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests live and near-live market data, scores supply and geopolitical events, derives volatility signals, and produces a ranked list of candidate options strategies — all without automated trade execution.
 
-The system is **advisory only** — it makes no trades. Output is a JSON-compatible list of candidate strategies, each carrying an `edge_score` and a map of the signals that contributed to it.
-
-### Four-Agent Pipeline
-
-Data flows unidirectionally through four loosely coupled agents that share a common market state object and a derived features store.
+### Pipeline at a Glance
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion ["① Data Ingestion Agent"]
-        A1[Crude Prices\nWTI · Brent]
-        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
-        A3[Options Chains\nStrike · Expiry · IV · Volume]
+    subgraph Ingestion["① Data Ingestion Agent"]
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[Shipping & Sentiment\nMarineTraffic · Reddit · Stocktwits]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
     end
 
-    subgraph Events ["② Event Detection Agent"]
-        B1[News & Geo Feeds\nGDELT · NewsAPI]
-        B2[Supply / Inventory\nEIA API]
-        B3[Shipping\nMarineTraffic]
-        B4[Confidence & Intensity\nScoring]
+    subgraph Events["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT / NewsAPI]
+        B2[Supply Disruption Scoring]
+        B3[Confidence & Intensity Scores]
     end
 
-    subgraph Features ["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealized vs Implied]
+    subgraph Features["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs. Implied]
         C2[Futures Curve Steepness]
         C3[Sector Dispersion]
         C4[Insider Conviction Score]
@@ -50,198 +48,289 @@ flowchart LR
         C6[Supply Shock Probability]
     end
 
-    subgraph Strategy ["④ Strategy Evaluation Agent"]
-        D1[Evaluate Eligible Structures\nStraddles · Spreads · Calendars]
+    subgraph Strategy["④ Strategy Evaluation Agent"]
+        D1[Evaluate Eligible Structures]
         D2[Compute Edge Scores]
-        D3[Ranked JSON Output]
+        D3[Rank Candidates]
     end
 
+    OUT[(JSON Output\nRanked Candidates)]
+
     Ingestion -->|Market State Object| Events
+    Ingestion -->|Market State Object| Features
     Events    -->|Scored Events| Features
-    Features  -->|Derived Signals| Strategy
-    Strategy  -->|candidates.json| Output[(Downstream\nDashboard /\nthinkorswim)]
+    Features  -->|Derived Signal Store| Strategy
+    Strategy  --> OUT
 ```
 
 ### In-Scope Instruments & Structures
 
 | Category | Items |
 |---|---|
-| Crude futures | Brent Crude, WTI |
-| ETFs | USO, XLE |
-| Energy equities | XOM (ExxonMobil), CVX (Chevron) |
-| Option structures (MVP) | Long straddle, call spread, put spread, calendar spread |
+| **Crude Futures** | Brent Crude, WTI (`CL=F`) |
+| **ETFs** | USO, XLE |
+| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option Structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+
+> **Advisory only.** The system produces recommendations; it does not execute trades.
 
 ---
 
 ## Prerequisites
 
-| Requirement | Minimum version / notes |
-|---|---|
-| Python | 3.10 or later |
-| pip | 23+ (ships with Python 3.10+) |
-| Git | Any recent version |
-| Operating system | Linux, macOS, or Windows (WSL2 recommended on Windows) |
-| Hardware | Single modest VM or laptop; no GPU required |
-| API keys | See [Setup & Configuration](#setup--configuration) |
+### System Requirements
 
-Install Python dependencies into a virtual environment:
+| Requirement | Minimum |
+|---|---|
+| Python | 3.10+ |
+| RAM | 2 GB |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Deployment target | Local machine, single VM, or container |
+
+### Required Tools
 
 ```bash
-git clone https://github.com/your-org/energy-options-agent.git
-cd energy-options-agent
+# Verify Python version
+python --version          # must be 3.10 or higher
 
+# Verify pip
+pip --version
+
+# Optional but recommended: create a virtual environment
 python -m venv .venv
-source .venv/bin/activate          # Windows: .venv\Scripts\activate
-
-pip install --upgrade pip
-pip install -r requirements.txt
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 ```
+
+### API Accounts
+
+Obtain credentials (all free or free-tier) before configuration:
+
+| Service | Purpose | Sign-up URL |
+|---|---|---|
+| Alpha Vantage **or** MetalpriceAPI | WTI / Brent spot & futures prices | https://www.alphavantage.co / https://metalpriceapi.com |
+| Polygon.io | Options chains (alternative to Yahoo Finance) | https://polygon.io |
+| EIA Open Data | Weekly supply & inventory data | https://www.eia.gov/opendata |
+| NewsAPI | News & geopolitical events | https://newsapi.org |
+| GDELT | Geopolitical event stream | No key required (public) |
+| SEC EDGAR / Quiver Quant | Insider trading activity | https://efts.sec.gov / https://www.quiverquant.com |
+| MarineTraffic **or** VesselFinder | Tanker flow data | https://www.marinetraffic.com / https://www.vesselfinder.com |
+
+> Yahoo Finance (`yfinance`), Reddit, Stocktwits, and GDELT do not require API keys for basic access.
 
 ---
 
 ## Setup & Configuration
 
-All runtime behaviour is controlled through environment variables. Copy the provided template and fill in your values:
+### 1. Clone & Install Dependencies
+
+```bash
+git clone https://github.com/your-org/energy-options-agent.git
+cd energy-options-agent
+
+pip install -r requirements.txt
+```
+
+### 2. Create the Environment File
+
+Copy the provided template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then open `.env` in your editor.
+Open `.env` in your editor and populate each variable (see the full reference table below).
 
-### Environment Variables
+### 3. Environment Variable Reference
+
+All pipeline behaviour is controlled via environment variables. The `.env` file is loaded automatically at startup.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed (WTI, Brent) |
-| `POLYGON_API_KEY` | No | — | Polygon.io key for options chain data (falls back to yfinance if unset) |
-| `NEWS_API_KEY` | No | — | NewsAPI.org key for headline ingestion |
-| `EIA_API_KEY` | Yes | — | U.S. Energy Information Administration API key (free, register at eia.gov) |
-| `MARINE_TRAFFIC_API_KEY` | No | — | MarineTraffic API key for tanker flow data (free tier supported) |
-| `QUIVER_QUANT_API_KEY` | No | — | Quiver Quantitative key for insider trade data |
-| `DATA_DIR` | No | `./data` | Directory for raw and derived historical data storage |
-| `OUTPUT_DIR` | No | `./output` | Directory where ranked `candidates.json` files are written |
-| `LOG_LEVEL` | No | `INFO` | Python logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `MARKET_REFRESH_INTERVAL_SECONDS` | No | `60` | Cadence for market data polling (minutes-level recommended) |
-| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory/refinery data polling |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of raw and derived data to retain for backtesting (180–365 recommended) |
-| `GDELT_ENABLED` | No | `true` | Set to `false` to disable GDELT geo-event ingestion |
-| `REDDIT_ENABLED` | No | `true` | Set to `false` to disable Reddit/Stocktwits sentiment ingestion |
-| `EDGE_SCORE_THRESHOLD` | No | `0.20` | Candidates with an edge score below this value are omitted from output |
-| `MAX_EXPIRATION_DAYS` | No | `90` | Maximum days-to-expiration considered when evaluating structures |
+| `ALPHA_VANTAGE_API_KEY` | Conditional¹ | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Conditional¹ | — | API key for MetalpriceAPI crude price feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA inventory & utilization data |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy headlines |
+| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
+| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
+| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes-level) |
+| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory polling |
+| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for SEC EDGAR insider data polling |
+| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw & derived data to retain (180–365 recommended) |
+| `OUTPUT_PATH` | No | `./output/candidates.json` | File path for ranked candidate JSON output |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to monitor |
+| `EDGE_SCORE_MIN_THRESHOLD` | No | `0.20` | Candidates below this edge score are suppressed from output |
+| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
+| `ENABLE_SHIPPING_SIGNALS` | No | `false` | Set `true` to activate MarineTraffic/VesselFinder agent |
+| `ENABLE_INSIDER_SIGNALS` | No | `false` | Set `true` to activate SEC EDGAR / Quiver Quant agent |
+| `ENABLE_NARRATIVE_SIGNALS` | No | `true` | Set `false` to disable Reddit/Stocktwits sentiment agent |
+| `DB_PATH` | No | `./data/market_state.db` | SQLite database path for historical storage |
 
-> **Tip:** Variables marked *No* under Required are optional for MVP Phase 1. You can run a functional pipeline with only `ALPHA_VANTAGE_API_KEY` and `EIA_API_KEY` set.
+> ¹ At least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY` must be provided.
 
-### Verifying Data-Source Connectivity
+### 4. Example `.env` File
 
-Run the built-in connectivity check before your first full pipeline run:
+```dotenv
+# Crude price source (provide at least one)
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+METALPRICE_API_KEY=
+
+# Options data
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+
+# Supply & inventory
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+
+# News & events
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
+
+# Optional alternative signals
+QUIVER_QUANT_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+ENABLE_SHIPPING_SIGNALS=false
+ENABLE_INSIDER_SIGNALS=false
+ENABLE_NARRATIVE_SIGNALS=true
+
+# Data refresh cadences
+DATA_REFRESH_INTERVAL_MINUTES=5
+EIA_REFRESH_INTERVAL_HOURS=24
+EDGAR_REFRESH_INTERVAL_HOURS=24
+
+# Storage & output
+HISTORICAL_RETENTION_DAYS=180
+DB_PATH=./data/market_state.db
+OUTPUT_PATH=./output/candidates.json
+
+# Pipeline tuning
+EDGE_SCORE_MIN_THRESHOLD=0.20
+MAX_CANDIDATES=20
+LOG_LEVEL=INFO
+```
+
+### 5. Initialise the Database
+
+Run the schema migration once before your first pipeline execution:
 
 ```bash
-python -m agent check-sources
+python -m agent init-db
 ```
 
-Expected output when all configured sources are reachable:
+Expected output:
 
 ```
-[OK]  alpha_vantage       — crude prices (WTI, Brent)
-[OK]  yfinance            — ETF/equity prices (USO, XLE, XOM, CVX)
-[OK]  yfinance            — options chains (fallback active)
-[OK]  eia                 — supply/inventory data
-[SKIP] polygon            — POLYGON_API_KEY not set; using yfinance fallback
-[SKIP] marine_traffic     — MARINE_TRAFFIC_API_KEY not set
-[SKIP] quiver_quant       — QUIVER_QUANT_API_KEY not set
-[OK]  gdelt               — geo/news events
-[OK]  reddit              — narrative sentiment
+[INFO] Initialising database at ./data/market_state.db
+[INFO] Schema applied successfully.
+[INFO] Ready.
 ```
-
-`[SKIP]` entries are non-fatal; those signal layers will be absent from edge score computation but will not stop the pipeline.
 
 ---
 
 ## Running the Pipeline
 
-### Full Pipeline (All Four Agents)
+### Pipeline Execution Flow
 
-The standard entry point runs all agents in sequence and writes ranked candidates to `$OUTPUT_DIR`.
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as CLI / Scheduler
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant OUT as JSON Output
+
+    User->>CLI: python -m agent run
+    CLI->>DIA: Fetch & normalise market data
+    DIA-->>CLI: Market State Object ✓
+    CLI->>EDA: Detect & score events
+    EDA-->>CLI: Scored Event List ✓
+    CLI->>FGA: Compute derived signals
+    FGA-->>CLI: Derived Feature Store ✓
+    CLI->>SEA: Evaluate & rank strategies
+    SEA-->>OUT: Write candidates.json
+    OUT-->>User: Ranked candidates ready
+```
+
+### Single Run (One-Shot)
+
+Execute the full four-agent pipeline once and write results to the configured output path:
 
 ```bash
 python -m agent run
 ```
 
-To override configuration inline without editing `.env`:
+### Continuous Mode
+
+Poll on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence, re-running the full pipeline each cycle:
 
 ```bash
-EDGE_SCORE_THRESHOLD=0.30 python -m agent run
+python -m agent run --continuous
 ```
 
-### Run a Single Agent
+Press `Ctrl+C` to stop gracefully.
 
-Each agent can be invoked independently for testing or incremental development.
+### Run Individual Agents
+
+Each agent is independently deployable and can be invoked in isolation for testing or incremental development:
 
 ```bash
-# Agent 1 — fetch and normalise market data only
+# Data Ingestion only
 python -m agent run --agent ingestion
 
-# Agent 2 — event detection (requires market state from Agent 1)
+# Event Detection only
 python -m agent run --agent events
 
-# Agent 3 — feature generation (requires market state + scored events)
+# Feature Generation only
 python -m agent run --agent features
 
-# Agent 4 — strategy evaluation and ranking (requires derived features)
+# Strategy Evaluation only
 python -m agent run --agent strategy
 ```
 
-### Scheduled / Continuous Mode
+> When running agents individually, earlier stages must have already written their outputs to the shared state store.
 
-To keep the pipeline running on its configured refresh cadence, use the `--loop` flag:
+### Override Configuration at Runtime
 
-```bash
-python -m agent run --loop
-```
-
-In loop mode the pipeline respects `MARKET_REFRESH_INTERVAL_SECONDS` for price/options data and `EIA_REFRESH_INTERVAL_HOURS` for slower supply feeds. Press `Ctrl+C` to stop gracefully.
-
-For production-style scheduling, use cron or a process supervisor:
-
-```cron
-# crontab example — run every 5 minutes during trading hours (UTC)
-*/5 13-21 * * 1-5 cd /opt/energy-options-agent && .venv/bin/python -m agent run >> logs/pipeline.log 2>&1
-```
-
-### Verbose / Debug Run
+Any environment variable can be overridden inline without editing `.env`:
 
 ```bash
-LOG_LEVEL=DEBUG python -m agent run
+LOG_LEVEL=DEBUG EDGE_SCORE_MIN_THRESHOLD=0.30 python -m agent run
 ```
 
-### Output Location
+### Scheduling with Cron
 
-After each successful run a timestamped file is written to `$OUTPUT_DIR`:
+To run once per hour on a Unix system:
 
+```bash
+# Edit crontab
+crontab -e
+
+# Add the following line (adjust paths as needed)
+0 * * * * /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
 ```
-output/
-└── candidates_2026-03-15T14:32:00Z.json
-```
-
-The most recent run is also symlinked as `output/candidates_latest.json`.
 
 ---
 
 ## Interpreting the Output
 
+### Output File
+
+Results are written to the path specified by `OUTPUT_PATH` (default: `./output/candidates.json`) as a JSON array, sorted descending by `edge_score`.
+
 ### Output Schema
 
-Each element in the output array represents one ranked strategy candidate.
+Each element in the array is a **strategy candidate** object:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument ticker, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | One of `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher = stronger signal confluence |
-| `signals` | `object` | Key/value map of contributing signals and their assessed states |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative states |
+| `generated_at` | ISO 8601 `datetime` | UTC timestamp of candidate generation |
 
 ### Example Output
 
@@ -262,11 +351,11 @@ Each element in the output array represents one ranked strategy candidate.
   {
     "instrument": "XLE",
     "structure": "call_spread",
-    "expiration": 45,
+    "expiration": 21,
     "edge_score": 0.31,
     "signals": {
-      "supply_shock_probability": "elevated",
       "volatility_gap": "positive",
+      "supply_shock_probability": "elevated",
       "sector_dispersion": "widening"
     },
     "generated_at": "2026-03-15T14:32:00Z"
@@ -276,87 +365,36 @@ Each element in the output array represents one ranked strategy candidate.
 
 ### Reading the Edge Score
 
+The `edge_score` is a composite float in the range 0.0–1.0. It reflects how many signals are aligned in support of a given strategy, weighted by their intensity.
+
 | Edge Score Range | Interpretation |
 |---|---|
-| `0.00 – 0.19` | Weak confluence; filtered out by default (`EDGE_SCORE_THRESHOLD`) |
-| `0.20 – 0.39` | Moderate signal alignment; worth monitoring |
-| `0.40 – 0.59` | Strong signal confluence; primary candidates for further review |
-| `0.60 – 1.00` | Very strong confluence; highest priority for manual analysis |
+| `0.00 – 0.19` | Weak / suppressed (filtered out by default) |
+| `0.20 – 0.34` | Low conviction — monitor for confirmation |
+| `0.35 – 0.49` | Moderate confluence — warrants closer review |
+| `0.50 – 0.69` | Strong signal alignment — high-priority candidate |
+| `0.70 – 1.00` | Very strong confluence — investigate immediately |
 
-> **Important:** A high `edge_score` reflects signal confluence, not a guaranteed profitable trade. Always apply your own risk assessment before entering any position.
+> The scoring function is intentionally heuristic in the MVP. Complexity and ML-based weighting are deferred to Phase 4.
 
-### Signal Reference
+### Understanding the `signals` Map
 
-| Signal Key | What it Measures |
-|---|---|
-| `volatility_gap` | Spread between realized and implied volatility; `positive` means IV is low relative to realized vol |
-| `futures_curve_steepness` | Degree of contango or backwardation in the WTI/Brent curve |
-| `sector_dispersion` | Divergence between energy sub-sectors (e.g. XOM vs. XLE) |
-| `insider_conviction_score` | Aggregated intensity of recent insider buying/selling activity |
-| `narrative_velocity` | Acceleration of energy-related headlines and social mentions |
-| `supply_shock_probability` | Model probability of a near-term supply disruption event |
-| `tanker_disruption_index` | Shipping anomaly score derived from AIS/MarineTraffic data |
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Use these to understand *why* a candidate was surfaced:
 
-### Consuming Output in thinkorswim or a Dashboard
-
-The JSON output is self-contained and can be loaded directly into any JSON-capable tool. For thinkorswim, import `candidates_latest.json` via the platform's **Scan** or custom scripting interface, mapping `instrument` → watchlist symbol and `edge_score` → sort column.
-
----
-
-## Troubleshooting
-
-### Pipeline Fails to Start
-
-| Symptom | Likely Cause | Fix |
+| Signal Key | Computed From | Possible Values |
 |---|---|---|
-| `KeyError: ALPHA_VANTAGE_API_KEY` | Missing required env var | Ensure `.env` is populated and the shell has loaded it (`source .env` or use a tool like `direnv`) |
-| `ModuleNotFoundError` | Dependencies not installed | Confirm the virtual environment is active and `pip install -r requirements.txt` completed without errors |
-| `Permission denied: ./data` | `DATA_DIR` not writable | `mkdir -p data output && chmod 755 data output` |
+| `volatility_gap` | Realised IV vs. implied IV | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | WTI/Brent futures curve shape | `steep`, `flat`, `inverted` |
+| `sector_dispersion` | XOM vs. CVX vs. XLE spread | `widening`, `stable`, `narrowing` |
+| `insider_conviction_score` | SEC EDGAR / Quiver Quant flows | `high`, `moderate`, `low` |
+| `narrative_velocity` | Reddit / Stocktwits headline rate | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | EIA data + event detection | `elevated`, `moderate`, `low` |
+| `tanker_disruption_index` | MarineTraffic / VesselFinder | `high`, `moderate`, `low` |
 
-### Data Source Errors
+### Consuming Output in thinkorswim or Another Dashboard
 
-| Symptom | Likely Cause | Fix |
-|---|---|---|
-| `[WARN] alpha_vantage: rate limit exceeded` | Free-tier API limit hit | Increase `MARKET_REFRESH_INTERVAL_SECONDS` to `300` (5 min) or obtain a paid key |
-| `[WARN] eia: HTTP 403` | Invalid or expired EIA key | Regenerate key at [eia.gov/opendata](https://www.eia.gov/opendata/) |
-| `[WARN] yfinance: no options data for XOM` | Options chain temporarily unavailable | The pipeline tolerates missing data; the affected instrument is skipped for that run and retried on the next cycle |
-| `[WARN] gdelt: timeout` | GDELT endpoint unreachable | Set `GDELT_ENABLED=false` temporarily; geo-event signals will be absent but pipeline will continue |
+The JSON output is compatible with any JSON-capable visualization tool. To import into thinkorswim or a custom dashboard:
 
-### Output is Empty or All Candidates Filtered
-
-```bash
-# Check what was generated before threshold filtering
-LOG_LEVEL=DEBUG python -m agent run --agent strategy
-```
-
-If the debug log shows candidates being discarded, your `EDGE_SCORE_THRESHOLD` may be too high for current market conditions.
-
-```bash
-# Lower the threshold for a single exploratory run
-EDGE_SCORE_THRESHOLD=0.10 python -m agent run
-```
-
-### Stale Output Timestamps
-
-If `generated_at` in the output is not advancing, the pipeline may be writing to a cached state. Clear the derived features store and re-run:
-
-```bash
-python -m agent clear-cache --features
-python -m agent run
-```
-
-> **Note:** `--features` clears only the derived signals cache. Raw historical price data in `$DATA_DIR` is not affected.
-
-### Data Retention and Storage Growth
-
-Historical raw and derived data defaults to 365 days (`HISTORY_RETENTION_DAYS`). If disk space is a concern, reduce this value:
-
-```bash
-HISTORY_RETENTION_DAYS=180 python -m agent run
-```
-
-The pipeline automatically purges records older than `HISTORY_RETENTION_DAYS` at the start of each run. A minimum of 180 days is recommended to support meaningful volatility and curve calculations.
-
----
-
-> **Disclaimer:** The Energy Options Opportunity Agent is an informational tool only. It does not execute trades and does not constitute financial advice. All output should be reviewed by a qualified individual before any trading decision is made.
+1. Point your tool at the file path set in `OUTPUT_PATH`.
+2. Refresh after each pipeline run (or after each cycle in continuous mode).
+3. Sort or filter on `

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting its output. It assumes you are comfortable with Python 3 and a Unix-style command line.
+> This guide walks a developer through setting up, configuring, and running the full Energy Options Opportunity Agent pipeline end-to-end.
 
 ---
 
@@ -18,61 +18,51 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests live and near-live market data, scores supply and geopolitical events, derives volatility signals, and produces a ranked list of candidate options strategies — all without automated trade execution.
+The Energy Options Opportunity Agent is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
 
-### Pipeline at a Glance
+The pipeline is composed of **four loosely coupled agents** that execute in a fixed, unidirectional sequence, communicating through a shared market state object and a derived features store.
 
 ```mermaid
 flowchart LR
     subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[Shipping & Sentiment\nMarineTraffic · Reddit · Stocktwits]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A1[Fetch crude prices\nETF / equity data\noptions chains]
+        A2[Normalize → unified\nmarket state object]
+        A1 --> A2
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[News & Geo Feeds\nGDELT / NewsAPI]
-        B2[Supply Disruption Scoring]
-        B3[Confidence & Intensity Scores]
+    subgraph Event["② Event Detection Agent"]
+        B1[Monitor news &\ngeo feeds]
+        B2[Score supply disruptions\nrefinery outages\ntanker chokepoints]
+        B1 --> B2
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs. Implied]
-        C2[Futures Curve Steepness]
-        C3[Sector Dispersion]
-        C4[Insider Conviction Score]
-        C5[Narrative Velocity]
-        C6[Supply Shock Probability]
+    subgraph Feature["③ Feature Generation Agent"]
+        C1[Compute derived signals:\nvol gaps · curve steepness\ndispersion · insider scores\nnarrative velocity · shock prob]
     end
 
     subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate Eligible Structures]
-        D2[Compute Edge Scores]
-        D3[Rank Candidates]
+        D1[Evaluate option structures\nagainst signals]
+        D2[Rank by edge score\nwith explainability refs]
+        D1 --> D2
     end
 
-    OUT[(JSON Output\nRanked Candidates)]
-
-    Ingestion -->|Market State Object| Events
-    Ingestion -->|Market State Object| Features
-    Events    -->|Scored Events| Features
-    Features  -->|Derived Signal Store| Strategy
-    Strategy  --> OUT
+    RAW[(Raw feeds)] --> Ingestion
+    Ingestion -->|market state| Event
+    Event -->|scored events| Feature
+    Feature -->|derived features| Strategy
+    Strategy -->|JSON candidates| OUT[(Output / Dashboard)]
 ```
 
 ### In-Scope Instruments & Structures
 
 | Category | Items |
 |---|---|
-| **Crude Futures** | Brent Crude, WTI (`CL=F`) |
+| **Crude futures** | Brent Crude, WTI (`CL=F`) |
 | **ETFs** | USO, XLE |
-| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option Structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
 
-> **Advisory only.** The system produces recommendations; it does not execute trades.
+> **Advisory only.** The system surfaces ranked opportunities but does **not** execute trades automatically.
 
 ---
 
@@ -84,145 +74,145 @@ flowchart LR
 |---|---|
 | Python | 3.10+ |
 | RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Disk | 10 GB (for 6–12 months of historical data) |
 | Deployment target | Local machine, single VM, or container |
 
-### Required Tools
+### External Accounts & API Keys
 
-```bash
-# Verify Python version
-python --version          # must be 3.10 or higher
-
-# Verify pip
-pip --version
-
-# Optional but recommended: create a virtual environment
-python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
-```
-
-### API Accounts
-
-Obtain credentials (all free or free-tier) before configuration:
+You must obtain credentials for the following services before running the pipeline. All sources listed below are free or offer a usable free tier.
 
 | Service | Purpose | Sign-up URL |
 |---|---|---|
-| Alpha Vantage **or** MetalpriceAPI | WTI / Brent spot & futures prices | https://www.alphavantage.co / https://metalpriceapi.com |
-| Polygon.io | Options chains (alternative to Yahoo Finance) | https://polygon.io |
-| EIA Open Data | Weekly supply & inventory data | https://www.eia.gov/opendata |
-| NewsAPI | News & geopolitical events | https://newsapi.org |
-| GDELT | Geopolitical event stream | No key required (public) |
-| SEC EDGAR / Quiver Quant | Insider trading activity | https://efts.sec.gov / https://www.quiverquant.com |
-| MarineTraffic **or** VesselFinder | Tanker flow data | https://www.marinetraffic.com / https://www.vesselfinder.com |
+| Alpha Vantage or MetalpriceAPI | WTI / Brent spot & futures prices | alphavantage.co / metalpriceapi.com |
+| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required (yfinance); polygon.io for enhanced options |
+| Polygon.io *(optional)* | Enhanced options chain data | polygon.io |
+| EIA Open Data API | Inventory & refinery utilization | eia.gov/opendata |
+| GDELT Project | Geopolitical & news event feed | gdeltproject.org (no key) |
+| NewsAPI | Headline news feed | newsapi.org |
+| SEC EDGAR | Insider activity (Form 4) | No key required |
+| Quiver Quant *(optional)* | Structured insider signals | quiverquant.com |
+| MarineTraffic / VesselFinder | Tanker shipping flows | marinetraffic.com (free tier) |
+| Reddit API | Retail sentiment / narrative velocity | reddit.com/dev/api |
+| Stocktwits *(optional)* | Retail sentiment | stocktwits.com/developers |
 
-> Yahoo Finance (`yfinance`), Reddit, Stocktwits, and GDELT do not require API keys for basic access.
+### Python Dependencies
+
+Install all dependencies from the project root:
+
+```bash
+pip install -r requirements.txt
+```
+
+Key packages include:
+
+```
+yfinance
+requests
+pandas
+numpy
+python-dotenv
+schedule
+```
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone & Install Dependencies
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
+```
 
+### 2. Create a Virtual Environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate        # macOS / Linux
+.venv\Scripts\activate           # Windows
+```
+
+### 3. Install Dependencies
+
+```bash
 pip install -r requirements.txt
 ```
 
-### 2. Create the Environment File
+### 4. Configure Environment Variables
 
-Copy the provided template and fill in your credentials:
+Copy the example environment file and populate it with your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and populate each variable (see the full reference table below).
+Open `.env` in your editor and fill in each value. The table below documents every supported variable.
 
-### 3. Environment Variable Reference
-
-All pipeline behaviour is controlled via environment variables. The `.env` file is loaded automatically at startup.
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Conditional¹ | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Conditional¹ | — | API key for MetalpriceAPI crude price feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory & utilization data |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy headlines |
-| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
-| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
-| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes-level) |
-| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory polling |
-| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for SEC EDGAR insider data polling |
-| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw & derived data to retain (180–365 recommended) |
-| `OUTPUT_PATH` | No | `./output/candidates.json` | File path for ranked candidate JSON output |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to monitor |
-| `EDGE_SCORE_MIN_THRESHOLD` | No | `0.20` | Candidates below this edge score are suppressed from output |
-| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
-| `ENABLE_SHIPPING_SIGNALS` | No | `false` | Set `true` to activate MarineTraffic/VesselFinder agent |
-| `ENABLE_INSIDER_SIGNALS` | No | `false` | Set `true` to activate SEC EDGAR / Quiver Quant agent |
-| `ENABLE_NARRATIVE_SIGNALS` | No | `true` | Set `false` to disable Reddit/Stocktwits sentiment agent |
-| `DB_PATH` | No | `./data/market_state.db` | SQLite database path for historical storage |
+| `ALPHA_VANTAGE_API_KEY` | Yes* | — | API key for Alpha Vantage crude price feed. *Required if not using MetalpriceAPI. |
+| `METALPRICE_API_KEY` | Yes* | — | API key for MetalpriceAPI. *Required if not using Alpha Vantage. |
+| `POLYGON_API_KEY` | No | — | Polygon.io key for enhanced options chain data. Falls back to yfinance if absent. |
+| `EIA_API_KEY` | Yes | — | EIA Open Data API key for inventory and refinery utilization data. |
+| `NEWS_API_KEY` | Yes | — | NewsAPI key for headline ingestion. |
+| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth client ID for sentiment feed. |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth client secret. |
+| `REDDIT_USER_AGENT` | No | `energy-options-agent/1.0` | Reddit API user-agent string. |
+| `MARINETRAFFIC_API_KEY` | No | — | MarineTraffic free-tier key for tanker flow data. |
+| `QUIVER_API_KEY` | No | — | Quiver Quant key for structured insider signals. |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written. |
+| `HISTORY_DAYS` | No | `180` | Days of historical data to retain (minimum 180; recommended 365). |
+| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Polling interval in minutes for market data (crude, ETF, equity). |
+| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Polling interval in hours for slow feeds (EIA, EDGAR). |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `EDGE_SCORE_THRESHOLD` | No | `0.30` | Minimum edge score `[0.0–1.0]` for a candidate to appear in output. |
 
-> ¹ At least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY` must be provided.
+> **Tip:** Variables marked *No* are optional but enable additional signal layers (Phase 2–3 features). The pipeline degrades gracefully when optional credentials are absent — it logs a warning and skips that data source rather than failing.
 
-### 4. Example `.env` File
+#### Example `.env`
 
 ```dotenv
-# Crude price source (provide at least one)
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-METALPRICE_API_KEY=
+# Required
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY
+EIA_API_KEY=YOUR_EIA_KEY
+NEWS_API_KEY=YOUR_NEWSAPI_KEY
 
-# Options data
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+# Optional — enhanced options data
+POLYGON_API_KEY=YOUR_POLYGON_KEY
 
-# Supply & inventory
-EIA_API_KEY=YOUR_EIA_KEY_HERE
+# Optional — alternative signals (Phase 2–3)
+REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
+REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
+REDDIT_USER_AGENT=energy-options-agent/1.0
+MARINETRAFFIC_API_KEY=YOUR_MT_KEY
+QUIVER_API_KEY=YOUR_QUIVER_KEY
 
-# News & events
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# Optional alternative signals
-QUIVER_QUANT_API_KEY=
-MARINE_TRAFFIC_API_KEY=
-ENABLE_SHIPPING_SIGNALS=false
-ENABLE_INSIDER_SIGNALS=false
-ENABLE_NARRATIVE_SIGNALS=true
-
-# Data refresh cadences
-DATA_REFRESH_INTERVAL_MINUTES=5
-EIA_REFRESH_INTERVAL_HOURS=24
-EDGAR_REFRESH_INTERVAL_HOURS=24
-
-# Storage & output
-HISTORICAL_RETENTION_DAYS=180
-DB_PATH=./data/market_state.db
-OUTPUT_PATH=./output/candidates.json
-
-# Pipeline tuning
-EDGE_SCORE_MIN_THRESHOLD=0.20
-MAX_CANDIDATES=20
+# Pipeline behaviour
+OUTPUT_DIR=./output
+HISTORY_DAYS=365
+MARKET_DATA_INTERVAL_MIN=5
+SLOW_FEED_INTERVAL_HOURS=24
 LOG_LEVEL=INFO
+EDGE_SCORE_THRESHOLD=0.30
 ```
 
-### 5. Initialise the Database
+### 5. Initialise the Data Store
 
-Run the schema migration once before your first pipeline execution:
+Run the bootstrap command once to create the local database schema and pull the initial historical window:
 
 ```bash
-python -m agent init-db
+python -m pipeline.bootstrap
 ```
 
 Expected output:
 
 ```
-[INFO] Initialising database at ./data/market_state.db
-[INFO] Schema applied successfully.
-[INFO] Ready.
+[INFO] Creating data store at ./data/market_state.db
+[INFO] Seeding 365 days of historical data for: CL=F, BZ=F, USO, XLE, XOM, CVX
+[INFO] Bootstrap complete. Run `python -m pipeline.run` to start the agent.
 ```
 
 ---
@@ -233,104 +223,104 @@ Expected output:
 
 ```mermaid
 sequenceDiagram
-    actor User
     participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant OUT as JSON Output
+    participant OUT as Output (JSON)
 
-    User->>CLI: python -m agent run
-    CLI->>DIA: Fetch & normalise market data
-    DIA-->>CLI: Market State Object ✓
-    CLI->>EDA: Detect & score events
-    EDA-->>CLI: Scored Event List ✓
-    CLI->>FGA: Compute derived signals
-    FGA-->>CLI: Derived Feature Store ✓
-    CLI->>SEA: Evaluate & rank strategies
-    SEA-->>OUT: Write candidates.json
-    OUT-->>User: Ranked candidates ready
+    CLI->>DIA: trigger run
+    DIA->>DIA: fetch & normalize feeds
+    DIA-->>EDA: market state object
+    EDA->>EDA: detect & score events
+    EDA-->>FGA: scored event list
+    FGA->>FGA: compute derived signals
+    FGA-->>SEA: features store
+    SEA->>SEA: evaluate & rank option structures
+    SEA-->>OUT: write candidate JSON
+    OUT-->>CLI: run complete
 ```
 
 ### Single Run (One-Shot)
 
-Execute the full four-agent pipeline once and write results to the configured output path:
+Execute one complete pipeline cycle and exit:
 
 ```bash
-python -m agent run
+python -m pipeline.run --once
 ```
 
-### Continuous Mode
+Use this for testing, ad-hoc analysis, or running from an external scheduler (cron, Task Scheduler, etc.).
 
-Poll on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence, re-running the full pipeline each cycle:
+### Continuous Mode (Scheduled)
+
+Run the pipeline on the configured polling schedule (`MARKET_DATA_INTERVAL_MIN` for market data, `SLOW_FEED_INTERVAL_HOURS` for EIA/EDGAR):
 
 ```bash
-python -m agent run --continuous
+python -m pipeline.run
 ```
 
-Press `Ctrl+C` to stop gracefully.
+The process loops indefinitely. Use a process manager (e.g., `systemd`, `supervisord`, or Docker) to keep it running in production.
 
-### Run Individual Agents
+### Run a Single Agent in Isolation
 
-Each agent is independently deployable and can be invoked in isolation for testing or incremental development:
+Each agent can be invoked independently for debugging or development:
 
 ```bash
-# Data Ingestion only
-python -m agent run --agent ingestion
+# Data Ingestion Agent only
+python -m pipeline.agents.ingestion
 
-# Event Detection only
-python -m agent run --agent events
+# Event Detection Agent only
+python -m pipeline.agents.event_detection
 
-# Feature Generation only
-python -m agent run --agent features
+# Feature Generation Agent only
+python -m pipeline.agents.feature_generation
 
-# Strategy Evaluation only
-python -m agent run --agent strategy
+# Strategy Evaluation Agent only
+python -m pipeline.agents.strategy_evaluation
 ```
 
-> When running agents individually, earlier stages must have already written their outputs to the shared state store.
+> **Note:** Running agents in isolation requires that upstream data already exists in the shared data store (i.e., a prior ingestion run has completed).
 
-### Override Configuration at Runtime
+### Running with Docker
 
-Any environment variable can be overridden inline without editing `.env`:
-
-```bash
-LOG_LEVEL=DEBUG EDGE_SCORE_MIN_THRESHOLD=0.30 python -m agent run
-```
-
-### Scheduling with Cron
-
-To run once per hour on a Unix system:
+A `Dockerfile` and `docker-compose.yml` are provided for containerised deployment:
 
 ```bash
-# Edit crontab
-crontab -e
+# Build the image
+docker build -t energy-options-agent:latest .
 
-# Add the following line (adjust paths as needed)
-0 * * * * /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
+# Run with your .env file
+docker run --env-file .env -v $(pwd)/output:/app/output energy-options-agent:latest
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File
+### Output Location
 
-Results are written to the path specified by `OUTPUT_PATH` (default: `./output/candidates.json`) as a JSON array, sorted descending by `edge_score`.
+By default, results are written to `./output/` as timestamped JSON files:
+
+```
+output/
+└── candidates_2026-03-15T14:32:00Z.json
+```
+
+The path is controlled by the `OUTPUT_DIR` environment variable.
 
 ### Output Schema
 
-Each element in the array is a **strategy candidate** object:
+Each file contains an array of candidate objects. Every field is described below.
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative states |
-| `generated_at` | ISO 8601 `datetime` | UTC timestamp of candidate generation |
+| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher values indicate stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their assessed levels |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
 ### Example Output
 
@@ -352,11 +342,11 @@ Each element in the array is a **strategy candidate** object:
     "instrument": "XLE",
     "structure": "call_spread",
     "expiration": 21,
-    "edge_score": 0.31,
+    "edge_score": 0.61,
     "signals": {
       "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "sector_dispersion": "widening"
+      "insider_conviction_score": "high"
     },
     "generated_at": "2026-03-15T14:32:00Z"
   }
@@ -365,36 +355,61 @@ Each element in the array is a **strategy candidate** object:
 
 ### Reading the Edge Score
 
-The `edge_score` is a composite float in the range 0.0–1.0. It reflects how many signals are aligned in support of a given strategy, weighted by their intensity.
-
 | Edge Score Range | Interpretation |
 |---|---|
-| `0.00 – 0.19` | Weak / suppressed (filtered out by default) |
-| `0.20 – 0.34` | Low conviction — monitor for confirmation |
-| `0.35 – 0.49` | Moderate confluence — warrants closer review |
-| `0.50 – 0.69` | Strong signal alignment — high-priority candidate |
-| `0.70 – 1.00` | Very strong confluence — investigate immediately |
+| `0.70 – 1.00` | Strong signal confluence — multiple independent signals aligned |
+| `0.50 – 0.69` | Moderate opportunity — meaningful signal overlap, worth monitoring |
+| `0.30 – 0.49` | Weak but detectable signal — included at default threshold |
+| `< 0.30` | Below threshold — filtered out by default (`EDGE_SCORE_THRESHOLD`) |
 
-> The scoring function is intentionally heuristic in the MVP. Complexity and ML-based weighting are deferred to Phase 4.
+Candidates are sorted in descending `edge_score` order within each output file.
 
-### Understanding the `signals` Map
+### Reading the Signals Map
 
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Use these to understand *why* a candidate was surfaced:
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Common signal keys and their meanings:
 
-| Signal Key | Computed From | Possible Values |
+| Signal Key | Source Agent | Meaning |
 |---|---|---|
-| `volatility_gap` | Realised IV vs. implied IV | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | WTI/Brent futures curve shape | `steep`, `flat`, `inverted` |
-| `sector_dispersion` | XOM vs. CVX vs. XLE spread | `widening`, `stable`, `narrowing` |
-| `insider_conviction_score` | SEC EDGAR / Quiver Quant flows | `high`, `moderate`, `low` |
-| `narrative_velocity` | Reddit / Stocktwits headline rate | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | EIA data + event detection | `elevated`, `moderate`, `low` |
-| `tanker_disruption_index` | MarineTraffic / VesselFinder | `high`, `moderate`, `low` |
+| `volatility_gap` | Feature Generation | Realised IV minus implied IV; `positive` = IV underpriced |
+| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the crude curve |
+| `sector_dispersion` | Feature Generation | Spread between energy sub-sector returns |
+| `insider_conviction_score` | Feature Generation | Aggregated insider buy/sell activity via EDGAR / Quiver Quant |
+| `narrative_velocity` | Feature Generation | Acceleration of energy-related headline volume |
+| `supply_shock_probability` | Feature Generation | Estimated probability of near-term supply disruption |
+| `tanker_disruption_index` | Event Detection | Severity of detected tanker / chokepoint disruptions |
+| `refinery_outage_flag` | Event Detection | Binary or scaled signal for active refinery outage events |
+| `geopolitical_intensity` | Event Detection | Confidence-weighted score for geopolitical events affecting supply |
 
-### Consuming Output in thinkorswim or Another Dashboard
+### Downstream Consumption
 
-The JSON output is compatible with any JSON-capable visualization tool. To import into thinkorswim or a custom dashboard:
+The JSON output is compatible with any JSON-capable dashboard or platform, including thinkorswim. To reload results programmatically:
 
-1. Point your tool at the file path set in `OUTPUT_PATH`.
-2. Refresh after each pipeline run (or after each cycle in continuous mode).
-3. Sort or filter on `
+```python
+import json
+from pathlib import Path
+
+candidates = json.loads(
+    Path("output/candidates_2026-03-15T14:32:00Z.json").read_text()
+)
+
+for c in sorted(candidates, key=lambda x: x["edge_score"], reverse=True):
+    print(f"{c['instrument']:>6}  {c['structure']:<20}  edge={c['edge_score']:.2f}")
+```
+
+---
+
+## Troubleshooting
+
+### Pipeline Fails to Start
+
+| Symptom | Likely Cause | Resolution |
+|---|---|---|
+| `KeyError: 'EIA_API_KEY'` | Missing required env var | Ensure `.env` is populated and loaded (`python-dotenv` reads it automatically). |
+| `ModuleNotFoundError` | Dependencies not installed | Run `pip install -r requirements.txt` inside your active virtual environment. |
+| `FileNotFoundError: market_state.db` | Bootstrap not run | Run `python -m pipeline.bootstrap` before the first pipeline run. |
+
+### Data Source Errors
+
+| Symptom | Likely Cause | Resolution |
+|---|---|---|
+| `[WARNING] Alpha

--- a/src/backtest/__init__.py
+++ b/src/backtest/__init__.py
@@ -1,0 +1,1 @@
+# src/backtest/__init__.py

--- a/src/backtest/backtest.py
+++ b/src/backtest/backtest.py
@@ -1,12 +1,14 @@
 """
 Backtesting pipeline for the Energy Options Opportunity Agent.
 
-Entry point:  run_backtest_pipeline(slices)
+This module currently provides the DB layer for historical backtest data.
 DB writers:   write_backtest_candidate(), record_outcome()
 
+Planned entry point (issue #166):
+  run_backtest_pipeline(slices) — calls compute_* functions directly, never
+  run_feature_generation(), to avoid writing to the live feature_sets table.
+
 Design notes (from eng review 2026-03-21):
-  - run_backtest_pipeline() calls compute_* functions DIRECTLY, never
-    run_feature_generation(), to avoid writing to the live feature_sets table.
   - backtest_candidates is isolated from strategy_candidates — historical replay
     rows never pollute production reporting queries.
   - profitable=None (not skipped) when yfinance returns no history for a date.
@@ -40,7 +42,9 @@ def write_backtest_candidate(candidate: BacktestCandidate, engine: Engine) -> uu
     the database-assigned UUID.
 
     Args:
-        candidate: Validated BacktestCandidate to insert.
+        candidate: Validated BacktestCandidate to insert. candidate.signals
+            (dict) is JSON-serialized internally before the INSERT — callers
+            pass the raw dict and do not need to pre-serialize.
         engine:    SQLAlchemy Engine connected to the target database.
 
     Returns:

--- a/src/backtest/backtest.py
+++ b/src/backtest/backtest.py
@@ -1,0 +1,153 @@
+"""
+Backtesting pipeline for the Energy Options Opportunity Agent.
+
+Entry point:  run_backtest_pipeline(slices)
+DB writers:   write_backtest_candidate(), record_outcome()
+
+Design notes (from eng review 2026-03-21):
+  - run_backtest_pipeline() calls compute_* functions DIRECTLY, never
+    run_feature_generation(), to avoid writing to the live feature_sets table.
+  - backtest_candidates is isolated from strategy_candidates — historical replay
+    rows never pollute production reporting queries.
+  - profitable=None (not skipped) when yfinance returns no history for a date.
+  - entry_premium/upper_strike/lower_strike are persisted for spread P&L even
+    though Sprint A only backtests long_straddle — schema is forward-compatible.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import logging
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from src.backtest.models import BacktestCandidate, BacktestOutcome
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# DB writers
+# ---------------------------------------------------------------------------
+
+
+def write_backtest_candidate(candidate: BacktestCandidate, engine: Engine) -> uuid.UUID:
+    """
+    Persist a single BacktestCandidate to backtest_candidates and return
+    the database-assigned UUID.
+
+    Args:
+        candidate: Validated BacktestCandidate to insert.
+        engine:    SQLAlchemy Engine connected to the target database.
+
+    Returns:
+        uuid.UUID: The generated primary key assigned by gen_random_uuid().
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: Propagates on constraint violation or
+            connection failure after logging the exception.
+    """
+    sql = text("""
+        INSERT INTO backtest_candidates
+            (instrument, structure, snapshot_time, edge_score, signals, generated_at)
+        VALUES
+            (:instrument, :structure, :snapshot_time, :edge_score, :signals, :generated_at)
+        RETURNING id
+        """)
+
+    params = {
+        "instrument": candidate.instrument,
+        "structure": candidate.structure,
+        "snapshot_time": candidate.snapshot_time,
+        "edge_score": candidate.edge_score,
+        "signals": json.dumps(candidate.signals),
+        "generated_at": candidate.generated_at,
+    }
+
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(sql, params).fetchone()
+    except Exception:
+        logger.exception(
+            "write_backtest_candidate failed for instrument=%s structure=%s",
+            candidate.instrument,
+            candidate.structure,
+        )
+        raise
+
+    if row is None:  # pragma: no cover — INSERT RETURNING always returns a row
+        raise RuntimeError("write_backtest_candidate: INSERT RETURNING returned no row")
+    assigned_id: uuid.UUID = row[0]
+    logger.debug(
+        "Wrote backtest candidate id=%s instrument=%s edge_score=%.4f",
+        assigned_id,
+        candidate.instrument,
+        candidate.edge_score,
+    )
+    return assigned_id
+
+
+def record_outcome(outcome: BacktestOutcome, engine: Engine) -> uuid.UUID:
+    """
+    Persist a BacktestOutcome to backtest_outcomes and return its UUID.
+
+    profitable=None is allowed — it means yfinance returned no data for the
+    expiration date. The row is still inserted so the audit trail is complete.
+
+    Args:
+        outcome: Validated BacktestOutcome to insert.
+        engine:  SQLAlchemy Engine connected to the target database.
+
+    Returns:
+        uuid.UUID: The generated primary key assigned by gen_random_uuid().
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: Propagates on constraint violation or
+            connection failure after logging the exception.
+    """
+    sql = text("""
+        INSERT INTO backtest_outcomes
+            (candidate_id, structure, expiration, underlying_close,
+             entry_premium, upper_strike, lower_strike, profitable, recorded_at)
+        VALUES
+            (:candidate_id, :structure, :expiration, :underlying_close,
+             :entry_premium, :upper_strike, :lower_strike, :profitable, :recorded_at)
+        RETURNING id
+        """)
+
+    params = {
+        "candidate_id": str(outcome.candidate_id),
+        "structure": outcome.structure,
+        "expiration": outcome.expiration,
+        "underlying_close": outcome.underlying_close,
+        "entry_premium": outcome.entry_premium,
+        "upper_strike": outcome.upper_strike,
+        "lower_strike": outcome.lower_strike,
+        "profitable": outcome.profitable,
+        "recorded_at": outcome.recorded_at or datetime.now(tz=UTC),
+    }
+
+    try:
+        with engine.begin() as conn:
+            row = conn.execute(sql, params).fetchone()
+    except Exception:
+        logger.exception(
+            "record_outcome failed for candidate_id=%s expiration=%s",
+            outcome.candidate_id,
+            outcome.expiration,
+        )
+        raise
+
+    if row is None:  # pragma: no cover — INSERT RETURNING always returns a row
+        raise RuntimeError("record_outcome: INSERT RETURNING returned no row")
+    assigned_id: uuid.UUID = row[0]
+    logger.debug(
+        "Recorded outcome id=%s candidate_id=%s profitable=%s",
+        assigned_id,
+        outcome.candidate_id,
+        outcome.profitable,
+    )
+    return assigned_id

--- a/src/backtest/models.py
+++ b/src/backtest/models.py
@@ -1,0 +1,61 @@
+"""
+Pydantic boundary models for the backtesting pipeline.
+
+These models are isolated from the live pipeline models (StrategyCandidate,
+FeatureSet, etc.) to ensure historical replay data never pollutes production
+tables or reporting queries.
+
+Data flow:
+    HistoricalLoader → HistoricalSlice
+    run_backtest_pipeline → BacktestCandidate (written via write_backtest_candidate)
+    OutcomeTracker → BacktestOutcome (written via record_outcome)
+    BacktestReport → reads from DB, produces matplotlib chart
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+import uuid
+
+from pydantic import BaseModel, Field
+
+
+class BacktestCandidate(BaseModel):
+    """
+    A strategy candidate produced during backtesting replay.
+
+    Written to backtest_candidates by write_backtest_candidate().
+    id is assigned by the database (gen_random_uuid()); it is None until
+    the row is persisted.
+    """
+
+    id: uuid.UUID | None = None
+    instrument: str
+    structure: str  # 'long_straddle' | 'call_spread' | 'put_spread'
+    snapshot_time: datetime  # Point-in-time of the historical slice
+    edge_score: float = Field(ge=0.0, le=1.0)
+    signals: dict[str, Any]
+    generated_at: datetime
+
+
+class BacktestOutcome(BaseModel):
+    """
+    The resolved P&L outcome for a BacktestCandidate at expiration.
+
+    Written to backtest_outcomes by record_outcome().
+    profitable=None means yfinance returned no data; row is still inserted.
+    entry_premium/upper_strike/lower_strike are nullable — None for long_straddle,
+    populated for spreads (deferred to Sprint A follow-up).
+    """
+
+    id: uuid.UUID | None = None
+    candidate_id: uuid.UUID
+    structure: str
+    expiration: datetime
+    underlying_close: float
+    entry_premium: float | None = None
+    upper_strike: float | None = None
+    lower_strike: float | None = None
+    profitable: bool | None = None  # None = could not be determined
+    recorded_at: datetime | None = None

--- a/tests/integration/test_backtest_integration.py
+++ b/tests/integration/test_backtest_integration.py
@@ -1,0 +1,229 @@
+"""
+Integration test — backtest_candidates and backtest_outcomes tables.
+
+Verifies (against a real Postgres container via testcontainers):
+  1. Both tables exist after the migration script is applied.
+  2. write_backtest_candidate() inserts a row and returns a valid UUID.
+  3. record_outcome() inserts a linked row with profitable=None (audit row).
+  4. record_outcome() inserts a row with profitable=True (resolved outcome).
+  5. The FK constraint between backtest_outcomes.candidate_id and
+     backtest_candidates.id is enforced (referential integrity).
+
+Design notes:
+  - Uses db/migrations/add_backtest_tables.sql, NOT the full schema.sql, to
+    confirm the migration works standalone (pgcrypto + table + index creation).
+  - profitable=None is explicitly tested — it is a valid state per the design
+    doc (yfinance returned no data; row still inserted for audit).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import os
+import pathlib
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import IntegrityError
+from testcontainers.postgres import PostgresContainer
+
+from src.backtest.backtest import record_outcome, write_backtest_candidate
+from src.backtest.models import BacktestCandidate, BacktestOutcome
+
+# Run integration tests only in CI unless the caller explicitly opts in.
+if not os.environ.get("CI"):
+    pytest.skip(
+        "Integration tests run in CI only. Set CI=1 to run locally.",
+        allow_module_level=True,
+    )
+
+_MIGRATION_PATH = (
+    pathlib.Path(__file__).parents[2] / "db" / "migrations" / "add_backtest_tables.sql"
+)
+
+# ---------------------------------------------------------------------------
+# Shared timestamps
+# ---------------------------------------------------------------------------
+_NOW = datetime.now(tz=UTC).replace(microsecond=0)
+_SNAPSHOT = _NOW - timedelta(days=30)
+_EXPIRATION = _NOW - timedelta(days=7)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _apply_migration(db_url: str) -> None:
+    """Apply the backtest migration against a fresh Postgres container."""
+    engine = create_engine(db_url)
+    sql = _MIGRATION_PATH.read_text(encoding="utf-8")
+    with engine.begin() as conn:
+        conn.exec_driver_sql(sql)
+
+
+def _make_candidate(instrument: str = "USO") -> BacktestCandidate:
+    return BacktestCandidate(
+        instrument=instrument,
+        structure="long_straddle",
+        snapshot_time=_SNAPSHOT,
+        edge_score=0.72,
+        signals={"volatility_gap": 0.12, "sector_dispersion": 0.08},
+        generated_at=_NOW,
+    )
+
+
+def _make_outcome(
+    candidate_id: uuid.UUID,
+    profitable: bool | None = None,
+) -> BacktestOutcome:
+    return BacktestOutcome(
+        candidate_id=candidate_id,
+        structure="long_straddle",
+        expiration=_EXPIRATION,
+        underlying_close=82.45,
+        profitable=profitable,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_migration_creates_both_tables() -> None:
+    """Both tables must exist after the migration is applied."""
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+
+        engine = create_engine(db_url)
+        with engine.connect() as conn:
+            tables = (
+                conn.execute(
+                    text(
+                        "SELECT table_name FROM information_schema.tables"
+                        " WHERE table_schema = 'public'"
+                        " ORDER BY table_name"
+                    )
+                )
+                .scalars()
+                .all()
+            )
+
+        assert "backtest_candidates" in tables, "backtest_candidates table missing"
+        assert "backtest_outcomes" in tables, "backtest_outcomes table missing"
+
+
+@pytest.mark.integration
+def test_write_backtest_candidate_returns_uuid() -> None:
+    """write_backtest_candidate() inserts a row and returns the DB-assigned UUID."""
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+
+        engine = create_engine(db_url)
+        os.environ["DATABASE_URL"] = db_url
+
+        candidate = _make_candidate("USO")
+        assigned_id = write_backtest_candidate(candidate, engine)
+
+        assert isinstance(assigned_id, uuid.UUID), "Expected UUID return type"
+
+        with engine.connect() as conn:
+            rows = conn.execute(
+                text("SELECT id, instrument, edge_score FROM backtest_candidates")
+            ).fetchall()
+
+        assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+        assert str(rows[0][0]) == str(assigned_id)
+        assert rows[0][1] == "USO"
+        assert float(rows[0][2]) == pytest.approx(0.72, abs=1e-4)
+
+
+@pytest.mark.integration
+def test_record_outcome_null_profitable() -> None:
+    """
+    record_outcome() with profitable=None — audit row for yfinance data gap.
+    Row must be inserted with profitable IS NULL, not skipped.
+    """
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+
+        engine = create_engine(db_url)
+        os.environ["DATABASE_URL"] = db_url
+
+        candidate_id = write_backtest_candidate(_make_candidate("XOM"), engine)
+        outcome_id = record_outcome(_make_outcome(candidate_id, profitable=None), engine)
+
+        assert isinstance(outcome_id, uuid.UUID)
+
+        with engine.connect() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT profitable, underlying_close, candidate_id"
+                    " FROM backtest_outcomes WHERE id = :id"
+                ),
+                {"id": str(outcome_id)},
+            ).fetchone()
+
+        assert row is not None
+        assert row[0] is None, "profitable should be NULL for yfinance data gap"
+        assert float(row[1]) == pytest.approx(82.45, abs=1e-4)
+        assert str(row[2]) == str(candidate_id)
+
+
+@pytest.mark.integration
+def test_record_outcome_profitable_true() -> None:
+    """record_outcome() with profitable=True — resolved long_straddle outcome."""
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+
+        engine = create_engine(db_url)
+        os.environ["DATABASE_URL"] = db_url
+
+        candidate_id = write_backtest_candidate(_make_candidate("CVX"), engine)
+        outcome_id = record_outcome(_make_outcome(candidate_id, profitable=True), engine)
+
+        with engine.connect() as conn:
+            profitable = conn.execute(
+                text("SELECT profitable FROM backtest_outcomes WHERE id = :id"),
+                {"id": str(outcome_id)},
+            ).scalar()
+
+        assert profitable is True
+
+
+@pytest.mark.integration
+def test_fk_constraint_rejects_unknown_candidate_id() -> None:
+    """
+    FK on backtest_outcomes.candidate_id must reject a non-existent UUID.
+    This ensures referential integrity between the two backtest tables.
+    """
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+
+        engine = create_engine(db_url)
+        os.environ["DATABASE_URL"] = db_url
+
+        fake_id = uuid.uuid4()
+        outcome = _make_outcome(fake_id, profitable=False)
+
+        with pytest.raises(IntegrityError):
+            # FK violation — candidate_id does not exist in backtest_candidates
+            record_outcome(outcome, engine)
+
+
+@pytest.mark.integration
+def test_migration_is_idempotent() -> None:
+    """Applying the migration twice must not raise an error (IF NOT EXISTS guards)."""
+    with PostgresContainer("postgres:15-alpine") as pg:
+        db_url = pg.get_connection_url()
+        _apply_migration(db_url)
+        # Second application must succeed — all DDL uses IF NOT EXISTS
+        _apply_migration(db_url)


### PR DESCRIPTION
## Summary

- **Migration:** `db/migrations/add_backtest_tables.sql` — two-table isolation design; `backtest_candidates` (UUID PK, snapshot_time, JSONB signals) + `backtest_outcomes` (UUID PK, FK→backtest_candidates, nullable `profitable`). Idempotent; includes `CREATE EXTENSION IF NOT EXISTS pgcrypto`.
- **DB layer:** `src/backtest/backtest.py` — `write_backtest_candidate()` returns DB-assigned UUID; `record_outcome()` supports `profitable=None` audit row when yfinance has no data.
- **Models:** `src/backtest/models.py` — `BacktestCandidate` and `BacktestOutcome` Pydantic boundary models isolated from live pipeline models.
- **Integration tests:** 5 testcontainers tests — migration creates both tables, UUID return, profitable=None audit row, profitable=True resolved outcome, FK constraint enforced, idempotent second migration.

## ⚠️ Human Sign-Off Required

**Do NOT run the migration script on any live database without human lead review and approval.**
This is an ESOD Hard Stop. The migration is documented and ready for review; execution is gated.

## Test Coverage

All 5 `local_check.sh` stages pass:
- ruff lint: PASS
- black format: PASS
- mypy (strict): PASS
- runtime import scan: PASS
- unit tests: 250 passed, 2 skipped

Integration tests in `tests/integration/test_backtest_integration.py` (5 tests, CI only via testcontainers).

## Pre-Landing Review

No frontend changes — design review skipped.

## TODOS

No TODOS.md items completed in this PR.

## Test plan
- [x] All unit tests pass (250 runs, 0 failures)
- [ ] Human lead reviews and approves migration SQL before applying to any live DB
- [ ] Integration tests pass in CI (testcontainers — requires CI=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)