### PR TITLE
feat(alternative-data): Phase 3 DB schema — insider_trades, shipping_events, narrative_signals (#148)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -373,7 +373,7 @@ Human lead approved 2026-03-21.
 
 ## Sprint Notes (2026-03-21, session 2)
 
-**#172 IN REVIEW** — DB migration and backtest DB layer implemented. PR opened.
+**#172 IN REVIEW** — DB migration and backtest DB layer complete. PR #177 open → develop.
 
 Two-table isolation design complete:
 - `db/migrations/add_backtest_tables.sql` — backtest_candidates (UUID PK, snapshot_time, edge_score,
@@ -387,4 +387,14 @@ Two-table isolation design complete:
 - All 5 local_check.sh stages pass (ruff, black, mypy, import scan, 250 unit tests).
 
 **HUMAN SIGN-OFF REQUIRED before running migration on any live DB (ESOD Hard Stop).**
-Next unblocked: #166 (HistoricalLoader) — depends on #172 merged.
+
+**#148 IN REVIEW** — Phase 3 alternative data DB schema complete. PR #178 open → develop.
+Three tables added to db/schema.sql: insider_trades, shipping_events, narrative_signals.
+src/agents/alternative_data/db.py: 6 typed stub functions (NotImplementedError) for issues #149-#153.
+All 5 local_check.sh stages pass.
+
+Next Sprint 9 unblocked issues (after #172 + #148 merge):
+- #149 — fetch_edgar_insider_trades (depends on insider_trades table from #148)
+- #151 — fetch_reddit_sentiment (depends on narrative_signals table from #148)
+- #152 — fetch_stocktwits_sentiment (depends on narrative_signals table from #148)
+- #153 — fetch_tanker_flows (depends on shipping_events table from #148)

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -388,13 +388,15 @@ Two-table isolation design complete:
 
 **HUMAN SIGN-OFF REQUIRED before running migration on any live DB (ESOD Hard Stop).**
 
+
 **#148 IN REVIEW** — Phase 3 alternative data DB schema complete. PR #178 open → develop.
-Three tables added to db/schema.sql: insider_trades, shipping_events, narrative_signals.
-src/agents/alternative_data/db.py: 6 typed stub functions (NotImplementedError) for issues #149-#153.
-All 5 local_check.sh stages pass.
+- db/schema.sql: insider_trades, shipping_events, narrative_signals tables added.
+- src/agents/alternative_data/db.py: 6 typed stub functions (NotImplementedError) for issues #149-#153.
+- All 5 local_check.sh stages pass.
 
 Next Sprint 9 unblocked issues (after #172 + #148 merge):
 - #149 — fetch_edgar_insider_trades (depends on insider_trades table from #148)
 - #151 — fetch_reddit_sentiment (depends on narrative_signals table from #148)
 - #152 — fetch_stocktwits_sentiment (depends on narrative_signals table from #148)
 - #153 — fetch_tanker_flows (depends on shipping_events table from #148)
+- #166 — HistoricalLoader / run_backtest_pipeline (depends on #172 merged)

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,6 @@
 -- =============================================================================
 -- db/schema.sql — Energy Options Opportunity Agent
--- Phase 1 + Phase 2 schema
+-- Phase 1 + Phase 2 + Phase 3 schema
 -- =============================================================================
 --
 -- Design principles (PRD Section 6.1):
@@ -8,10 +8,14 @@
 --   - All time-series tables use TIMESTAMPTZ (not TIMESTAMP) so that
 --     TimescaleDB hypertable conversion requires zero SQL changes.
 --   - Hypertable candidates (Phase 2, PRD Section 6.2):
---       * market_prices   → partition by timestamp
---       * options_chain   → partition by timestamp
---       * eia_inventory   → partition by fetched_at
---       * detected_events → partition by detected_at
+--       * market_prices      → partition by timestamp
+--       * options_chain      → partition by timestamp
+--       * eia_inventory      → partition by fetched_at
+--       * detected_events    → partition by detected_at
+--   - Hypertable candidates (Phase 3, issue #148):
+--       * insider_trades     → partition by trade_date
+--       * shipping_events    → partition by timestamp
+--       * narrative_signals  → partition by window_start
 --
 -- TimescaleDB migration triggers (PRD Section 6.2) — convert to hypertables
 -- when ANY of the following conditions is met:
@@ -24,6 +28,7 @@
 -- Apply:  psql $DATABASE_URL -f db/schema.sql
 -- Verify: \d market_prices    \d options_chain    \d feature_sets
 --         \d strategy_candidates    \d eia_inventory    \d detected_events
+--         \d insider_trades   \d shipping_events   \d narrative_signals
 -- =============================================================================
 
 
@@ -162,3 +167,88 @@ CREATE TABLE IF NOT EXISTS detected_events (
 
 CREATE INDEX IF NOT EXISTS idx_detected_events_detected_at
     ON detected_events (detected_at DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- insider_trades                                                     (Phase 3)
+--
+-- Stores SEC EDGAR Form 4 insider trade records fetched by
+-- fetch_edgar_insider_trades() (issue #149), optionally enriched by
+-- fetch_quiver_enrichment() (issue #150).
+-- One row per trade filing. (instrument, officer_name, trade_date) is not
+-- UNIQUE because the same officer may file multiple transactions on the same
+-- day for the same instrument (e.g., multiple grants/sales in a single Form 4).
+-- Hypertable candidate: partition by trade_date.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS insider_trades (
+    id            BIGSERIAL       PRIMARY KEY,
+    instrument    TEXT            NOT NULL,
+    trade_date    TIMESTAMPTZ     NOT NULL,
+    trade_type    TEXT            NOT NULL CHECK (trade_type IN ('buy', 'sell', 'grant', 'exercise')),
+    shares        BIGINT,
+    value_usd     NUMERIC(18, 2),
+    officer_name  TEXT,
+    source        TEXT            NOT NULL,
+    fetched_at    TIMESTAMPTZ     NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_insider_trades_instrument_trade_date
+    ON insider_trades (instrument, trade_date DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- shipping_events                                                    (Phase 3)
+--
+-- Stores tanker and vessel movement events fetched by fetch_tanker_flows()
+-- (issue #153) from MarineTraffic or VesselFinder.
+-- event_type examples: 'chokepoint_delay', 'route_deviation', 'anchored',
+--   'port_call', 'ais_gap'.
+-- Hypertable candidate: partition by timestamp.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS shipping_events (
+    id            BIGSERIAL       PRIMARY KEY,
+    instrument    TEXT,                              -- affected energy instrument (nullable)
+    vessel_id     TEXT            NOT NULL,
+    event_type    TEXT            NOT NULL,
+    latitude      NUMERIC(9, 6),
+    longitude     NUMERIC(9, 6),
+    timestamp     TIMESTAMPTZ     NOT NULL,
+    source        TEXT            NOT NULL,
+    fetched_at    TIMESTAMPTZ     NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_shipping_events_instrument_timestamp
+    ON shipping_events (instrument, timestamp DESC);
+
+CREATE INDEX IF NOT EXISTS idx_shipping_events_vessel_timestamp
+    ON shipping_events (vessel_id, timestamp DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- narrative_signals                                                  (Phase 3)
+--
+-- Stores social/news narrative velocity scores fetched by
+-- fetch_reddit_sentiment() (issue #151) and
+-- fetch_stocktwits_sentiment() (issue #152).
+-- platform: 'reddit' | 'stocktwits' | 'combined'
+-- sentiment: 'bullish' | 'bearish' | 'neutral' | 'mixed'
+-- UNIQUE (instrument, platform, window_start) prevents duplicate ingestion
+-- for the same time window — re-fetch uses ON CONFLICT DO NOTHING.
+-- Hypertable candidate: partition by window_start.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS narrative_signals (
+    id             BIGSERIAL       PRIMARY KEY,
+    instrument     TEXT            NOT NULL,
+    platform       TEXT            NOT NULL CHECK (platform IN ('reddit', 'stocktwits', 'combined')),
+    score          NUMERIC(6, 4),                   -- normalized velocity score [0,1]
+    mention_count  INTEGER,
+    sentiment      TEXT            CHECK (sentiment IN ('bullish', 'bearish', 'neutral', 'mixed')),
+    window_start   TIMESTAMPTZ     NOT NULL,
+    window_end     TIMESTAMPTZ     NOT NULL,
+    fetched_at     TIMESTAMPTZ     NOT NULL,
+    CONSTRAINT uq_narrative_signals_instrument_platform_window
+        UNIQUE (instrument, platform, window_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_narrative_signals_instrument_window
+    ON narrative_signals (instrument, window_start DESC);

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 · March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
+> Advisory system only. No automated trade execution is performed.
 
 ---
 
@@ -18,114 +18,106 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments as ranked, explainable strategy candidates.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies with full signal explainability.
 
-### Pipeline Architecture
+### What the pipeline does
 
-The system comprises four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**. Data flows in one direction only — from raw ingestion through to ranked output.
-
-```mermaid
-flowchart LR
-    subgraph Agents
-        A["🗄️ Data Ingestion Agent\n— Fetch & Normalize"]
-        B["📡 Event Detection Agent\n— Supply & Geo Signals"]
-        C["⚙️ Feature Generation Agent\n— Derived Signal Computation"]
-        D["🏆 Strategy Evaluation Agent\n— Opportunity Ranking"]
-    end
-
-    RAW["Raw Feeds\n(prices, options chains,\nnews, EIA, EDGAR,\nshipping, sentiment)"]
-    STATE["Market State Object"]
-    FEATURES["Derived Features Store"]
-    OUTPUT["Ranked Candidates\n(JSON)"]
-
-    RAW --> A
-    A --> STATE
-    STATE --> B
-    B --> STATE
-    STATE --> C
-    C --> FEATURES
-    FEATURES --> D
-    D --> OUTPUT
-```
-
-| Agent | Role | Key Outputs |
+| Stage | Agent | Core output |
 |---|---|---|
-| **Data Ingestion** | Fetch & Normalize | Unified market state object, historical price store |
-| **Event Detection** | Supply & Geo Signals | Scored supply disruption events (confidence + intensity) |
-| **Feature Generation** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
-| **Strategy Evaluation** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
+| 1 — Ingest | Data Ingestion Agent | Unified market state object |
+| 2 — Detect | Event Detection Agent | Scored supply/geo events |
+| 3 — Derive | Feature Generation Agent | Computed signals (vol gaps, curve steepness, etc.) |
+| 4 — Rank | Strategy Evaluation Agent | Ranked opportunities with edge scores |
 
-### In-Scope Instruments
+### In-scope instruments
 
 | Category | Instruments |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| Crude futures | Brent Crude, WTI (`CL=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-### In-Scope Option Structures (MVP)
+### In-scope option structures (MVP)
 
 - Long straddles
 - Call / put spreads
 - Calendar spreads
 
-> **Advisory only.** Automated trade execution is explicitly out of scope. All output is informational.
+> **Out of scope (MVP):** exotic/multi-legged structures, regional refined product pricing (OPIS), and automated trade execution.
+
+### Pipeline architecture
+
+```mermaid
+flowchart LR
+    subgraph Sources["External Data Sources"]
+        S1["Alpha Vantage / MetalpriceAPI\n(Crude prices)"]
+        S2["Yahoo Finance / yfinance\n(ETF & Equity)"]
+        S3["Yahoo Finance / Polygon.io\n(Options chains)"]
+        S4["EIA API\n(Supply/Inventory)"]
+        S5["GDELT / NewsAPI\n(News & Geo)"]
+        S6["SEC EDGAR / Quiver Quant\n(Insider activity)"]
+        S7["MarineTraffic / VesselFinder\n(Shipping)"]
+        S8["Reddit / Stocktwits\n(Sentiment)"]
+    end
+
+    subgraph Pipeline["Agent Pipeline"]
+        A1["🔵 Data Ingestion Agent\nFetch & Normalize"]
+        A2["🟡 Event Detection Agent\nSupply & Geo Signals"]
+        A3["🟠 Feature Generation Agent\nDerived Signal Computation"]
+        A4["🔴 Strategy Evaluation Agent\nOpportunity Ranking"]
+    end
+
+    subgraph Output["Output"]
+        O1["JSON Candidates\n(instrument, structure,\nedge_score, signals)"]
+    end
+
+    Sources --> A1
+    A1 -->|"Market State Object"| A2
+    A2 -->|"Scored Events"| A3
+    A3 -->|"Derived Features"| A4
+    A4 --> O1
+```
+
+Data flows strictly left-to-right. Each agent is independently deployable; a failure or slow feed in one agent does not halt the pipeline.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Python | 3.10 or later |
-| Operating System | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| Deployment target | Local machine, single VM, or container |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS to data source APIs |
 
-### Required Knowledge
+### Required knowledge
 
-This guide assumes you are comfortable with:
+- Python virtual environments (`venv` or `conda`)
+- Basic CLI usage
+- Familiarity with JSON output and options terminology is helpful but not required to run the pipeline
 
-- Running commands in a terminal / shell
-- Python virtual environments and `pip`
-- Editing `.env` files or shell environment variables
-- Reading JSON output
+### Install system dependencies
 
-### API Accounts
+```bash
+# Debian/Ubuntu
+sudo apt update && sudo apt install -y python3 python3-pip python3-venv git
 
-Register for the following free or low-cost services before proceeding. All are free-tier unless noted.
+# macOS (with Homebrew)
+brew install python git
+```
 
-| Service | Used For | Sign-up URL | Cost |
-|---|---|---|---|
-| Alpha Vantage | WTI / Brent spot and futures prices | https://www.alphavantage.co | Free |
-| Yahoo Finance (`yfinance`) | ETF / equity prices, options chains | No registration required | Free |
-| Polygon.io | Options chains (alternative/supplement) | https://polygon.io | Free / Limited |
-| EIA API | Inventory, refinery utilization | https://www.eia.gov/opendata | Free |
-| GDELT | News and geopolitical events | No key required | Free |
-| NewsAPI | News headlines | https://newsapi.org | Free |
-| SEC EDGAR | Insider trading filings | No key required | Free |
-| Quiver Quant | Insider activity enrichment | https://www.quiverquant.com | Free / Limited |
-| MarineTraffic | Tanker / shipping flows | https://www.marinetraffic.com | Free tier |
-| Reddit API | Narrative / retail sentiment | https://www.reddit.com/prefs/apps | Free |
-| Stocktwits | Narrative / retail sentiment | https://api.stocktwits.com | Free |
-
-> **Phase note:** You do not need all API keys immediately. See [MVP Phasing](#mvp-phasing-and-optional-keys) below for which keys are required at each phase.
-
----
-
-## Setup & Configuration
-
-### 1. Clone the Repository
+### Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### Create and activate a virtual environment
 
 ```bash
 python3 -m venv .venv
@@ -133,204 +125,183 @@ source .venv/bin/activate        # Linux / macOS
 # .venv\Scripts\activate         # Windows
 ```
 
-### 3. Install Dependencies
+### Install Python dependencies
 
 ```bash
 pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+---
 
-Copy the example environment file and populate your API keys:
+## Setup & Configuration
+
+### 1. Copy the environment template
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set values for each variable listed in the table below.
+### 2. Populate `.env`
 
-#### Environment Variable Reference
-
-| Variable | Required | Phase | Description | Example Value |
-|---|---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | 1 | API key for crude price feeds | `ABC123XYZ` |
-| `POLYGON_API_KEY` | Optional | 1 | Polygon.io key for options chain data | `pk_abc123` |
-| `EIA_API_KEY` | Yes | 2 | EIA Open Data API key | `eia_abc123` |
-| `NEWS_API_KEY` | Yes | 2 | NewsAPI key for headline ingestion | `newsabc123` |
-| `QUIVER_API_KEY` | Optional | 3 | Quiver Quant insider activity enrichment | `qv_abc123` |
-| `MARINE_TRAFFIC_API_KEY` | Optional | 3 | MarineTraffic free-tier API key | `mt_abc123` |
-| `REDDIT_CLIENT_ID` | Optional | 3 | Reddit OAuth client ID | `reddit_id_abc` |
-| `REDDIT_CLIENT_SECRET` | Optional | 3 | Reddit OAuth client secret | `reddit_sec_abc` |
-| `REDDIT_USER_AGENT` | Optional | 3 | Reddit API user-agent string | `energy-agent/1.0` |
-| `STOCKTWITS_API_KEY` | Optional | 3 | Stocktwits API key | `st_abc123` |
-| `DATA_DIR` | Yes | 1 | Path to local directory for historical data storage | `./data` |
-| `OUTPUT_DIR` | Yes | 1 | Path to directory for ranked candidate JSON output | `./output` |
-| `LOG_LEVEL` | No | 1 | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
-| `PRICE_REFRESH_INTERVAL_SECONDS` | No | 1 | Cadence for market price polling (minutes-level recommended) | `300` |
-| `SLOW_FEED_REFRESH_INTERVAL_SECONDS` | No | 2 | Cadence for EIA / EDGAR polling (daily recommended) | `86400` |
-| `HISTORICAL_RETENTION_DAYS` | No | 1 | Days of historical data to retain (180–365 recommended) | `365` |
-
-> **Tip:** Variables marked **Optional** are safe to leave blank. The pipeline will skip the corresponding data source gracefully and log a warning rather than failing.
-
-#### Example `.env` File
+Open `.env` in any editor and supply values for the variables below.
 
 ```dotenv
-# --- Core (Phase 1) ---
-ALPHA_VANTAGE_API_KEY=ABC123XYZ
-POLYGON_API_KEY=pk_abc123
-DATA_DIR=./data
+# ── Data Ingestion ─────────────────────────────────────────────
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+METALPRICE_API_KEY=your_metalprice_key
+POLYGON_API_KEY=your_polygon_key
+
+# ── Event Detection ────────────────────────────────────────────
+NEWS_API_KEY=your_newsapi_key
+GDELT_ENABLED=true                   # Set false to skip GDELT
+
+# ── Alternative Signals ────────────────────────────────────────
+QUIVER_QUANT_API_KEY=your_quiver_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+
+# ── EIA Supply Data ────────────────────────────────────────────
+EIA_API_KEY=your_eia_key
+
+# ── Pipeline Behaviour ─────────────────────────────────────────
+DATA_REFRESH_INTERVAL_SECONDS=60     # Minutes-level cadence for market data
+SLOW_FEED_REFRESH_INTERVAL_SECONDS=86400  # Daily cadence for EIA, EDGAR
+HISTORICAL_RETENTION_DAYS=180        # 180–365 days recommended
+
+# ── Output ─────────────────────────────────────────────────────
 OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-PRICE_REFRESH_INTERVAL_SECONDS=300
-HISTORICAL_RETENTION_DAYS=365
-
-# --- Supply & Events (Phase 2) ---
-EIA_API_KEY=eia_abc123
-NEWS_API_KEY=newsabc123
-SLOW_FEED_REFRESH_INTERVAL_SECONDS=86400
-
-# --- Alternative Signals (Phase 3) ---
-QUIVER_API_KEY=
-MARINE_TRAFFIC_API_KEY=
-REDDIT_CLIENT_ID=
-REDDIT_CLIENT_SECRET=
-REDDIT_USER_AGENT=energy-agent/1.0
-STOCKTWITS_API_KEY=
+OUTPUT_FORMAT=json                   # json | dashboard
+LOG_LEVEL=INFO                       # DEBUG | INFO | WARNING | ERROR
 ```
 
-### 5. Initialise the Data Directory
+### Environment variable reference
 
-Create the storage directories used by the pipeline:
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | WTI and Brent spot/futures via Alpha Vantage |
+| `METALPRICE_API_KEY` | No | — | Fallback crude price feed |
+| `POLYGON_API_KEY` | No | — | Options chain data (strike, expiry, IV, volume) |
+| `NEWS_API_KEY` | Yes | — | Energy-related news and geopolitical events |
+| `GDELT_ENABLED` | No | `true` | Enable GDELT continuous event feed |
+| `QUIVER_QUANT_API_KEY` | No | — | Insider conviction scores via Quiver Quant |
+| `EIA_API_KEY` | Yes | — | Weekly inventory and refinery utilization data |
+| `MARINE_TRAFFIC_API_KEY` | No | — | Tanker flow and chokepoint monitoring |
+| `DATA_REFRESH_INTERVAL_SECONDS` | No | `60` | Polling interval for market price feeds |
+| `SLOW_FEED_REFRESH_INTERVAL_SECONDS` | No | `86400` | Polling interval for EIA and EDGAR |
+| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw and derived data to retain |
+| `OUTPUT_DIR` | No | `./output` | Directory for JSON output files |
+| `OUTPUT_FORMAT` | No | `json` | Output format (`json` or `dashboard`) |
+| `LOG_LEVEL` | No | `INFO` | Python logging level |
+
+> **Tip:** API keys marked **No** correspond to Phase 2 and Phase 3 data sources. You can run a reduced pipeline (Phase 1 only) without them; see [Running the Pipeline](#running-the-pipeline) for flags.
+
+### 3. Initialise the local database
+
+The pipeline uses a lightweight local store (SQLite by default) for historical raw and derived data.
 
 ```bash
-mkdir -p ./data ./output
+python -m agent.db init
 ```
 
-### MVP Phasing and Optional Keys
+Expected output:
 
-Development is structured in four phases. You can run the pipeline at any phase; later-phase keys extend the signal set without blocking earlier functionality.
-
-| Phase | Name | Minimum Required Keys |
-|---|---|---|
-| 1 | Core Market Signals & Options | `ALPHA_VANTAGE_API_KEY`, `DATA_DIR`, `OUTPUT_DIR` |
-| 2 | Supply & Event Augmentation | Phase 1 + `EIA_API_KEY`, `NEWS_API_KEY` |
-| 3 | Alternative / Contextual Signals | Phase 2 + one or more of: `QUIVER_API_KEY`, `MARINE_TRAFFIC_API_KEY`, `REDDIT_*`, `STOCKTWITS_API_KEY` |
-| 4 | High-Fidelity Enhancements | Deferred — see [Future Considerations](#future-considerations) |
+```
+[INFO] Database initialised at ./data/market_state.db
+[INFO] Schema version: 1.0
+```
 
 ---
 
 ## Running the Pipeline
 
-### Full Pipeline (Single Run)
-
-Execute all four agents in sequence:
+### Full pipeline (all four agents)
 
 ```bash
-python -m energy_agent.pipeline run
+python -m agent.run --all
 ```
 
-This command:
+This executes the agents in sequence:
 
-1. Invokes the **Data Ingestion Agent** to fetch and normalize all configured feeds.
-2. Passes the market state object to the **Event Detection Agent** for supply/geo signal scoring.
-3. Passes the updated state to the **Feature Generation Agent** to compute derived signals.
-4. Passes derived features to the **Strategy Evaluation Agent** to produce ranked candidates.
-5. Writes structured JSON to `$OUTPUT_DIR/candidates_<timestamp>.json`.
+1. **Data Ingestion Agent** — fetches and normalises market data
+2. **Event Detection Agent** — scores supply and geopolitical events
+3. **Feature Generation Agent** — computes derived signals
+4. **Strategy Evaluation Agent** — ranks candidates and writes output
 
-### Continuous / Scheduled Mode
+### Run a single phase
 
-To run the pipeline on a recurring cadence (respecting `PRICE_REFRESH_INTERVAL_SECONDS`):
+Use `--phase` to limit execution to a specific MVP phase:
 
 ```bash
-python -m energy_agent.pipeline run --continuous
+python -m agent.run --phase 1   # Core market signals only (no external event/alt data required)
+python -m agent.run --phase 2   # Phase 1 + supply & event augmentation
+python -m agent.run --phase 3   # Phases 1–2 + alternative/contextual signals
 ```
 
-Press `Ctrl+C` to stop.
-
-### Running Individual Agents
-
-Each agent is independently deployable. You can run any single stage against an existing state snapshot:
+### Run individual agents
 
 ```bash
-# Data Ingestion only
-python -m energy_agent.pipeline run --agent ingestion
-
-# Event Detection only (requires an existing market state snapshot)
-python -m energy_agent.pipeline run --agent events
-
-# Feature Generation only
-python -m energy_agent.pipeline run --agent features
-
-# Strategy Evaluation only
-python -m energy_agent.pipeline run --agent strategy
+python -m agent.run --agent ingestion
+python -m agent.run --agent event_detection
+python -m agent.run --agent feature_generation
+python -m agent.run --agent strategy_evaluation
 ```
 
-### Specifying an Output File
+### Continuous (daemon) mode
+
+Reruns the full pipeline on the configured `DATA_REFRESH_INTERVAL_SECONDS` cadence:
 
 ```bash
-python -m energy_agent.pipeline run --output ./output/my_run.json
+python -m agent.run --all --daemon
 ```
 
-### Controlling Log Verbosity
+Stop with `Ctrl+C`. The pipeline tolerates delayed or missing data without exiting — a degraded run produces output based on whatever feeds are available and logs a warning for each missing source.
 
-Override `LOG_LEVEL` at runtime:
+### Common flags
+
+| Flag | Description |
+|---|---|
+| `--all` | Run all four agents end-to-end |
+| `--phase <1–4>` | Restrict to a specific MVP phase |
+| `--agent <name>` | Run a single named agent |
+| `--daemon` | Continuous polling mode |
+| `--output-dir <path>` | Override `OUTPUT_DIR` from `.env` |
+| `--log-level <level>` | Override `LOG_LEVEL` from `.env` |
+| `--dry-run` | Validate config and connectivity without writing output |
+
+### Validate configuration before running
 
 ```bash
-LOG_LEVEL=DEBUG python -m energy_agent.pipeline run
+python -m agent.run --dry-run
 ```
 
-### Pipeline Execution Flow
+Expected output:
 
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DI as Data Ingestion Agent
-    participant ED as Event Detection Agent
-    participant FG as Feature Generation Agent
-    participant SE as Strategy Evaluation Agent
-    participant FS as Filesystem (data/ + output/)
-
-    CLI->>DI: Start pipeline run
-    DI->>FS: Write normalized market state snapshot
-    DI-->>ED: Pass market state object
-    ED->>ED: Score supply disruptions & geo events
-    ED-->>FG: Pass enriched market state
-    FG->>FG: Compute volatility gaps, curve steepness,\nshock probability, narrative velocity, etc.
-    FG->>FS: Write derived features to features store
-    FG-->>SE: Pass derived features
-    SE->>SE: Evaluate eligible option structures;\ncompute edge scores
-    SE->>FS: Write ranked candidates JSON
-    SE-->>CLI: Return exit code 0 (success)
+```
+[INFO] Config validated.
+[INFO] Connectivity check: Alpha Vantage ... OK
+[INFO] Connectivity check: EIA API       ... OK
+[INFO] Connectivity check: NewsAPI       ... OK
+[WARN] Connectivity check: Polygon.io    ... SKIPPED (key not set)
+[INFO] Dry run complete. No output written.
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output location
 
-On each successful run, a timestamped JSON file is written to `$OUTPUT_DIR`:
+Each pipeline run writes one or more JSON files to `OUTPUT_DIR` (default `./output`):
 
 ```
 output/
-└── candidates_2026-03-15T14_32_00Z.json
+├── candidates_2026-03-15T14:32:00Z.json
+└── candidates_latest.json          ← always points to the most recent run
 ```
 
-### Output Schema
+### Output schema
 
-Each file contains an array of strategy candidate objects. Fields are defined as follows:
-
-| Field | Type | Description |
-|---|---|---|
-| `instrument` | `string` | Target instrument identifier, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Target expiration in **calendar days** from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher values indicate stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their current values; used for explainability |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
-
-### Example Output
+Each file contains a JSON array of candidate objects:
 
 ```json
 [
@@ -345,47 +316,133 @@ Each file contains an array of strategy candidate objects. Fields are defined as
       "narrative_velocity": "rising"
     },
     "generated_at": "2026-03-15T14:32:00Z"
-  },
-  {
-    "instrument": "XOM",
-    "structure": "call_spread",
-    "expiration": 45,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive",
-      "supply_shock_probability": "elevated",
-      "insider_conviction": "moderate"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Reading the Edge Score
+### Field reference
 
-| Edge Score Range | Interpretation |
-|---|---|
-| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
-| `0.40 – 0.69` | Moderate confluence — worth monitoring; validate contributing signals |
-| `0.20 – 0.39` | Weak signal — limited alignment; treat with caution |
-| `0.00 – 0.19` | Noise threshold — generally not actionable |
-
-> **Important:** Edge scores are advisory. They reflect computed signal confluence, not a guarantee of profitability. No automated execution is performed.
-
-### Signal Reference
-
-| Signal Key | Description | Possible Values |
+| Field | Type | Description |
 |---|---|---|
-| `volatility_gap` | Realized vs. implied volatility differential | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | Contango / backwardation level in the futures curve | `steep`, `flat`, `inverted` |
-| `sector_dispersion` | Cross-sector correlation spread within energy | `high`, `moderate`, `low` |
-| `insider_conviction` | Aggregated insider trading activity score | `high`, `moderate`, `low` |
-| `narrative_velocity` | Rate of acceleration of energy-related headlines | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | Probability score of a near-term supply disruption | `elevated`, `moderate`, `low` |
-| `tanker_disruption_index` | Shipping / logistics disruption indicator | `high`, `moderate`, `low` |
+| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
+| `structure` | enum | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | float [0.0–1.0] | Composite opportunity score — higher indicates stronger signal confluence |
+| `signals` | object | Map of contributing signals and their qualitative values |
+| `generated_at` | ISO 8601 UTC | Timestamp of candidate generation |
 
-### Consuming Output in thinkorswim or Other Tools
+### Understanding `edge_score`
 
-The JSON output is compatible with any dashboard or tool that accepts JSON. To load in thinkorswim or a custom visualisation:
+```
+0.0 ──────────────┬───────────────┬──────────────── 1.0
+                  │               │
+               Weak            Strong
+               signal          confluence
+               (low priority)  (high priority)
+```
 
-1. Point your tool at the latest file in `$OUTPUT_DIR
+The edge score is a composite of all contributing signals weighted by the active pipeline phase. It is **not** a probability of profit; it measures signal strength and confluence. Always review the `signals` object alongside the score to understand what is driving a candidate.
+
+### Contributing signals glossary
+
+| Signal key | What it measures |
+|---|---|
+| `volatility_gap` | Spread between realised and implied volatility |
+| `futures_curve_steepness` | Contango or backwardation in the crude futures curve |
+| `sector_dispersion` | Price divergence between energy equities and ETFs |
+| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
+| `narrative_velocity` | Acceleration of energy-related headlines (Reddit/Stocktwits) |
+| `supply_shock_probability` | Probability of supply disruption from EIA + event data |
+| `tanker_disruption_index` | Chokepoint and tanker flow anomaly score |
+
+### Consuming output in thinkorswim
+
+The JSON output is compatible with any thinkorswim scripting or watchlist import workflow that accepts JSON. Point your import script at `candidates_latest.json` and map `instrument → symbol`, `structure → strategy type`, and `edge_score → sort column`.
+
+---
+
+## Troubleshooting
+
+### Pipeline fails to start
+
+```
+[ERROR] Missing required environment variable: EIA_API_KEY
+```
+
+**Fix:** Ensure all required variables are set in `.env` and the file is present in the project root. Re-run `--dry-run` to identify any remaining gaps.
+
+---
+
+### An agent produces no output
+
+```
+[WARN] Feature Generation Agent: no derived features computed — upstream market state is empty.
+```
+
+**Cause:** The Data Ingestion Agent ran but returned no data (e.g. market closed, API rate-limited).  
+**Fix:**
+1. Check `./logs/` for the ingestion agent's error detail.
+2. Verify your API keys are valid and have not exceeded free-tier rate limits.
+3. Re-run ingestion in isolation: `python -m agent.run --agent ingestion --log-level DEBUG`
+
+---
+
+### Missing optional API key warning
+
+```
+[WARN] Connectivity check: MarineTraffic ... SKIPPED (key not set)
+```
+
+**This is not an error.** Optional keys for Phase 2/3 sources (Quiver Quant, MarineTraffic, Polygon) can be omitted. The pipeline runs at reduced signal fidelity and logs which signals were excluded from edge scoring.
+
+---
+
+### Database initialisation error
+
+```
+[ERROR] Database initialised failed: ./data/ does not exist.
+```
+
+**Fix:**
+
+```bash
+mkdir -p data
+python -m agent.db init
+```
+
+---
+
+### Stale `candidates_latest.json`
+
+If the timestamp in `generated_at` is unexpectedly old, the daemon may have silently stopped.
+
+**Fix:**
+
+```bash
+# Check if the daemon process is running
+ps aux | grep "agent.run"
+
+# Restart in daemon mode
+python -m agent.run --all --daemon
+```
+
+---
+
+### High memory or disk usage
+
+If historical data grows beyond expected bounds, reduce retention or purge old records:
+
+```bash
+# Purge records older than HISTORICAL_RETENTION_DAYS
+python -m agent.db purge --older-than 180
+```
+
+---
+
+### Common error quick-reference
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| `KeyError: 'edge_score'` in output | Strategy Evaluation Agent skipped | Check feature generation logs; ensure at least one signal computed |
+| All `edge_score` values are `0.0` | No signals passed threshold | Lower signal threshold in config or verify feed data quality |
+| `ConnectionTimeout` on news feed | GDELT/NewsAPI

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide walks a developer through setting up, configuring, and running the full Energy Options Opportunity Agent pipeline end-to-end.
+> **Version 1.0 · March 2026**
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
 
 ---
 
@@ -18,51 +18,58 @@
 
 ## Overview
 
-The Energy Options Opportunity Agent is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments as ranked, explainable strategy candidates.
 
-The pipeline is composed of **four loosely coupled agents** that execute in a fixed, unidirectional sequence, communicating through a shared market state object and a derived features store.
+### Pipeline Architecture
+
+The system comprises four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**. Data flows in one direction only — from raw ingestion through to ranked output.
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Fetch crude prices\nETF / equity data\noptions chains]
-        A2[Normalize → unified\nmarket state object]
-        A1 --> A2
+    subgraph Agents
+        A["🗄️ Data Ingestion Agent\n— Fetch & Normalize"]
+        B["📡 Event Detection Agent\n— Supply & Geo Signals"]
+        C["⚙️ Feature Generation Agent\n— Derived Signal Computation"]
+        D["🏆 Strategy Evaluation Agent\n— Opportunity Ranking"]
     end
 
-    subgraph Event["② Event Detection Agent"]
-        B1[Monitor news &\ngeo feeds]
-        B2[Score supply disruptions\nrefinery outages\ntanker chokepoints]
-        B1 --> B2
-    end
+    RAW["Raw Feeds\n(prices, options chains,\nnews, EIA, EDGAR,\nshipping, sentiment)"]
+    STATE["Market State Object"]
+    FEATURES["Derived Features Store"]
+    OUTPUT["Ranked Candidates\n(JSON)"]
 
-    subgraph Feature["③ Feature Generation Agent"]
-        C1[Compute derived signals:\nvol gaps · curve steepness\ndispersion · insider scores\nnarrative velocity · shock prob]
-    end
-
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate option structures\nagainst signals]
-        D2[Rank by edge score\nwith explainability refs]
-        D1 --> D2
-    end
-
-    RAW[(Raw feeds)] --> Ingestion
-    Ingestion -->|market state| Event
-    Event -->|scored events| Feature
-    Feature -->|derived features| Strategy
-    Strategy -->|JSON candidates| OUT[(Output / Dashboard)]
+    RAW --> A
+    A --> STATE
+    STATE --> B
+    B --> STATE
+    STATE --> C
+    C --> FEATURES
+    FEATURES --> D
+    D --> OUTPUT
 ```
 
-### In-Scope Instruments & Structures
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion** | Fetch & Normalize | Unified market state object, historical price store |
+| **Event Detection** | Supply & Geo Signals | Scored supply disruption events (confidence + intensity) |
+| **Feature Generation** | Derived Signal Computation | Volatility gaps, curve steepness, supply shock probability, etc. |
+| **Strategy Evaluation** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
 
-| Category | Items |
+### In-Scope Instruments
+
+| Category | Instruments |
 |---|---|
-| **Crude futures** | Brent Crude, WTI (`CL=F`) |
-| **ETFs** | USO, XLE |
-| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-> **Advisory only.** The system surfaces ranked opportunities but does **not** execute trades automatically.
+### In-Scope Option Structures (MVP)
+
+- Long straddles
+- Call / put spreads
+- Calendar spreads
+
+> **Advisory only.** Automated trade execution is explicitly out of scope. All output is informational.
 
 ---
 
@@ -72,47 +79,40 @@ flowchart LR
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
+| Python | 3.10 or later |
+| Operating System | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
 | Disk | 10 GB (for 6–12 months of historical data) |
 | Deployment target | Local machine, single VM, or container |
 
-### External Accounts & API Keys
+### Required Knowledge
 
-You must obtain credentials for the following services before running the pipeline. All sources listed below are free or offer a usable free tier.
+This guide assumes you are comfortable with:
 
-| Service | Purpose | Sign-up URL |
-|---|---|---|
-| Alpha Vantage or MetalpriceAPI | WTI / Brent spot & futures prices | alphavantage.co / metalpriceapi.com |
-| Yahoo Finance / yfinance | ETF & equity prices, options chains | No key required (yfinance); polygon.io for enhanced options |
-| Polygon.io *(optional)* | Enhanced options chain data | polygon.io |
-| EIA Open Data API | Inventory & refinery utilization | eia.gov/opendata |
-| GDELT Project | Geopolitical & news event feed | gdeltproject.org (no key) |
-| NewsAPI | Headline news feed | newsapi.org |
-| SEC EDGAR | Insider activity (Form 4) | No key required |
-| Quiver Quant *(optional)* | Structured insider signals | quiverquant.com |
-| MarineTraffic / VesselFinder | Tanker shipping flows | marinetraffic.com (free tier) |
-| Reddit API | Retail sentiment / narrative velocity | reddit.com/dev/api |
-| Stocktwits *(optional)* | Retail sentiment | stocktwits.com/developers |
+- Running commands in a terminal / shell
+- Python virtual environments and `pip`
+- Editing `.env` files or shell environment variables
+- Reading JSON output
 
-### Python Dependencies
+### API Accounts
 
-Install all dependencies from the project root:
+Register for the following free or low-cost services before proceeding. All are free-tier unless noted.
 
-```bash
-pip install -r requirements.txt
-```
+| Service | Used For | Sign-up URL | Cost |
+|---|---|---|---|
+| Alpha Vantage | WTI / Brent spot and futures prices | https://www.alphavantage.co | Free |
+| Yahoo Finance (`yfinance`) | ETF / equity prices, options chains | No registration required | Free |
+| Polygon.io | Options chains (alternative/supplement) | https://polygon.io | Free / Limited |
+| EIA API | Inventory, refinery utilization | https://www.eia.gov/opendata | Free |
+| GDELT | News and geopolitical events | No key required | Free |
+| NewsAPI | News headlines | https://newsapi.org | Free |
+| SEC EDGAR | Insider trading filings | No key required | Free |
+| Quiver Quant | Insider activity enrichment | https://www.quiverquant.com | Free / Limited |
+| MarineTraffic | Tanker / shipping flows | https://www.marinetraffic.com | Free tier |
+| Reddit API | Narrative / retail sentiment | https://www.reddit.com/prefs/apps | Free |
+| Stocktwits | Narrative / retail sentiment | https://api.stocktwits.com | Free |
 
-Key packages include:
-
-```
-yfinance
-requests
-pandas
-numpy
-python-dotenv
-schedule
-```
+> **Phase note:** You do not need all API keys immediately. See [MVP Phasing](#mvp-phasing-and-optional-keys) below for which keys are required at each phase.
 
 ---
 
@@ -125,202 +125,210 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a Virtual Environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate        # macOS / Linux
-.venv\Scripts\activate           # Windows
+python3 -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows
 ```
 
 ### 3. Install Dependencies
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
 ### 4. Configure Environment Variables
 
-Copy the example environment file and populate it with your credentials:
+Copy the example environment file and populate your API keys:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in each value. The table below documents every supported variable.
+Open `.env` in your editor and set values for each variable listed in the table below.
 
 #### Environment Variable Reference
 
-| Variable | Required | Default | Description |
-|---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes* | — | API key for Alpha Vantage crude price feed. *Required if not using MetalpriceAPI. |
-| `METALPRICE_API_KEY` | Yes* | — | API key for MetalpriceAPI. *Required if not using Alpha Vantage. |
-| `POLYGON_API_KEY` | No | — | Polygon.io key for enhanced options chain data. Falls back to yfinance if absent. |
-| `EIA_API_KEY` | Yes | — | EIA Open Data API key for inventory and refinery utilization data. |
-| `NEWS_API_KEY` | Yes | — | NewsAPI key for headline ingestion. |
-| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth client ID for sentiment feed. |
-| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth client secret. |
-| `REDDIT_USER_AGENT` | No | `energy-options-agent/1.0` | Reddit API user-agent string. |
-| `MARINETRAFFIC_API_KEY` | No | — | MarineTraffic free-tier key for tanker flow data. |
-| `QUIVER_API_KEY` | No | — | Quiver Quant key for structured insider signals. |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written. |
-| `HISTORY_DAYS` | No | `180` | Days of historical data to retain (minimum 180; recommended 365). |
-| `MARKET_DATA_INTERVAL_MIN` | No | `5` | Polling interval in minutes for market data (crude, ETF, equity). |
-| `SLOW_FEED_INTERVAL_HOURS` | No | `24` | Polling interval in hours for slow feeds (EIA, EDGAR). |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
-| `EDGE_SCORE_THRESHOLD` | No | `0.30` | Minimum edge score `[0.0–1.0]` for a candidate to appear in output. |
+| Variable | Required | Phase | Description | Example Value |
+|---|---|---|---|---|
+| `ALPHA_VANTAGE_API_KEY` | Yes | 1 | API key for crude price feeds | `ABC123XYZ` |
+| `POLYGON_API_KEY` | Optional | 1 | Polygon.io key for options chain data | `pk_abc123` |
+| `EIA_API_KEY` | Yes | 2 | EIA Open Data API key | `eia_abc123` |
+| `NEWS_API_KEY` | Yes | 2 | NewsAPI key for headline ingestion | `newsabc123` |
+| `QUIVER_API_KEY` | Optional | 3 | Quiver Quant insider activity enrichment | `qv_abc123` |
+| `MARINE_TRAFFIC_API_KEY` | Optional | 3 | MarineTraffic free-tier API key | `mt_abc123` |
+| `REDDIT_CLIENT_ID` | Optional | 3 | Reddit OAuth client ID | `reddit_id_abc` |
+| `REDDIT_CLIENT_SECRET` | Optional | 3 | Reddit OAuth client secret | `reddit_sec_abc` |
+| `REDDIT_USER_AGENT` | Optional | 3 | Reddit API user-agent string | `energy-agent/1.0` |
+| `STOCKTWITS_API_KEY` | Optional | 3 | Stocktwits API key | `st_abc123` |
+| `DATA_DIR` | Yes | 1 | Path to local directory for historical data storage | `./data` |
+| `OUTPUT_DIR` | Yes | 1 | Path to directory for ranked candidate JSON output | `./output` |
+| `LOG_LEVEL` | No | 1 | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) | `INFO` |
+| `PRICE_REFRESH_INTERVAL_SECONDS` | No | 1 | Cadence for market price polling (minutes-level recommended) | `300` |
+| `SLOW_FEED_REFRESH_INTERVAL_SECONDS` | No | 2 | Cadence for EIA / EDGAR polling (daily recommended) | `86400` |
+| `HISTORICAL_RETENTION_DAYS` | No | 1 | Days of historical data to retain (180–365 recommended) | `365` |
 
-> **Tip:** Variables marked *No* are optional but enable additional signal layers (Phase 2–3 features). The pipeline degrades gracefully when optional credentials are absent — it logs a warning and skips that data source rather than failing.
+> **Tip:** Variables marked **Optional** are safe to leave blank. The pipeline will skip the corresponding data source gracefully and log a warning rather than failing.
 
-#### Example `.env`
+#### Example `.env` File
 
 ```dotenv
-# Required
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY
-EIA_API_KEY=YOUR_EIA_KEY
-NEWS_API_KEY=YOUR_NEWSAPI_KEY
-
-# Optional — enhanced options data
-POLYGON_API_KEY=YOUR_POLYGON_KEY
-
-# Optional — alternative signals (Phase 2–3)
-REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
-REDDIT_CLIENT_SECRET=YOUR_REDDIT_SECRET
-REDDIT_USER_AGENT=energy-options-agent/1.0
-MARINETRAFFIC_API_KEY=YOUR_MT_KEY
-QUIVER_API_KEY=YOUR_QUIVER_KEY
-
-# Pipeline behaviour
+# --- Core (Phase 1) ---
+ALPHA_VANTAGE_API_KEY=ABC123XYZ
+POLYGON_API_KEY=pk_abc123
+DATA_DIR=./data
 OUTPUT_DIR=./output
-HISTORY_DAYS=365
-MARKET_DATA_INTERVAL_MIN=5
-SLOW_FEED_INTERVAL_HOURS=24
 LOG_LEVEL=INFO
-EDGE_SCORE_THRESHOLD=0.30
+PRICE_REFRESH_INTERVAL_SECONDS=300
+HISTORICAL_RETENTION_DAYS=365
+
+# --- Supply & Events (Phase 2) ---
+EIA_API_KEY=eia_abc123
+NEWS_API_KEY=newsabc123
+SLOW_FEED_REFRESH_INTERVAL_SECONDS=86400
+
+# --- Alternative Signals (Phase 3) ---
+QUIVER_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_API_KEY=
 ```
 
-### 5. Initialise the Data Store
+### 5. Initialise the Data Directory
 
-Run the bootstrap command once to create the local database schema and pull the initial historical window:
+Create the storage directories used by the pipeline:
 
 ```bash
-python -m pipeline.bootstrap
+mkdir -p ./data ./output
 ```
 
-Expected output:
+### MVP Phasing and Optional Keys
 
-```
-[INFO] Creating data store at ./data/market_state.db
-[INFO] Seeding 365 days of historical data for: CL=F, BZ=F, USO, XLE, XOM, CVX
-[INFO] Bootstrap complete. Run `python -m pipeline.run` to start the agent.
-```
+Development is structured in four phases. You can run the pipeline at any phase; later-phase keys extend the signal set without blocking earlier functionality.
+
+| Phase | Name | Minimum Required Keys |
+|---|---|---|
+| 1 | Core Market Signals & Options | `ALPHA_VANTAGE_API_KEY`, `DATA_DIR`, `OUTPUT_DIR` |
+| 2 | Supply & Event Augmentation | Phase 1 + `EIA_API_KEY`, `NEWS_API_KEY` |
+| 3 | Alternative / Contextual Signals | Phase 2 + one or more of: `QUIVER_API_KEY`, `MARINE_TRAFFIC_API_KEY`, `REDDIT_*`, `STOCKTWITS_API_KEY` |
+| 4 | High-Fidelity Enhancements | Deferred — see [Future Considerations](#future-considerations) |
 
 ---
 
 ## Running the Pipeline
+
+### Full Pipeline (Single Run)
+
+Execute all four agents in sequence:
+
+```bash
+python -m energy_agent.pipeline run
+```
+
+This command:
+
+1. Invokes the **Data Ingestion Agent** to fetch and normalize all configured feeds.
+2. Passes the market state object to the **Event Detection Agent** for supply/geo signal scoring.
+3. Passes the updated state to the **Feature Generation Agent** to compute derived signals.
+4. Passes derived features to the **Strategy Evaluation Agent** to produce ranked candidates.
+5. Writes structured JSON to `$OUTPUT_DIR/candidates_<timestamp>.json`.
+
+### Continuous / Scheduled Mode
+
+To run the pipeline on a recurring cadence (respecting `PRICE_REFRESH_INTERVAL_SECONDS`):
+
+```bash
+python -m energy_agent.pipeline run --continuous
+```
+
+Press `Ctrl+C` to stop.
+
+### Running Individual Agents
+
+Each agent is independently deployable. You can run any single stage against an existing state snapshot:
+
+```bash
+# Data Ingestion only
+python -m energy_agent.pipeline run --agent ingestion
+
+# Event Detection only (requires an existing market state snapshot)
+python -m energy_agent.pipeline run --agent events
+
+# Feature Generation only
+python -m energy_agent.pipeline run --agent features
+
+# Strategy Evaluation only
+python -m energy_agent.pipeline run --agent strategy
+```
+
+### Specifying an Output File
+
+```bash
+python -m energy_agent.pipeline run --output ./output/my_run.json
+```
+
+### Controlling Log Verbosity
+
+Override `LOG_LEVEL` at runtime:
+
+```bash
+LOG_LEVEL=DEBUG python -m energy_agent.pipeline run
+```
 
 ### Pipeline Execution Flow
 
 ```mermaid
 sequenceDiagram
     participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant OUT as Output (JSON)
+    participant DI as Data Ingestion Agent
+    participant ED as Event Detection Agent
+    participant FG as Feature Generation Agent
+    participant SE as Strategy Evaluation Agent
+    participant FS as Filesystem (data/ + output/)
 
-    CLI->>DIA: trigger run
-    DIA->>DIA: fetch & normalize feeds
-    DIA-->>EDA: market state object
-    EDA->>EDA: detect & score events
-    EDA-->>FGA: scored event list
-    FGA->>FGA: compute derived signals
-    FGA-->>SEA: features store
-    SEA->>SEA: evaluate & rank option structures
-    SEA-->>OUT: write candidate JSON
-    OUT-->>CLI: run complete
-```
-
-### Single Run (One-Shot)
-
-Execute one complete pipeline cycle and exit:
-
-```bash
-python -m pipeline.run --once
-```
-
-Use this for testing, ad-hoc analysis, or running from an external scheduler (cron, Task Scheduler, etc.).
-
-### Continuous Mode (Scheduled)
-
-Run the pipeline on the configured polling schedule (`MARKET_DATA_INTERVAL_MIN` for market data, `SLOW_FEED_INTERVAL_HOURS` for EIA/EDGAR):
-
-```bash
-python -m pipeline.run
-```
-
-The process loops indefinitely. Use a process manager (e.g., `systemd`, `supervisord`, or Docker) to keep it running in production.
-
-### Run a Single Agent in Isolation
-
-Each agent can be invoked independently for debugging or development:
-
-```bash
-# Data Ingestion Agent only
-python -m pipeline.agents.ingestion
-
-# Event Detection Agent only
-python -m pipeline.agents.event_detection
-
-# Feature Generation Agent only
-python -m pipeline.agents.feature_generation
-
-# Strategy Evaluation Agent only
-python -m pipeline.agents.strategy_evaluation
-```
-
-> **Note:** Running agents in isolation requires that upstream data already exists in the shared data store (i.e., a prior ingestion run has completed).
-
-### Running with Docker
-
-A `Dockerfile` and `docker-compose.yml` are provided for containerised deployment:
-
-```bash
-# Build the image
-docker build -t energy-options-agent:latest .
-
-# Run with your .env file
-docker run --env-file .env -v $(pwd)/output:/app/output energy-options-agent:latest
+    CLI->>DI: Start pipeline run
+    DI->>FS: Write normalized market state snapshot
+    DI-->>ED: Pass market state object
+    ED->>ED: Score supply disruptions & geo events
+    ED-->>FG: Pass enriched market state
+    FG->>FG: Compute volatility gaps, curve steepness,\nshock probability, narrative velocity, etc.
+    FG->>FS: Write derived features to features store
+    FG-->>SE: Pass derived features
+    SE->>SE: Evaluate eligible option structures;\ncompute edge scores
+    SE->>FS: Write ranked candidates JSON
+    SE-->>CLI: Return exit code 0 (success)
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output Location
+### Output File Location
 
-By default, results are written to `./output/` as timestamped JSON files:
+On each successful run, a timestamped JSON file is written to `$OUTPUT_DIR`:
 
 ```
 output/
-└── candidates_2026-03-15T14:32:00Z.json
+└── candidates_2026-03-15T14_32_00Z.json
 ```
-
-The path is controlled by the `OUTPUT_DIR` environment variable.
 
 ### Output Schema
 
-Each file contains an array of candidate objects. Every field is described below.
+Each file contains an array of strategy candidate objects. Fields are defined as follows:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher values indicate stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their assessed levels |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument identifier, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in **calendar days** from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher values indicate stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their current values; used for explainability |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
 ### Example Output
 
@@ -339,14 +347,14 @@ Each file contains an array of candidate objects. Every field is described below
     "generated_at": "2026-03-15T14:32:00Z"
   },
   {
-    "instrument": "XLE",
+    "instrument": "XOM",
     "structure": "call_spread",
-    "expiration": 21,
-    "edge_score": 0.61,
+    "expiration": 45,
+    "edge_score": 0.31,
     "signals": {
       "volatility_gap": "positive",
       "supply_shock_probability": "elevated",
-      "insider_conviction_score": "high"
+      "insider_conviction": "moderate"
     },
     "generated_at": "2026-03-15T14:32:00Z"
   }
@@ -357,59 +365,27 @@ Each file contains an array of candidate objects. Every field is described below
 
 | Edge Score Range | Interpretation |
 |---|---|
-| `0.70 – 1.00` | Strong signal confluence — multiple independent signals aligned |
-| `0.50 – 0.69` | Moderate opportunity — meaningful signal overlap, worth monitoring |
-| `0.30 – 0.49` | Weak but detectable signal — included at default threshold |
-| `< 0.30` | Below threshold — filtered out by default (`EDGE_SCORE_THRESHOLD`) |
+| `0.70 – 1.00` | Strong signal confluence — multiple independent signals align |
+| `0.40 – 0.69` | Moderate confluence — worth monitoring; validate contributing signals |
+| `0.20 – 0.39` | Weak signal — limited alignment; treat with caution |
+| `0.00 – 0.19` | Noise threshold — generally not actionable |
 
-Candidates are sorted in descending `edge_score` order within each output file.
+> **Important:** Edge scores are advisory. They reflect computed signal confluence, not a guarantee of profitability. No automated execution is performed.
 
-### Reading the Signals Map
+### Signal Reference
 
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Common signal keys and their meanings:
-
-| Signal Key | Source Agent | Meaning |
+| Signal Key | Description | Possible Values |
 |---|---|---|
-| `volatility_gap` | Feature Generation | Realised IV minus implied IV; `positive` = IV underpriced |
-| `futures_curve_steepness` | Feature Generation | Degree of contango or backwardation in the crude curve |
-| `sector_dispersion` | Feature Generation | Spread between energy sub-sector returns |
-| `insider_conviction_score` | Feature Generation | Aggregated insider buy/sell activity via EDGAR / Quiver Quant |
-| `narrative_velocity` | Feature Generation | Acceleration of energy-related headline volume |
-| `supply_shock_probability` | Feature Generation | Estimated probability of near-term supply disruption |
-| `tanker_disruption_index` | Event Detection | Severity of detected tanker / chokepoint disruptions |
-| `refinery_outage_flag` | Event Detection | Binary or scaled signal for active refinery outage events |
-| `geopolitical_intensity` | Event Detection | Confidence-weighted score for geopolitical events affecting supply |
+| `volatility_gap` | Realized vs. implied volatility differential | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | Contango / backwardation level in the futures curve | `steep`, `flat`, `inverted` |
+| `sector_dispersion` | Cross-sector correlation spread within energy | `high`, `moderate`, `low` |
+| `insider_conviction` | Aggregated insider trading activity score | `high`, `moderate`, `low` |
+| `narrative_velocity` | Rate of acceleration of energy-related headlines | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | Probability score of a near-term supply disruption | `elevated`, `moderate`, `low` |
+| `tanker_disruption_index` | Shipping / logistics disruption indicator | `high`, `moderate`, `low` |
 
-### Downstream Consumption
+### Consuming Output in thinkorswim or Other Tools
 
-The JSON output is compatible with any JSON-capable dashboard or platform, including thinkorswim. To reload results programmatically:
+The JSON output is compatible with any dashboard or tool that accepts JSON. To load in thinkorswim or a custom visualisation:
 
-```python
-import json
-from pathlib import Path
-
-candidates = json.loads(
-    Path("output/candidates_2026-03-15T14:32:00Z.json").read_text()
-)
-
-for c in sorted(candidates, key=lambda x: x["edge_score"], reverse=True):
-    print(f"{c['instrument']:>6}  {c['structure']:<20}  edge={c['edge_score']:.2f}")
-```
-
----
-
-## Troubleshooting
-
-### Pipeline Fails to Start
-
-| Symptom | Likely Cause | Resolution |
-|---|---|---|
-| `KeyError: 'EIA_API_KEY'` | Missing required env var | Ensure `.env` is populated and loaded (`python-dotenv` reads it automatically). |
-| `ModuleNotFoundError` | Dependencies not installed | Run `pip install -r requirements.txt` inside your active virtual environment. |
-| `FileNotFoundError: market_state.db` | Bootstrap not run | Run `python -m pipeline.bootstrap` before the first pipeline run. |
-
-### Data Source Errors
-
-| Symptom | Likely Cause | Resolution |
-|---|---|---|
-| `[WARNING] Alpha
+1. Point your tool at the latest file in `$OUTPUT_DIR

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> Advisory system only. No automated trade execution is performed.
+> **Version 1.0 • March 2026**
+> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting its output. It assumes you are comfortable with Python 3 and a Unix-style command line.
 
 ---
 
@@ -18,290 +18,321 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then produces structured, ranked candidate options strategies with full signal explainability.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests live and near-live market data, scores supply and geopolitical events, derives volatility signals, and produces a ranked list of candidate options strategies — all without automated trade execution.
 
-### What the pipeline does
-
-| Stage | Agent | Core output |
-|---|---|---|
-| 1 — Ingest | Data Ingestion Agent | Unified market state object |
-| 2 — Detect | Event Detection Agent | Scored supply/geo events |
-| 3 — Derive | Feature Generation Agent | Computed signals (vol gaps, curve steepness, etc.) |
-| 4 — Rank | Strategy Evaluation Agent | Ranked opportunities with edge scores |
-
-### In-scope instruments
-
-| Category | Instruments |
-|---|---|
-| Crude futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy equities | Exxon Mobil (XOM), Chevron (CVX) |
-
-### In-scope option structures (MVP)
-
-- Long straddles
-- Call / put spreads
-- Calendar spreads
-
-> **Out of scope (MVP):** exotic/multi-legged structures, regional refined product pricing (OPIS), and automated trade execution.
-
-### Pipeline architecture
+### Pipeline at a Glance
 
 ```mermaid
 flowchart LR
-    subgraph Sources["External Data Sources"]
-        S1["Alpha Vantage / MetalpriceAPI\n(Crude prices)"]
-        S2["Yahoo Finance / yfinance\n(ETF & Equity)"]
-        S3["Yahoo Finance / Polygon.io\n(Options chains)"]
-        S4["EIA API\n(Supply/Inventory)"]
-        S5["GDELT / NewsAPI\n(News & Geo)"]
-        S6["SEC EDGAR / Quiver Quant\n(Insider activity)"]
-        S7["MarineTraffic / VesselFinder\n(Shipping)"]
-        S8["Reddit / Stocktwits\n(Sentiment)"]
+    subgraph Ingestion["① Data Ingestion Agent"]
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[Shipping & Sentiment\nMarineTraffic · Reddit · Stocktwits]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
     end
 
-    subgraph Pipeline["Agent Pipeline"]
-        A1["🔵 Data Ingestion Agent\nFetch & Normalize"]
-        A2["🟡 Event Detection Agent\nSupply & Geo Signals"]
-        A3["🟠 Feature Generation Agent\nDerived Signal Computation"]
-        A4["🔴 Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Events["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT / NewsAPI]
+        B2[Supply Disruption Scoring]
+        B3[Confidence & Intensity Scores]
     end
 
-    subgraph Output["Output"]
-        O1["JSON Candidates\n(instrument, structure,\nedge_score, signals)"]
+    subgraph Features["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs. Implied]
+        C2[Futures Curve Steepness]
+        C3[Sector Dispersion]
+        C4[Insider Conviction Score]
+        C5[Narrative Velocity]
+        C6[Supply Shock Probability]
     end
 
-    Sources --> A1
-    A1 -->|"Market State Object"| A2
-    A2 -->|"Scored Events"| A3
-    A3 -->|"Derived Features"| A4
-    A4 --> O1
+    subgraph Strategy["④ Strategy Evaluation Agent"]
+        D1[Evaluate Eligible Structures]
+        D2[Compute Edge Scores]
+        D3[Rank Candidates]
+    end
+
+    OUT[(JSON Output\nRanked Candidates)]
+
+    Ingestion -->|Market State Object| Events
+    Ingestion -->|Market State Object| Features
+    Events    -->|Scored Events| Features
+    Features  -->|Derived Signal Store| Strategy
+    Strategy  --> OUT
 ```
 
-Data flows strictly left-to-right. Each agent is independently deployable; a failure or slow feed in one agent does not halt the pipeline.
+### In-Scope Instruments & Structures
+
+| Category | Items |
+|---|---|
+| **Crude Futures** | Brent Crude, WTI (`CL=F`) |
+| **ETFs** | USO, XLE |
+| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option Structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+
+> **Advisory only.** The system produces recommendations; it does not execute trades.
 
 ---
 
 ## Prerequisites
 
-### System requirements
+### System Requirements
 
 | Requirement | Minimum |
 |---|---|
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| Python | 3.10 or later |
+| Python | 3.10+ |
 | RAM | 2 GB |
 | Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS to data source APIs |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Deployment target | Local machine, single VM, or container |
 
-### Required knowledge
-
-- Python virtual environments (`venv` or `conda`)
-- Basic CLI usage
-- Familiarity with JSON output and options terminology is helpful but not required to run the pipeline
-
-### Install system dependencies
+### Required Tools
 
 ```bash
-# Debian/Ubuntu
-sudo apt update && sudo apt install -y python3 python3-pip python3-venv git
+# Verify Python version
+python --version          # must be 3.10 or higher
 
-# macOS (with Homebrew)
-brew install python git
+# Verify pip
+pip --version
+
+# Optional but recommended: create a virtual environment
+python -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
 ```
 
-### Clone the repository
+### API Accounts
 
-```bash
-git clone https://github.com/your-org/energy-options-agent.git
-cd energy-options-agent
-```
+Obtain credentials (all free or free-tier) before configuration:
 
-### Create and activate a virtual environment
+| Service | Purpose | Sign-up URL |
+|---|---|---|
+| Alpha Vantage **or** MetalpriceAPI | WTI / Brent spot & futures prices | https://www.alphavantage.co / https://metalpriceapi.com |
+| Polygon.io | Options chains (alternative to Yahoo Finance) | https://polygon.io |
+| EIA Open Data | Weekly supply & inventory data | https://www.eia.gov/opendata |
+| NewsAPI | News & geopolitical events | https://newsapi.org |
+| GDELT | Geopolitical event stream | No key required (public) |
+| SEC EDGAR / Quiver Quant | Insider trading activity | https://efts.sec.gov / https://www.quiverquant.com |
+| MarineTraffic **or** VesselFinder | Tanker flow data | https://www.marinetraffic.com / https://www.vesselfinder.com |
 
-```bash
-python3 -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows
-```
-
-### Install Python dependencies
-
-```bash
-pip install --upgrade pip
-pip install -r requirements.txt
-```
+> Yahoo Finance (`yfinance`), Reddit, Stocktwits, and GDELT do not require API keys for basic access.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Copy the environment template
+### 1. Clone & Install Dependencies
+
+```bash
+git clone https://github.com/your-org/energy-options-agent.git
+cd energy-options-agent
+
+pip install -r requirements.txt
+```
+
+### 2. Create the Environment File
+
+Copy the provided template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-### 2. Populate `.env`
+Open `.env` in your editor and populate each variable (see the full reference table below).
 
-Open `.env` in any editor and supply values for the variables below.
+### 3. Environment Variable Reference
 
-```dotenv
-# ── Data Ingestion ─────────────────────────────────────────────
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-METALPRICE_API_KEY=your_metalprice_key
-POLYGON_API_KEY=your_polygon_key
-
-# ── Event Detection ────────────────────────────────────────────
-NEWS_API_KEY=your_newsapi_key
-GDELT_ENABLED=true                   # Set false to skip GDELT
-
-# ── Alternative Signals ────────────────────────────────────────
-QUIVER_QUANT_API_KEY=your_quiver_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-
-# ── EIA Supply Data ────────────────────────────────────────────
-EIA_API_KEY=your_eia_key
-
-# ── Pipeline Behaviour ─────────────────────────────────────────
-DATA_REFRESH_INTERVAL_SECONDS=60     # Minutes-level cadence for market data
-SLOW_FEED_REFRESH_INTERVAL_SECONDS=86400  # Daily cadence for EIA, EDGAR
-HISTORICAL_RETENTION_DAYS=180        # 180–365 days recommended
-
-# ── Output ─────────────────────────────────────────────────────
-OUTPUT_DIR=./output
-OUTPUT_FORMAT=json                   # json | dashboard
-LOG_LEVEL=INFO                       # DEBUG | INFO | WARNING | ERROR
-```
-
-### Environment variable reference
+All pipeline behaviour is controlled via environment variables. The `.env` file is loaded automatically at startup.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | WTI and Brent spot/futures via Alpha Vantage |
-| `METALPRICE_API_KEY` | No | — | Fallback crude price feed |
-| `POLYGON_API_KEY` | No | — | Options chain data (strike, expiry, IV, volume) |
-| `NEWS_API_KEY` | Yes | — | Energy-related news and geopolitical events |
-| `GDELT_ENABLED` | No | `true` | Enable GDELT continuous event feed |
-| `QUIVER_QUANT_API_KEY` | No | — | Insider conviction scores via Quiver Quant |
-| `EIA_API_KEY` | Yes | — | Weekly inventory and refinery utilization data |
-| `MARINE_TRAFFIC_API_KEY` | No | — | Tanker flow and chokepoint monitoring |
-| `DATA_REFRESH_INTERVAL_SECONDS` | No | `60` | Polling interval for market price feeds |
-| `SLOW_FEED_REFRESH_INTERVAL_SECONDS` | No | `86400` | Polling interval for EIA and EDGAR |
-| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw and derived data to retain |
-| `OUTPUT_DIR` | No | `./output` | Directory for JSON output files |
-| `OUTPUT_FORMAT` | No | `json` | Output format (`json` or `dashboard`) |
-| `LOG_LEVEL` | No | `INFO` | Python logging level |
+| `ALPHA_VANTAGE_API_KEY` | Conditional¹ | — | API key for Alpha Vantage crude price feed |
+| `METALPRICE_API_KEY` | Conditional¹ | — | API key for MetalpriceAPI crude price feed |
+| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chain data |
+| `EIA_API_KEY` | Yes | — | API key for EIA inventory & utilization data |
+| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy headlines |
+| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
+| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
+| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes-level) |
+| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory polling |
+| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for SEC EDGAR insider data polling |
+| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw & derived data to retain (180–365 recommended) |
+| `OUTPUT_PATH` | No | `./output/candidates.json` | File path for ranked candidate JSON output |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to monitor |
+| `EDGE_SCORE_MIN_THRESHOLD` | No | `0.20` | Candidates below this edge score are suppressed from output |
+| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
+| `ENABLE_SHIPPING_SIGNALS` | No | `false` | Set `true` to activate MarineTraffic/VesselFinder agent |
+| `ENABLE_INSIDER_SIGNALS` | No | `false` | Set `true` to activate SEC EDGAR / Quiver Quant agent |
+| `ENABLE_NARRATIVE_SIGNALS` | No | `true` | Set `false` to disable Reddit/Stocktwits sentiment agent |
+| `DB_PATH` | No | `./data/market_state.db` | SQLite database path for historical storage |
 
-> **Tip:** API keys marked **No** correspond to Phase 2 and Phase 3 data sources. You can run a reduced pipeline (Phase 1 only) without them; see [Running the Pipeline](#running-the-pipeline) for flags.
+> ¹ At least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY` must be provided.
 
-### 3. Initialise the local database
+### 4. Example `.env` File
 
-The pipeline uses a lightweight local store (SQLite by default) for historical raw and derived data.
+```dotenv
+# Crude price source (provide at least one)
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
+METALPRICE_API_KEY=
+
+# Options data
+POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
+
+# Supply & inventory
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+
+# News & events
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
+
+# Optional alternative signals
+QUIVER_QUANT_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+ENABLE_SHIPPING_SIGNALS=false
+ENABLE_INSIDER_SIGNALS=false
+ENABLE_NARRATIVE_SIGNALS=true
+
+# Data refresh cadences
+DATA_REFRESH_INTERVAL_MINUTES=5
+EIA_REFRESH_INTERVAL_HOURS=24
+EDGAR_REFRESH_INTERVAL_HOURS=24
+
+# Storage & output
+HISTORICAL_RETENTION_DAYS=180
+DB_PATH=./data/market_state.db
+OUTPUT_PATH=./output/candidates.json
+
+# Pipeline tuning
+EDGE_SCORE_MIN_THRESHOLD=0.20
+MAX_CANDIDATES=20
+LOG_LEVEL=INFO
+```
+
+### 5. Initialise the Database
+
+Run the schema migration once before your first pipeline execution:
 
 ```bash
-python -m agent.db init
+python -m agent init-db
 ```
 
 Expected output:
 
 ```
-[INFO] Database initialised at ./data/market_state.db
-[INFO] Schema version: 1.0
+[INFO] Initialising database at ./data/market_state.db
+[INFO] Schema applied successfully.
+[INFO] Ready.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Full pipeline (all four agents)
+### Pipeline Execution Flow
+
+```mermaid
+sequenceDiagram
+    actor User
+    participant CLI as CLI / Scheduler
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant OUT as JSON Output
+
+    User->>CLI: python -m agent run
+    CLI->>DIA: Fetch & normalise market data
+    DIA-->>CLI: Market State Object ✓
+    CLI->>EDA: Detect & score events
+    EDA-->>CLI: Scored Event List ✓
+    CLI->>FGA: Compute derived signals
+    FGA-->>CLI: Derived Feature Store ✓
+    CLI->>SEA: Evaluate & rank strategies
+    SEA-->>OUT: Write candidates.json
+    OUT-->>User: Ranked candidates ready
+```
+
+### Single Run (One-Shot)
+
+Execute the full four-agent pipeline once and write results to the configured output path:
 
 ```bash
-python -m agent.run --all
+python -m agent run
 ```
 
-This executes the agents in sequence:
+### Continuous Mode
 
-1. **Data Ingestion Agent** — fetches and normalises market data
-2. **Event Detection Agent** — scores supply and geopolitical events
-3. **Feature Generation Agent** — computes derived signals
-4. **Strategy Evaluation Agent** — ranks candidates and writes output
-
-### Run a single phase
-
-Use `--phase` to limit execution to a specific MVP phase:
+Poll on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence, re-running the full pipeline each cycle:
 
 ```bash
-python -m agent.run --phase 1   # Core market signals only (no external event/alt data required)
-python -m agent.run --phase 2   # Phase 1 + supply & event augmentation
-python -m agent.run --phase 3   # Phases 1–2 + alternative/contextual signals
+python -m agent run --continuous
 ```
 
-### Run individual agents
+Press `Ctrl+C` to stop gracefully.
+
+### Run Individual Agents
+
+Each agent is independently deployable and can be invoked in isolation for testing or incremental development:
 
 ```bash
-python -m agent.run --agent ingestion
-python -m agent.run --agent event_detection
-python -m agent.run --agent feature_generation
-python -m agent.run --agent strategy_evaluation
+# Data Ingestion only
+python -m agent run --agent ingestion
+
+# Event Detection only
+python -m agent run --agent events
+
+# Feature Generation only
+python -m agent run --agent features
+
+# Strategy Evaluation only
+python -m agent run --agent strategy
 ```
 
-### Continuous (daemon) mode
+> When running agents individually, earlier stages must have already written their outputs to the shared state store.
 
-Reruns the full pipeline on the configured `DATA_REFRESH_INTERVAL_SECONDS` cadence:
+### Override Configuration at Runtime
+
+Any environment variable can be overridden inline without editing `.env`:
 
 ```bash
-python -m agent.run --all --daemon
+LOG_LEVEL=DEBUG EDGE_SCORE_MIN_THRESHOLD=0.30 python -m agent run
 ```
 
-Stop with `Ctrl+C`. The pipeline tolerates delayed or missing data without exiting — a degraded run produces output based on whatever feeds are available and logs a warning for each missing source.
+### Scheduling with Cron
 
-### Common flags
-
-| Flag | Description |
-|---|---|
-| `--all` | Run all four agents end-to-end |
-| `--phase <1–4>` | Restrict to a specific MVP phase |
-| `--agent <name>` | Run a single named agent |
-| `--daemon` | Continuous polling mode |
-| `--output-dir <path>` | Override `OUTPUT_DIR` from `.env` |
-| `--log-level <level>` | Override `LOG_LEVEL` from `.env` |
-| `--dry-run` | Validate config and connectivity without writing output |
-
-### Validate configuration before running
+To run once per hour on a Unix system:
 
 ```bash
-python -m agent.run --dry-run
-```
+# Edit crontab
+crontab -e
 
-Expected output:
-
-```
-[INFO] Config validated.
-[INFO] Connectivity check: Alpha Vantage ... OK
-[INFO] Connectivity check: EIA API       ... OK
-[INFO] Connectivity check: NewsAPI       ... OK
-[WARN] Connectivity check: Polygon.io    ... SKIPPED (key not set)
-[INFO] Dry run complete. No output written.
+# Add the following line (adjust paths as needed)
+0 * * * * /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output location
+### Output File
 
-Each pipeline run writes one or more JSON files to `OUTPUT_DIR` (default `./output`):
+Results are written to the path specified by `OUTPUT_PATH` (default: `./output/candidates.json`) as a JSON array, sorted descending by `edge_score`.
 
-```
-output/
-├── candidates_2026-03-15T14:32:00Z.json
-└── candidates_latest.json          ← always points to the most recent run
-```
+### Output Schema
 
-### Output schema
+Each element in the array is a **strategy candidate** object:
 
-Each file contains a JSON array of candidate objects:
+| Field | Type | Description |
+|---|---|---|
+| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative states |
+| `generated_at` | ISO 8601 `datetime` | UTC timestamp of candidate generation |
+
+### Example Output
 
 ```json
 [
@@ -316,133 +347,54 @@ Each file contains a JSON array of candidate objects:
       "narrative_velocity": "rising"
     },
     "generated_at": "2026-03-15T14:32:00Z"
+  },
+  {
+    "instrument": "XLE",
+    "structure": "call_spread",
+    "expiration": 21,
+    "edge_score": 0.31,
+    "signals": {
+      "volatility_gap": "positive",
+      "supply_shock_probability": "elevated",
+      "sector_dispersion": "widening"
+    },
+    "generated_at": "2026-03-15T14:32:00Z"
   }
 ]
 ```
 
-### Field reference
+### Reading the Edge Score
 
-| Field | Type | Description |
-|---|---|---|
-| `instrument` | string | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
-| `structure` | enum | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
-| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | float [0.0–1.0] | Composite opportunity score — higher indicates stronger signal confluence |
-| `signals` | object | Map of contributing signals and their qualitative values |
-| `generated_at` | ISO 8601 UTC | Timestamp of candidate generation |
+The `edge_score` is a composite float in the range 0.0–1.0. It reflects how many signals are aligned in support of a given strategy, weighted by their intensity.
 
-### Understanding `edge_score`
-
-```
-0.0 ──────────────┬───────────────┬──────────────── 1.0
-                  │               │
-               Weak            Strong
-               signal          confluence
-               (low priority)  (high priority)
-```
-
-The edge score is a composite of all contributing signals weighted by the active pipeline phase. It is **not** a probability of profit; it measures signal strength and confluence. Always review the `signals` object alongside the score to understand what is driving a candidate.
-
-### Contributing signals glossary
-
-| Signal key | What it measures |
+| Edge Score Range | Interpretation |
 |---|---|
-| `volatility_gap` | Spread between realised and implied volatility |
-| `futures_curve_steepness` | Contango or backwardation in the crude futures curve |
-| `sector_dispersion` | Price divergence between energy equities and ETFs |
-| `insider_conviction_score` | Aggregated executive trade activity (EDGAR/Quiver) |
-| `narrative_velocity` | Acceleration of energy-related headlines (Reddit/Stocktwits) |
-| `supply_shock_probability` | Probability of supply disruption from EIA + event data |
-| `tanker_disruption_index` | Chokepoint and tanker flow anomaly score |
+| `0.00 – 0.19` | Weak / suppressed (filtered out by default) |
+| `0.20 – 0.34` | Low conviction — monitor for confirmation |
+| `0.35 – 0.49` | Moderate confluence — warrants closer review |
+| `0.50 – 0.69` | Strong signal alignment — high-priority candidate |
+| `0.70 – 1.00` | Very strong confluence — investigate immediately |
 
-### Consuming output in thinkorswim
+> The scoring function is intentionally heuristic in the MVP. Complexity and ML-based weighting are deferred to Phase 4.
 
-The JSON output is compatible with any thinkorswim scripting or watchlist import workflow that accepts JSON. Point your import script at `candidates_latest.json` and map `instrument → symbol`, `structure → strategy type`, and `edge_score → sort column`.
+### Understanding the `signals` Map
 
----
+Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Use these to understand *why* a candidate was surfaced:
 
-## Troubleshooting
-
-### Pipeline fails to start
-
-```
-[ERROR] Missing required environment variable: EIA_API_KEY
-```
-
-**Fix:** Ensure all required variables are set in `.env` and the file is present in the project root. Re-run `--dry-run` to identify any remaining gaps.
-
----
-
-### An agent produces no output
-
-```
-[WARN] Feature Generation Agent: no derived features computed — upstream market state is empty.
-```
-
-**Cause:** The Data Ingestion Agent ran but returned no data (e.g. market closed, API rate-limited).  
-**Fix:**
-1. Check `./logs/` for the ingestion agent's error detail.
-2. Verify your API keys are valid and have not exceeded free-tier rate limits.
-3. Re-run ingestion in isolation: `python -m agent.run --agent ingestion --log-level DEBUG`
-
----
-
-### Missing optional API key warning
-
-```
-[WARN] Connectivity check: MarineTraffic ... SKIPPED (key not set)
-```
-
-**This is not an error.** Optional keys for Phase 2/3 sources (Quiver Quant, MarineTraffic, Polygon) can be omitted. The pipeline runs at reduced signal fidelity and logs which signals were excluded from edge scoring.
-
----
-
-### Database initialisation error
-
-```
-[ERROR] Database initialised failed: ./data/ does not exist.
-```
-
-**Fix:**
-
-```bash
-mkdir -p data
-python -m agent.db init
-```
-
----
-
-### Stale `candidates_latest.json`
-
-If the timestamp in `generated_at` is unexpectedly old, the daemon may have silently stopped.
-
-**Fix:**
-
-```bash
-# Check if the daemon process is running
-ps aux | grep "agent.run"
-
-# Restart in daemon mode
-python -m agent.run --all --daemon
-```
-
----
-
-### High memory or disk usage
-
-If historical data grows beyond expected bounds, reduce retention or purge old records:
-
-```bash
-# Purge records older than HISTORICAL_RETENTION_DAYS
-python -m agent.db purge --older-than 180
-```
-
----
-
-### Common error quick-reference
-
-| Symptom | Likely cause | Action |
+| Signal Key | Computed From | Possible Values |
 |---|---|---|
-| `KeyError: 'edge_score'` in output | Strategy Evaluation Agent skipped | Check feature generation logs; ensure at least one signal computed |
-| All `edge_score` values are `0.0` | No signals passed threshold | Lower signal threshold in config or verify feed data quality |
-| `ConnectionTimeout` on news feed | GDELT/NewsAPI
+| `volatility_gap` | Realised IV vs. implied IV | `positive`, `negative`, `neutral` |
+| `futures_curve_steepness` | WTI/Brent futures curve shape | `steep`, `flat`, `inverted` |
+| `sector_dispersion` | XOM vs. CVX vs. XLE spread | `widening`, `stable`, `narrowing` |
+| `insider_conviction_score` | SEC EDGAR / Quiver Quant flows | `high`, `moderate`, `low` |
+| `narrative_velocity` | Reddit / Stocktwits headline rate | `rising`, `stable`, `falling` |
+| `supply_shock_probability` | EIA data + event detection | `elevated`, `moderate`, `low` |
+| `tanker_disruption_index` | MarineTraffic / VesselFinder | `high`, `moderate`, `low` |
+
+### Consuming Output in thinkorswim or Another Dashboard
+
+The JSON output is compatible with any JSON-capable visualization tool. To import into thinkorswim or a custom dashboard:
+
+1. Point your tool at the file path set in `OUTPUT_PATH`.
+2. Refresh after each pipeline run (or after each cycle in continuous mode).
+3. Sort or filter on `

--- a/src/agents/alternative_data/db.py
+++ b/src/agents/alternative_data/db.py
@@ -1,0 +1,175 @@
+"""
+Database read/write for the Alternative Data Agent (Phase 3).
+
+Handles persistence for three alternative signal tables:
+    insider_trades     — SEC EDGAR Form 4 insider trades (issue #149)
+    shipping_events    — tanker/vessel movement events (issue #153)
+    narrative_signals  — Reddit/Stocktwits sentiment velocity (issues #151, #152)
+
+All tables use TIMESTAMPTZ throughout (TimescaleDB-compatible).
+Re-ingestion is idempotent:
+    insider_trades    — no UNIQUE constraint; duplicates possible if same officer
+                        files multiple transactions for the same instrument/date.
+    shipping_events   — no UNIQUE constraint; same vessel may emit multiple events.
+    narrative_signals — UNIQUE (instrument, platform, window_start); use
+                        ON CONFLICT DO NOTHING to skip already-fetched windows.
+
+Functions are stubs pending implementation in issues #149-#153.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# insider_trades
+# ---------------------------------------------------------------------------
+
+
+def write_insider_trades(records: list[dict[str, Any]], engine: Engine) -> int:
+    """
+    Persist insider trade records to insider_trades table.
+
+    Args:
+        records: List of dicts with keys:
+            instrument (str), trade_date (datetime), trade_type (str),
+            shares (int | None), value_usd (float | None),
+            officer_name (str | None), source (str), fetched_at (datetime)
+        engine: SQLAlchemy Engine.
+
+    Returns:
+        Number of rows inserted.
+
+    Raises:
+        NotImplementedError: Until implemented in issue #149.
+    """
+    raise NotImplementedError("write_insider_trades not yet implemented — see issue #149")
+
+
+def read_insider_trades(
+    instrument: str,
+    engine: Engine,
+    *,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """
+    Read the most recent insider trade records for an instrument.
+
+    Args:
+        instrument: Ticker symbol (e.g. 'XOM').
+        engine: SQLAlchemy Engine.
+        limit: Maximum rows to return.
+
+    Returns:
+        List of dicts ordered by trade_date DESC.
+
+    Raises:
+        NotImplementedError: Until implemented in issue #149.
+    """
+    raise NotImplementedError("read_insider_trades not yet implemented — see issue #149")
+
+
+# ---------------------------------------------------------------------------
+# shipping_events
+# ---------------------------------------------------------------------------
+
+
+def write_shipping_events(records: list[dict[str, Any]], engine: Engine) -> int:
+    """
+    Persist vessel/tanker movement events to shipping_events table.
+
+    Args:
+        records: List of dicts with keys:
+            instrument (str | None), vessel_id (str), event_type (str),
+            latitude (float | None), longitude (float | None),
+            timestamp (datetime), source (str), fetched_at (datetime)
+        engine: SQLAlchemy Engine.
+
+    Returns:
+        Number of rows inserted.
+
+    Raises:
+        NotImplementedError: Until implemented in issue #153.
+    """
+    raise NotImplementedError("write_shipping_events not yet implemented — see issue #153")
+
+
+def read_shipping_events(
+    engine: Engine,
+    *,
+    instrument: str | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    """
+    Read recent shipping events, optionally filtered by affected instrument.
+
+    Args:
+        engine: SQLAlchemy Engine.
+        instrument: Optional ticker to filter by (e.g. 'CL=F'). None returns all.
+        limit: Maximum rows to return.
+
+    Returns:
+        List of dicts ordered by timestamp DESC.
+
+    Raises:
+        NotImplementedError: Until implemented in issue #153.
+    """
+    raise NotImplementedError("read_shipping_events not yet implemented — see issue #153")
+
+
+# ---------------------------------------------------------------------------
+# narrative_signals
+# ---------------------------------------------------------------------------
+
+
+def write_narrative_signal(record: dict[str, Any], engine: Engine) -> int:
+    """
+    Persist a single narrative velocity signal to narrative_signals.
+
+    Uses ON CONFLICT DO NOTHING on (instrument, platform, window_start) so
+    re-fetching the same window is idempotent.
+
+    Args:
+        record: Dict with keys:
+            instrument (str), platform (str), score (float | None),
+            mention_count (int | None), sentiment (str | None),
+            window_start (datetime), window_end (datetime), fetched_at (datetime)
+        engine: SQLAlchemy Engine.
+
+    Returns:
+        1 if inserted, 0 if skipped due to conflict.
+
+    Raises:
+        NotImplementedError: Until implemented in issues #151 / #152.
+    """
+    raise NotImplementedError("write_narrative_signal not yet implemented — see issues #151 / #152")
+
+
+def read_latest_narrative_signal(
+    instrument: str,
+    platform: str,
+    engine: Engine,
+) -> dict[str, Any] | None:
+    """
+    Read the most recent narrative signal for an instrument + platform pair.
+
+    Args:
+        instrument: Ticker symbol (e.g. 'USO').
+        platform: 'reddit' | 'stocktwits' | 'combined'.
+        engine: SQLAlchemy Engine.
+
+    Returns:
+        Dict of the most recent row, or None if no records exist.
+
+    Raises:
+        NotImplementedError: Until implemented in issues #151 / #152.
+    """
+    raise NotImplementedError(
+        "read_latest_narrative_signal not yet implemented — see issues #151 / #152"
+    )


### PR DESCRIPTION
## Summary

- **`db/schema.sql`** — 3 new Phase 3 tables (TIMESTAMPTZ throughout, IF NOT EXISTS, idempotent):
  - `insider_trades` — EDGAR Form 4 + optional Quiver enrichment; `trade_type` CHECK constraint; composite index on `(instrument, trade_date DESC)`
  - `shipping_events` — MarineTraffic/VesselFinder tanker movement; `instrument` nullable (event may not map to a single ticker); dual indexes (instrument+timestamp, vessel+timestamp)
  - `narrative_signals` — Reddit/Stocktwits velocity; `platform` and `sentiment` CHECK constraints; UNIQUE `(instrument, platform, window_start)` for idempotent re-fetch via ON CONFLICT DO NOTHING; index on `(instrument, window_start DESC)`
  - Schema header updated to Phase 1+2+3; 3 new hypertable candidates documented

- **`src/agents/alternative_data/db.py`** — typed stub module with 6 public functions (`NotImplementedError`): `write_insider_trades`, `read_insider_trades`, `write_shipping_events`, `read_shipping_events`, `write_narrative_signal`, `read_latest_narrative_signal`. All use `dict[str, Any]`; mypy strict clean.

## Test Coverage

All 5 `local_check.sh` stages pass: ruff ✓ black ✓ mypy ✓ import scan ✓ 250 unit tests ✓

DB functions are stubs — integration tests will be added in issues #149-#153 when each function is implemented.

## TODOS

No TODOS.md items completed in this PR.

## Test plan
- [x] All unit tests pass (250 runs, 0 failures)
- [ ] Integration test verifying all 3 tables exist after schema.sql apply (can be added in #149 or a dedicated test issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)