### PR TITLE
feat(alternative-data): implement fetch_edgar_insider_trades — SEC EDGAR Form 4 (#149)

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -400,3 +400,15 @@ Next Sprint 9 unblocked issues (after #172 + #148 merge):
 - #152 — fetch_stocktwits_sentiment (depends on narrative_signals table from #148)
 - #153 — fetch_tanker_flows (depends on shipping_events table from #148)
 - #166 — HistoricalLoader / run_backtest_pipeline (depends on #172 merged)
+
+## Sprint Notes (2026-03-22, session 1)
+
+**#149 IN REVIEW** — fetch_edgar_insider_trades implemented. PR to be opened → develop.
+
+Implementation details:
+- `src/agents/alternative_data/alternative_data_agent.py`: `fetch_edgar_insider_trades(instruments)` queries EFTS full-text search, downloads Form 4 XML index, parses `nonDerivativeTransaction` elements into `InsiderTrade` records.
+- `src/agents/alternative_data/models.py`: `InsiderTrade` Pydantic model + `TradeType` StrEnum.
+- `@with_retry()` applied; missing/malformed filings logged as WARNING, never raised.
+- `_TX_CODE_MAP`: P→buy, S→sell, A→grant, M→exercise; other codes (F, J) skipped silently.
+- 16 unit tests across `TestParseForm4Xml`, `TestEftsSearch`, `TestFetchEdgarInsiderTrades`.
+- All 5 local_check.sh stages pass (ruff, black, mypy strict, import scan, 266 unit tests).

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide walks you through setting up, configuring, and running the full pipeline end-to-end, and explains how to interpret and act on its output.
+> **Version 1.0 • March 2026**
+> Advisory only. This system surfaces ranked trading candidates; it does **not** execute trades automatically.
 
 ---
 
@@ -18,44 +18,54 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then ranks candidate options strategies by a computed **edge score**.
 
-### Pipeline at a Glance
+### Pipeline Architecture
+
+Data flows unidirectionally through four loosely coupled agents that communicate via a shared market state object and a derived features store.
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion ["① Data Ingestion Agent"]
-        A1[Crude Prices\nWTI · Brent]
-        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
-        A3[Options Chains\nStrike · IV · Volume]
+    subgraph Inputs
+        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
+        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A3[Options Chains\nYahoo Finance / Polygon.io]
+        A4[Supply & Inventory\nEIA API]
+        A5[News & Geo Events\nGDELT / NewsAPI]
+        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+        A7[Shipping & Logistics\nMarineTraffic / VesselFinder]
+        A8[Narrative / Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Event ["② Event Detection Agent"]
-        B1[News & Geo Feeds\nGDELT · NewsAPI]
-        B2[Supply Signals\nEIA · Shipping]
-        B3[Confidence &\nIntensity Scores]
+    subgraph Pipeline
+        direction TB
+        P1["🟦 Data Ingestion Agent\nFetch & Normalize"]
+        P2["🟨 Event Detection Agent\nSupply & Geo Signals"]
+        P3["🟩 Feature Generation Agent\nDerived Signal Computation"]
+        P4["🟥 Strategy Evaluation Agent\nOpportunity Ranking"]
     end
 
-    subgraph Features ["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs Implied]
-        C2[Futures Curve\nSteepness]
-        C3[Supply Shock\nProbability]
-        C4[Narrative Velocity\nInsider Conviction]
+    subgraph Output
+        O1[Ranked Candidates\nJSON / Dashboard]
     end
 
-    subgraph Strategy ["④ Strategy Evaluation Agent"]
-        D1[Eligible Structures\nStraddles · Spreads]
-        D2[Edge Score\nComputation]
-        D3[Ranked Candidates\nJSON Output]
-    end
-
-    Ingestion -->|Unified Market\nState Object| Event
-    Event -->|Scored Events| Features
-    Features -->|Derived Signal\nStore| Strategy
-    Strategy -->|candidates.json| Output[(Output)]
+    Inputs --> P1
+    P1 -->|Unified market state object| P2
+    P2 -->|Scored events| P3
+    P3 -->|Derived features store| P4
+    P4 --> O1
 ```
 
-### In-Scope Instruments
+### Agent Responsibilities at a Glance
+
+| Agent | Role | Key Outputs |
+|---|---|---|
+| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical data store |
+| **Event Detection Agent** | Supply & Geo Signals | Scored supply disruptions, outages, chokepoints |
+| **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, shock probability, etc. |
+| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
+
+### In-Scope Instruments (MVP)
 
 | Category | Instruments |
 |---|---|
@@ -72,7 +82,7 @@ flowchart LR
 | Put Spread | `put_spread` |
 | Calendar Spread | `calendar_spread` |
 
-> **Advisory only.** The system produces ranked recommendations. No automated trade execution occurs.
+> **Out of scope (MVP):** Exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
 
 ---
 
@@ -83,46 +93,35 @@ flowchart LR
 | Requirement | Minimum |
 |---|---|
 | Python | 3.10+ |
+| Operating System | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
-| Deployment target | Local machine, single VM, or container |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data source APIs |
 
-### Python Dependencies
+### Required Knowledge
 
-Install all dependencies from the project root:
+- Comfortable running Python scripts and CLI commands
+- Familiarity with virtual environments (`venv` or `conda`)
+- Basic understanding of options trading concepts (IV, straddles, spreads)
 
-```bash
-pip install -r requirements.txt
-```
+### API Accounts
 
-Key packages used by the pipeline:
+Register for the following free (or free-tier) services before proceeding. All are zero- or low-cost.
 
-| Package | Purpose |
-|---|---|
-| `yfinance` | ETF / equity price fetching |
-| `requests` | REST API calls (EIA, Alpha Vantage, GDELT, etc.) |
-| `pandas` | Data normalisation and feature computation |
-| `numpy` | Numerical signal calculations |
-| `schedule` | Cadence-based job scheduling |
-| `python-dotenv` | Loading environment variables from `.env` |
-
-### External API Accounts
-
-All required data sources are **free or low-cost**. Register for API keys before running the pipeline:
-
-| Source | Used By | Sign-up URL |
-|---|---|---|
-| Alpha Vantage | Data Ingestion | https://www.alphavantage.co/support/#api-key |
-| Polygon.io | Data Ingestion (options) | https://polygon.io |
-| EIA Open Data | Event Detection | https://www.eia.gov/opendata/ |
-| NewsAPI | Event Detection | https://newsapi.org |
-| GDELT | Event Detection | No key required (public) |
-| SEC EDGAR | Feature Generation | No key required (public) |
-| Quiver Quant | Feature Generation | https://www.quiverquant.com |
-| MarineTraffic | Feature Generation | https://www.marinetraffic.com/en/p/api-services |
-
-> **Tip:** The pipeline is designed to tolerate missing or delayed data without failing. If you skip optional sources (e.g., MarineTraffic, Quiver Quant), the corresponding signals will be absent from edge score computation but the pipeline will still run.
+| Service | Used For | Cost | Sign-Up URL |
+|---|---|---|---|
+| Alpha Vantage | WTI / Brent crude prices | Free | https://www.alphavantage.co |
+| Yahoo Finance / yfinance | ETF, equity, options data | Free | *(no account needed for yfinance)* |
+| Polygon.io | Options chains (fallback) | Free tier | https://polygon.io |
+| EIA API | Inventory & refinery data | Free | https://www.eia.gov/opendata |
+| GDELT | News & geopolitical events | Free | https://www.gdeltproject.org |
+| NewsAPI | News headlines | Free tier | https://newsapi.org |
+| SEC EDGAR | Insider trading filings | Free | https://www.sec.gov/developer |
+| Quiver Quant | Insider conviction scores | Free/Limited | https://www.quiverquant.com |
+| MarineTraffic | Tanker shipping data | Free tier | https://www.marinetraffic.com |
+| VesselFinder | Tanker flows (fallback) | Free tier | https://www.vesselfinder.com |
+| Reddit API | Narrative / sentiment | Free | https://www.reddit.com/dev/api |
+| Stocktwits API | Retail sentiment | Free | https://api.stocktwits.com |
 
 ---
 
@@ -135,177 +134,204 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create a Virtual Environment
+### 2. Create and Activate a Virtual Environment
 
 ```bash
-python -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate         # Windows PowerShell
+# .venv\Scripts\activate.bat    # Windows CMD
+# .venv\Scripts\Activate.ps1   # Windows PowerShell
 ```
 
 ### 3. Install Dependencies
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
 ### 4. Configure Environment Variables
 
-Copy the provided template and fill in your credentials:
+The pipeline is configured entirely through environment variables. Copy the provided template and fill in your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and populate every value. The full set of supported variables is described in the table below.
+Open `.env` in your editor and set each variable as described in the table below.
 
-#### Environment Variable Reference
+#### Complete Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
+| **Data Ingestion** | | | |
 | `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for crude price feeds (WTI, Brent) |
-| `POLYGON_API_KEY` | ⚠️ Optional | — | API key for options chain data (strike, expiry, IV, volume) |
-| `EIA_API_KEY` | ✅ | — | API key for EIA inventory and refinery utilization data |
-| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI energy event headlines |
-| `QUIVER_QUANT_API_KEY` | ⚠️ Optional | — | API key for insider conviction signal (EDGAR fallback used if absent) |
-| `MARINETRAFFIC_API_KEY` | ⚠️ Optional | — | API key for tanker flow / shipping logistics data |
-| `OUTPUT_DIR` | ✅ | `./output` | Directory where `candidates.json` and logs are written |
-| `HISTORICAL_DATA_DIR` | ✅ | `./data/historical` | Directory for persisted raw and derived data |
-| `RETENTION_DAYS` | ⚠️ Optional | `365` | Days of historical data to retain (minimum 180 recommended) |
-| `MARKET_DATA_INTERVAL_MINUTES` | ⚠️ Optional | `5` | Polling cadence for minute-level market data feeds |
-| `LOG_LEVEL` | ⚠️ Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `EDGE_SCORE_THRESHOLD` | ⚠️ Optional | `0.30` | Minimum edge score for a candidate to appear in output |
-| `MAX_CANDIDATES` | ⚠️ Optional | `20` | Maximum number of ranked candidates emitted per run |
+| `POLYGON_API_KEY` | ⚠️ | — | Polygon.io key; used as options chain fallback when Yahoo Finance is unavailable |
+| `EIA_API_KEY` | ✅ | — | EIA Open Data API key for inventory and refinery utilization |
+| `MARKET_DATA_REFRESH_INTERVAL_SECONDS` | ❌ | `60` | Polling interval for minute-level market data feeds |
+| `OPTIONS_DATA_REFRESH_INTERVAL_SECONDS` | ❌ | `86400` | Polling interval for options chain data (daily by default) |
+| `EIA_REFRESH_INTERVAL_SECONDS` | ❌ | `604800` | Polling interval for EIA data (weekly by default) |
+| **Event Detection** | | | |
+| `NEWSAPI_KEY` | ✅ | — | NewsAPI key for energy headline ingestion |
+| `GDELT_ENABLED` | ❌ | `true` | Set to `false` to disable GDELT event monitoring |
+| `EVENT_CONFIDENCE_THRESHOLD` | ❌ | `0.5` | Minimum confidence score `[0.0–1.0]` for an event to be forwarded to feature generation |
+| **Feature Generation** | | | |
+| `QUIVER_QUANT_API_KEY` | ⚠️ | — | Quiver Quant key for insider conviction scores (optional; falls back to raw EDGAR) |
+| `REDDIT_CLIENT_ID` | ⚠️ | — | Reddit API client ID for narrative velocity computation |
+| `REDDIT_CLIENT_SECRET` | ⚠️ | — | Reddit API client secret |
+| `REDDIT_USER_AGENT` | ⚠️ | — | Reddit API user-agent string, e.g. `energy-agent/1.0` |
+| `STOCKTWITS_ENABLED` | ❌ | `true` | Set to `false` to disable Stocktwits sentiment ingestion |
+| `MARINE_TRAFFIC_API_KEY` | ⚠️ | — | MarineTraffic API key for tanker flow data |
+| **Strategy Evaluation** | | | |
+| `EDGE_SCORE_MIN_THRESHOLD` | ❌ | `0.0` | Candidates with an edge score below this value are excluded from output |
+| `MAX_CANDIDATES_OUTPUT` | ❌ | `20` | Maximum number of ranked candidates written per pipeline run |
+| `TARGET_EXPIRATION_DAYS` | ❌ | `30` | Default target expiration window (calendar days) for generated candidates |
+| **Storage & Output** | | | |
+| `DATA_STORE_PATH` | ❌ | `./data` | Local directory for raw and derived historical data |
+| `HISTORICAL_RETENTION_DAYS` | ❌ | `365` | Number of days of historical data to retain (minimum 180 recommended) |
+| `OUTPUT_PATH` | ❌ | `./output` | Directory where JSON output files are written |
+| `OUTPUT_FORMAT` | ❌ | `json` | Output format; currently only `json` is supported |
+| **Deployment** | | | |
+| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_MODE` | ❌ | `continuous` | `continuous` (polling loop) or `once` (single run and exit) |
 
-A minimal `.env` for getting started looks like this:
+> **Legend:** ✅ Required · ⚠️ Recommended (pipeline degrades gracefully without it) · ❌ Optional
+
+#### Example `.env` File
 
 ```dotenv
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-EIA_API_KEY=your_eia_key
-NEWS_API_KEY=your_newsapi_key
-OUTPUT_DIR=./output
-HISTORICAL_DATA_DIR=./data/historical
+# --- Data Ingestion ---
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
+POLYGON_API_KEY=your_polygon_key_here
+EIA_API_KEY=your_eia_key_here
+MARKET_DATA_REFRESH_INTERVAL_SECONDS=60
+OPTIONS_DATA_REFRESH_INTERVAL_SECONDS=86400
+EIA_REFRESH_INTERVAL_SECONDS=604800
+
+# --- Event Detection ---
+NEWSAPI_KEY=your_newsapi_key_here
+GDELT_ENABLED=true
+EVENT_CONFIDENCE_THRESHOLD=0.5
+
+# --- Feature Generation ---
+QUIVER_QUANT_API_KEY=your_quiver_key_here
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-agent/1.0
+STOCKTWITS_ENABLED=true
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key_here
+
+# --- Strategy Evaluation ---
+EDGE_SCORE_MIN_THRESHOLD=0.25
+MAX_CANDIDATES_OUTPUT=20
+TARGET_EXPIRATION_DAYS=30
+
+# --- Storage & Output ---
+DATA_STORE_PATH=./data
+HISTORICAL_RETENTION_DAYS=365
+OUTPUT_PATH=./output
+OUTPUT_FORMAT=json
+
+# --- Deployment ---
+LOG_LEVEL=INFO
+PIPELINE_MODE=continuous
 ```
 
 ### 5. Initialise the Data Store
 
-Run the initialisation script to create the required directory structure and seed the historical data store:
+Run the initialisation script once before the first pipeline execution. It creates the directory structure and seeds the historical data store.
 
 ```bash
-python scripts/init_store.py
+python -m agent.init
 ```
 
 Expected output:
 
 ```
-[INFO] Created directory: ./output
-[INFO] Created directory: ./data/historical
-[INFO] Historical data store initialised successfully.
+[INFO] Data store initialised at ./data
+[INFO] Output directory created at ./output
+[INFO] Schema validation: OK
+[INFO] Ready to run.
 ```
 
 ---
 
 ## Running the Pipeline
 
-The pipeline can be executed in two modes: **single-shot** (run once and exit) and **scheduled** (run continuously on a defined cadence).
+### Quick Start — Single Run
 
-### Pipeline Execution Flow
-
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant FS as File System
-
-    CLI->>DIA: Trigger run
-    DIA->>DIA: Fetch crude, ETF, equity prices
-    DIA->>DIA: Fetch options chains
-    DIA->>DIA: Normalise → MarketState object
-    DIA-->>EDA: MarketState
-
-    EDA->>EDA: Query GDELT / NewsAPI
-    EDA->>EDA: Query EIA / MarineTraffic
-    EDA->>EDA: Score events (confidence + intensity)
-    EDA-->>FGA: MarketState + ScoredEvents
-
-    FGA->>FGA: Compute volatility gap
-    FGA->>FGA: Compute curve steepness
-    FGA->>FGA: Compute supply shock probability
-    FGA->>FGA: Compute narrative velocity & insider conviction
-    FGA-->>SEA: DerivedFeaturesStore
-
-    SEA->>SEA: Evaluate eligible structures
-    SEA->>SEA: Compute edge scores
-    SEA->>SEA: Rank candidates
-    SEA->>FS: Write candidates.json
-    FS-->>CLI: Done
-```
-
-### Single-Shot Run
-
-Use this mode for on-demand analysis or debugging:
+To execute all four agents once and write output to `./output`, set `PIPELINE_MODE=once` in your `.env` (or override inline):
 
 ```bash
-python -m agent.pipeline --mode once
+PIPELINE_MODE=once python -m agent.pipeline
 ```
 
-To override the output directory for a single run:
+### Continuous Mode (Default)
+
+In continuous mode the pipeline polls market data on the configured intervals without manual intervention:
 
 ```bash
-python -m agent.pipeline --mode once --output-dir ./output/run_20260315
+python -m agent.pipeline
 ```
 
-To set the minimum edge score threshold at runtime:
+The agents execute in sequence on each polling cycle:
 
-```bash
-python -m agent.pipeline --mode once --edge-threshold 0.40
 ```
-
-### Scheduled / Continuous Run
-
-Use this mode to keep the pipeline running on the configured cadence:
-
-```bash
-python -m agent.pipeline --mode scheduled
+[INFO] Cycle 1 starting at 2026-03-15T09:30:00Z
+[INFO] [DataIngestionAgent]     Fetching crude prices ... OK
+[INFO] [DataIngestionAgent]     Fetching ETF/equity prices ... OK
+[INFO] [DataIngestionAgent]     Fetching options chains ... OK
+[INFO] [EventDetectionAgent]    Processing GDELT feed ... 3 events detected
+[INFO] [EventDetectionAgent]    Processing NewsAPI feed ... 1 event detected
+[INFO] [FeatureGenerationAgent] Computing volatility gaps ... OK
+[INFO] [FeatureGenerationAgent] Computing supply shock probability ... OK
+[INFO] [StrategyEvaluationAgent] Evaluating structures ... 5 candidates generated
+[INFO] Output written to ./output/candidates_20260315T093012Z.json
+[INFO] Cycle 1 complete. Next cycle in 60s.
 ```
-
-The scheduler respects the `MARKET_DATA_INTERVAL_MINUTES` environment variable for market data refreshes. Slower feeds (EIA, EDGAR) are polled on their own daily or weekly schedules regardless of this setting.
 
 ### Running Individual Agents
 
-Each agent can be run independently for testing or incremental development:
+Each agent can be invoked independently for testing or incremental development:
 
 ```bash
 # Run only the Data Ingestion Agent
 python -m agent.ingestion
 
 # Run only the Event Detection Agent
-python -m agent.event_detection
+python -m agent.events
 
 # Run only the Feature Generation Agent
-python -m agent.feature_generation
+python -m agent.features
 
 # Run only the Strategy Evaluation Agent
-python -m agent.strategy_evaluation
+python -m agent.strategy
 ```
 
-> **Note:** Running an agent in isolation requires that the upstream artefacts (MarketState object, scored events, derived features store) are already present in `HISTORICAL_DATA_DIR` from a prior run.
+> **Note:** Agents downstream of Data Ingestion read from the shared market state object written to `DATA_STORE_PATH`. Run ingestion at least once before running downstream agents in isolation.
 
-### Running in a Container
+### Running with Docker
 
-A `Dockerfile` is provided for containerised deployment:
+A single-container deployment is supported for local or cloud VM use:
 
 ```bash
-docker build -t energy-options-agent:latest .
+# Build the image
+docker build -t energy-options-agent:1.0 .
 
+# Run with your .env file mounted
 docker run --env-file .env \
-  -v $(pwd)/output:/app/output \
-  -v $(pwd)/data:/app/data \
-  energy-options-agent:latest \
-  python -m agent.pipeline --mode scheduled
+           -v $(pwd)/data:/app/data \
+           -v $(pwd)/output:/app/output \
+           energy-options-agent:1.0
+```
+
+### Scheduling (Cron Example)
+
+To run a single pipeline pass on a schedule, set `PIPELINE_MODE=once` and use cron:
+
+```cron
+# Run every weekday at 09:00 and 15:00 UTC
+0 9,15 * * 1-5 /path/to/.venv/bin/python -m agent.pipeline >> /var/log/energy-agent.log 2>&1
 ```
 
 ---
@@ -314,103 +340,35 @@ docker run --env-file .env \
 
 ### Output File Location
 
-After each successful run, the pipeline writes a JSON file to `OUTPUT_DIR`:
+Each pipeline run writes a timestamped JSON file to `OUTPUT_PATH`:
 
 ```
-./output/
-└── candidates.json          # Latest ranked candidates
-└── candidates_20260315T143000Z.json   # Timestamped archive copy
+./output/candidates_20260315T093012Z.json
 ```
 
 ### Output Schema
 
-Each element in the `candidates` array has the following structure:
+Each file contains a JSON array of candidate objects. Every candidate has the following fields:
 
 | Field | Type | Description |
 |---|---|---|
 | `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher = stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their assessed levels |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
-### Example `candidates.json`
+### Example Output
 
 ```json
-{
-  "generated_at": "2026-03-15T14:30:00Z",
-  "candidates": [
-    {
-      "instrument": "USO",
-      "structure": "long_straddle",
-      "expiration": 30,
-      "edge_score": 0.47,
-      "signals": {
-        "tanker_disruption_index": "high",
-        "volatility_gap": "positive",
-        "narrative_velocity": "rising"
-      },
-      "generated_at": "2026-03-15T14:30:00Z"
-    },
-    {
-      "instrument": "XLE",
-      "structure": "call_spread",
-      "expiration": 21,
-      "edge_score": 0.38,
-      "signals": {
-        "supply_shock_probability": "elevated",
-        "volatility_gap": "positive",
-        "futures_curve_steepness": "steep"
-      },
-      "generated_at": "2026-03-15T14:30:00Z"
-    }
-  ]
-}
-```
-
-### Understanding the Edge Score
-
-The `edge_score` is a composite float in the range **0.0–1.0** that reflects the degree of signal confluence supporting a given candidate. A higher score means more contributing signals are aligned in the same directional thesis.
-
-| Edge Score Range | Interpretation |
-|---|---|
-| `0.00 – 0.29` | Weak or insufficient signal confluence; filtered out by default threshold |
-| `0.30 – 0.44` | Moderate confluence; worth monitoring |
-| `0.45 – 0.64` | Strong confluence; primary review candidates |
-| `0.65 – 1.00` | High conviction; strongest signal alignment |
-
-> Candidates below `EDGE_SCORE_THRESHOLD` (default `0.30`) are excluded from output. Adjust this variable in `.env` to widen or narrow the result set.
-
-### Understanding the Signals Map
-
-The `signals` object shows which derived features contributed to the edge score and their qualitative state at the time of evaluation.
-
-| Signal Key | Source Agent | What It Measures |
-|---|---|---|
-| `volatility_gap` | Feature Generation | Gap between realised and implied volatility |
-| `futures_curve_steepness` | Feature Generation | Contango / backwardation degree of the futures curve |
-| `supply_shock_probability` | Feature Generation | Probability of a near-term supply disruption |
-| `narrative_velocity` | Feature Generation | Acceleration of energy-related headline volume |
-| `insider_conviction` | Feature Generation | Strength of recent executive insider trading signals |
-| `tanker_disruption_index` | Event Detection | Severity of tanker chokepoint or shipping disruptions |
-| `sector_dispersion` | Feature Generation | Cross-sector correlation divergence within energy equities |
-
-### Viewing Output in thinkorswim or a Dashboard
-
-The output JSON is compatible with any JSON-capable dashboard. For thinkorswim:
-
-1. Set `OUTPUT_DIR` to a path accessible by your local machine.
-2. Load `candidates.json` via a thinkorswim **thinkScript** watchlist or use the **Scan** tab with a custom script that reads from the file.
-3. Use `edge_score` as the primary sort key and `expiration` to filter by desired time horizon.
-
----
-
-## Troubleshooting
-
-### Common Issues
-
-| Symptom | Likely Cause | Resolution |
-|---|---|---|
-| `KeyError: ALPHA_VANTAGE_API_KEY` | `.env` file not loaded or variable missing | Confirm `.env` exists in the project root; check `python-dotenv` is installed |
-| `candidates.json` is empty
+[
+  {
+    "instrument": "USO",
+    "structure": "long_straddle",
+    "expiration": 30,
+    "edge_score": 0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap": "positive",
+      "narrative_velocity

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 • March 2026**
-> This guide walks you through installing, configuring, and running the full pipeline end-to-end, then interpreting its output. It assumes you are comfortable with Python 3 and a Unix-style command line.
+> **Version 1.0 · March 2026**
+> This guide walks you through setting up, configuring, and running the full pipeline end-to-end, and explains how to interpret and act on its output.
 
 ---
 
@@ -18,61 +18,61 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests live and near-live market data, scores supply and geopolitical events, derives volatility signals, and produces a ranked list of candidate options strategies — all without automated trade execution.
+The **Energy Options Opportunity Agent** is a four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
 
 ### Pipeline at a Glance
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nYahoo Finance / yfinance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
-        A5[Shipping & Sentiment\nMarineTraffic · Reddit · Stocktwits]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
+    subgraph Ingestion ["① Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nStrike · IV · Volume]
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[News & Geo Feeds\nGDELT / NewsAPI]
-        B2[Supply Disruption Scoring]
-        B3[Confidence & Intensity Scores]
+    subgraph Event ["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT · NewsAPI]
+        B2[Supply Signals\nEIA · Shipping]
+        B3[Confidence &\nIntensity Scores]
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealised vs. Implied]
-        C2[Futures Curve Steepness]
-        C3[Sector Dispersion]
-        C4[Insider Conviction Score]
-        C5[Narrative Velocity]
-        C6[Supply Shock Probability]
+    subgraph Features ["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs Implied]
+        C2[Futures Curve\nSteepness]
+        C3[Supply Shock\nProbability]
+        C4[Narrative Velocity\nInsider Conviction]
     end
 
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate Eligible Structures]
-        D2[Compute Edge Scores]
-        D3[Rank Candidates]
+    subgraph Strategy ["④ Strategy Evaluation Agent"]
+        D1[Eligible Structures\nStraddles · Spreads]
+        D2[Edge Score\nComputation]
+        D3[Ranked Candidates\nJSON Output]
     end
 
-    OUT[(JSON Output\nRanked Candidates)]
-
-    Ingestion -->|Market State Object| Events
-    Ingestion -->|Market State Object| Features
-    Events    -->|Scored Events| Features
-    Features  -->|Derived Signal Store| Strategy
-    Strategy  --> OUT
+    Ingestion -->|Unified Market\nState Object| Event
+    Event -->|Scored Events| Features
+    Features -->|Derived Signal\nStore| Strategy
+    Strategy -->|candidates.json| Output[(Output)]
 ```
 
-### In-Scope Instruments & Structures
+### In-Scope Instruments
 
-| Category | Items |
+| Category | Instruments |
 |---|---|
-| **Crude Futures** | Brent Crude, WTI (`CL=F`) |
-| **ETFs** | USO, XLE |
-| **Energy Equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option Structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| ETFs | USO, XLE |
+| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
 
-> **Advisory only.** The system produces recommendations; it does not execute trades.
+### In-Scope Option Structures (MVP)
+
+| Structure | Enum Value |
+|---|---|
+| Long Straddle | `long_straddle` |
+| Call Spread | `call_spread` |
+| Put Spread | `put_spread` |
+| Calendar Spread | `calendar_spread` |
+
+> **Advisory only.** The system produces ranked recommendations. No automated trade execution occurs.
 
 ---
 
@@ -84,54 +84,72 @@ flowchart LR
 |---|---|
 | Python | 3.10+ |
 | RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
+| Disk | 10 GB (for 6–12 months of historical data) |
 | OS | Linux, macOS, or Windows (WSL2 recommended) |
 | Deployment target | Local machine, single VM, or container |
 
-### Required Tools
+### Python Dependencies
+
+Install all dependencies from the project root:
 
 ```bash
-# Verify Python version
-python --version          # must be 3.10 or higher
-
-# Verify pip
-pip --version
-
-# Optional but recommended: create a virtual environment
-python -m venv .venv
-source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
 ```
 
-### API Accounts
+Key packages used by the pipeline:
 
-Obtain credentials (all free or free-tier) before configuration:
+| Package | Purpose |
+|---|---|
+| `yfinance` | ETF / equity price fetching |
+| `requests` | REST API calls (EIA, Alpha Vantage, GDELT, etc.) |
+| `pandas` | Data normalisation and feature computation |
+| `numpy` | Numerical signal calculations |
+| `schedule` | Cadence-based job scheduling |
+| `python-dotenv` | Loading environment variables from `.env` |
 
-| Service | Purpose | Sign-up URL |
+### External API Accounts
+
+All required data sources are **free or low-cost**. Register for API keys before running the pipeline:
+
+| Source | Used By | Sign-up URL |
 |---|---|---|
-| Alpha Vantage **or** MetalpriceAPI | WTI / Brent spot & futures prices | https://www.alphavantage.co / https://metalpriceapi.com |
-| Polygon.io | Options chains (alternative to Yahoo Finance) | https://polygon.io |
-| EIA Open Data | Weekly supply & inventory data | https://www.eia.gov/opendata |
-| NewsAPI | News & geopolitical events | https://newsapi.org |
-| GDELT | Geopolitical event stream | No key required (public) |
-| SEC EDGAR / Quiver Quant | Insider trading activity | https://efts.sec.gov / https://www.quiverquant.com |
-| MarineTraffic **or** VesselFinder | Tanker flow data | https://www.marinetraffic.com / https://www.vesselfinder.com |
+| Alpha Vantage | Data Ingestion | https://www.alphavantage.co/support/#api-key |
+| Polygon.io | Data Ingestion (options) | https://polygon.io |
+| EIA Open Data | Event Detection | https://www.eia.gov/opendata/ |
+| NewsAPI | Event Detection | https://newsapi.org |
+| GDELT | Event Detection | No key required (public) |
+| SEC EDGAR | Feature Generation | No key required (public) |
+| Quiver Quant | Feature Generation | https://www.quiverquant.com |
+| MarineTraffic | Feature Generation | https://www.marinetraffic.com/en/p/api-services |
 
-> Yahoo Finance (`yfinance`), Reddit, Stocktwits, and GDELT do not require API keys for basic access.
+> **Tip:** The pipeline is designed to tolerate missing or delayed data without failing. If you skip optional sources (e.g., MarineTraffic, Quiver Quant), the corresponding signals will be absent from edge score computation but the pipeline will still run.
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone & Install Dependencies
+### 1. Clone the Repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
+```
 
+### 2. Create a Virtual Environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate         # Windows PowerShell
+```
+
+### 3. Install Dependencies
+
+```bash
 pip install -r requirements.txt
 ```
 
-### 2. Create the Environment File
+### 4. Configure Environment Variables
 
 Copy the provided template and fill in your credentials:
 
@@ -139,189 +157,174 @@ Copy the provided template and fill in your credentials:
 cp .env.example .env
 ```
 
-Open `.env` in your editor and populate each variable (see the full reference table below).
+Open `.env` in your editor and populate every value. The full set of supported variables is described in the table below.
 
-### 3. Environment Variable Reference
-
-All pipeline behaviour is controlled via environment variables. The `.env` file is loaded automatically at startup.
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Conditional¹ | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Conditional¹ | — | API key for MetalpriceAPI crude price feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA inventory & utilization data |
-| `NEWS_API_KEY` | Yes | — | API key for NewsAPI geopolitical/energy headlines |
-| `QUIVER_QUANT_API_KEY` | Optional | — | API key for Quiver Quant insider data |
-| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic tanker flow data |
-| `DATA_REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data polling (minutes-level) |
-| `EIA_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for EIA inventory polling |
-| `EDGAR_REFRESH_INTERVAL_HOURS` | No | `24` | Cadence for SEC EDGAR insider data polling |
-| `HISTORICAL_RETENTION_DAYS` | No | `180` | Days of raw & derived data to retain (180–365 recommended) |
-| `OUTPUT_PATH` | No | `./output/candidates.json` | File path for ranked candidate JSON output |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F,BZ=F` | Comma-separated list of instruments to monitor |
-| `EDGE_SCORE_MIN_THRESHOLD` | No | `0.20` | Candidates below this edge score are suppressed from output |
-| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates written per run |
-| `ENABLE_SHIPPING_SIGNALS` | No | `false` | Set `true` to activate MarineTraffic/VesselFinder agent |
-| `ENABLE_INSIDER_SIGNALS` | No | `false` | Set `true` to activate SEC EDGAR / Quiver Quant agent |
-| `ENABLE_NARRATIVE_SIGNALS` | No | `true` | Set `false` to disable Reddit/Stocktwits sentiment agent |
-| `DB_PATH` | No | `./data/market_state.db` | SQLite database path for historical storage |
+| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for crude price feeds (WTI, Brent) |
+| `POLYGON_API_KEY` | ⚠️ Optional | — | API key for options chain data (strike, expiry, IV, volume) |
+| `EIA_API_KEY` | ✅ | — | API key for EIA inventory and refinery utilization data |
+| `NEWS_API_KEY` | ✅ | — | API key for NewsAPI energy event headlines |
+| `QUIVER_QUANT_API_KEY` | ⚠️ Optional | — | API key for insider conviction signal (EDGAR fallback used if absent) |
+| `MARINETRAFFIC_API_KEY` | ⚠️ Optional | — | API key for tanker flow / shipping logistics data |
+| `OUTPUT_DIR` | ✅ | `./output` | Directory where `candidates.json` and logs are written |
+| `HISTORICAL_DATA_DIR` | ✅ | `./data/historical` | Directory for persisted raw and derived data |
+| `RETENTION_DAYS` | ⚠️ Optional | `365` | Days of historical data to retain (minimum 180 recommended) |
+| `MARKET_DATA_INTERVAL_MINUTES` | ⚠️ Optional | `5` | Polling cadence for minute-level market data feeds |
+| `LOG_LEVEL` | ⚠️ Optional | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `EDGE_SCORE_THRESHOLD` | ⚠️ Optional | `0.30` | Minimum edge score for a candidate to appear in output |
+| `MAX_CANDIDATES` | ⚠️ Optional | `20` | Maximum number of ranked candidates emitted per run |
 
-> ¹ At least one of `ALPHA_VANTAGE_API_KEY` or `METALPRICE_API_KEY` must be provided.
-
-### 4. Example `.env` File
+A minimal `.env` for getting started looks like this:
 
 ```dotenv
-# Crude price source (provide at least one)
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-METALPRICE_API_KEY=
-
-# Options data
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-
-# Supply & inventory
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-
-# News & events
-NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# Optional alternative signals
-QUIVER_QUANT_API_KEY=
-MARINE_TRAFFIC_API_KEY=
-ENABLE_SHIPPING_SIGNALS=false
-ENABLE_INSIDER_SIGNALS=false
-ENABLE_NARRATIVE_SIGNALS=true
-
-# Data refresh cadences
-DATA_REFRESH_INTERVAL_MINUTES=5
-EIA_REFRESH_INTERVAL_HOURS=24
-EDGAR_REFRESH_INTERVAL_HOURS=24
-
-# Storage & output
-HISTORICAL_RETENTION_DAYS=180
-DB_PATH=./data/market_state.db
-OUTPUT_PATH=./output/candidates.json
-
-# Pipeline tuning
-EDGE_SCORE_MIN_THRESHOLD=0.20
-MAX_CANDIDATES=20
-LOG_LEVEL=INFO
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+EIA_API_KEY=your_eia_key
+NEWS_API_KEY=your_newsapi_key
+OUTPUT_DIR=./output
+HISTORICAL_DATA_DIR=./data/historical
 ```
 
-### 5. Initialise the Database
+### 5. Initialise the Data Store
 
-Run the schema migration once before your first pipeline execution:
+Run the initialisation script to create the required directory structure and seed the historical data store:
 
 ```bash
-python -m agent init-db
+python scripts/init_store.py
 ```
 
 Expected output:
 
 ```
-[INFO] Initialising database at ./data/market_state.db
-[INFO] Schema applied successfully.
-[INFO] Ready.
+[INFO] Created directory: ./output
+[INFO] Created directory: ./data/historical
+[INFO] Historical data store initialised successfully.
 ```
 
 ---
 
 ## Running the Pipeline
 
+The pipeline can be executed in two modes: **single-shot** (run once and exit) and **scheduled** (run continuously on a defined cadence).
+
 ### Pipeline Execution Flow
 
 ```mermaid
 sequenceDiagram
-    actor User
     participant CLI as CLI / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant OUT as JSON Output
+    participant FS as File System
 
-    User->>CLI: python -m agent run
-    CLI->>DIA: Fetch & normalise market data
-    DIA-->>CLI: Market State Object ✓
-    CLI->>EDA: Detect & score events
-    EDA-->>CLI: Scored Event List ✓
-    CLI->>FGA: Compute derived signals
-    FGA-->>CLI: Derived Feature Store ✓
-    CLI->>SEA: Evaluate & rank strategies
-    SEA-->>OUT: Write candidates.json
-    OUT-->>User: Ranked candidates ready
+    CLI->>DIA: Trigger run
+    DIA->>DIA: Fetch crude, ETF, equity prices
+    DIA->>DIA: Fetch options chains
+    DIA->>DIA: Normalise → MarketState object
+    DIA-->>EDA: MarketState
+
+    EDA->>EDA: Query GDELT / NewsAPI
+    EDA->>EDA: Query EIA / MarineTraffic
+    EDA->>EDA: Score events (confidence + intensity)
+    EDA-->>FGA: MarketState + ScoredEvents
+
+    FGA->>FGA: Compute volatility gap
+    FGA->>FGA: Compute curve steepness
+    FGA->>FGA: Compute supply shock probability
+    FGA->>FGA: Compute narrative velocity & insider conviction
+    FGA-->>SEA: DerivedFeaturesStore
+
+    SEA->>SEA: Evaluate eligible structures
+    SEA->>SEA: Compute edge scores
+    SEA->>SEA: Rank candidates
+    SEA->>FS: Write candidates.json
+    FS-->>CLI: Done
 ```
 
-### Single Run (One-Shot)
+### Single-Shot Run
 
-Execute the full four-agent pipeline once and write results to the configured output path:
+Use this mode for on-demand analysis or debugging:
 
 ```bash
-python -m agent run
+python -m agent.pipeline --mode once
 ```
 
-### Continuous Mode
-
-Poll on the configured `DATA_REFRESH_INTERVAL_MINUTES` cadence, re-running the full pipeline each cycle:
+To override the output directory for a single run:
 
 ```bash
-python -m agent run --continuous
+python -m agent.pipeline --mode once --output-dir ./output/run_20260315
 ```
 
-Press `Ctrl+C` to stop gracefully.
-
-### Run Individual Agents
-
-Each agent is independently deployable and can be invoked in isolation for testing or incremental development:
+To set the minimum edge score threshold at runtime:
 
 ```bash
-# Data Ingestion only
-python -m agent run --agent ingestion
-
-# Event Detection only
-python -m agent run --agent events
-
-# Feature Generation only
-python -m agent run --agent features
-
-# Strategy Evaluation only
-python -m agent run --agent strategy
+python -m agent.pipeline --mode once --edge-threshold 0.40
 ```
 
-> When running agents individually, earlier stages must have already written their outputs to the shared state store.
+### Scheduled / Continuous Run
 
-### Override Configuration at Runtime
-
-Any environment variable can be overridden inline without editing `.env`:
+Use this mode to keep the pipeline running on the configured cadence:
 
 ```bash
-LOG_LEVEL=DEBUG EDGE_SCORE_MIN_THRESHOLD=0.30 python -m agent run
+python -m agent.pipeline --mode scheduled
 ```
 
-### Scheduling with Cron
+The scheduler respects the `MARKET_DATA_INTERVAL_MINUTES` environment variable for market data refreshes. Slower feeds (EIA, EDGAR) are polled on their own daily or weekly schedules regardless of this setting.
 
-To run once per hour on a Unix system:
+### Running Individual Agents
+
+Each agent can be run independently for testing or incremental development:
 
 ```bash
-# Edit crontab
-crontab -e
+# Run only the Data Ingestion Agent
+python -m agent.ingestion
 
-# Add the following line (adjust paths as needed)
-0 * * * * /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
+# Run only the Event Detection Agent
+python -m agent.event_detection
+
+# Run only the Feature Generation Agent
+python -m agent.feature_generation
+
+# Run only the Strategy Evaluation Agent
+python -m agent.strategy_evaluation
+```
+
+> **Note:** Running an agent in isolation requires that the upstream artefacts (MarketState object, scored events, derived features store) are already present in `HISTORICAL_DATA_DIR` from a prior run.
+
+### Running in a Container
+
+A `Dockerfile` is provided for containerised deployment:
+
+```bash
+docker build -t energy-options-agent:latest .
+
+docker run --env-file .env \
+  -v $(pwd)/output:/app/output \
+  -v $(pwd)/data:/app/data \
+  energy-options-agent:latest \
+  python -m agent.pipeline --mode scheduled
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File
+### Output File Location
 
-Results are written to the path specified by `OUTPUT_PATH` (default: `./output/candidates.json`) as a JSON array, sorted descending by `edge_score`.
+After each successful run, the pipeline writes a JSON file to `OUTPUT_DIR`:
+
+```
+./output/
+└── candidates.json          # Latest ranked candidates
+└── candidates_20260315T143000Z.json   # Timestamped archive copy
+```
 
 ### Output Schema
 
-Each element in the array is a **strategy candidate** object:
+Each element in the `candidates` array has the following structure:
 
 | Field | Type | Description |
 |---|---|---|
@@ -329,72 +332,85 @@ Each element in the array is a **strategy candidate** object:
 | `structure` | `enum` | Options structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
 | `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
 | `edge_score` | `float` [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative states |
-| `generated_at` | ISO 8601 `datetime` | UTC timestamp of candidate generation |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example Output
+### Example `candidates.json`
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity": "rising"
+{
+  "generated_at": "2026-03-15T14:30:00Z",
+  "candidates": [
+    {
+      "instrument": "USO",
+      "structure": "long_straddle",
+      "expiration": 30,
+      "edge_score": 0.47,
+      "signals": {
+        "tanker_disruption_index": "high",
+        "volatility_gap": "positive",
+        "narrative_velocity": "rising"
+      },
+      "generated_at": "2026-03-15T14:30:00Z"
     },
-    "generated_at": "2026-03-15T14:32:00Z"
-  },
-  {
-    "instrument": "XLE",
-    "structure": "call_spread",
-    "expiration": 21,
-    "edge_score": 0.31,
-    "signals": {
-      "volatility_gap": "positive",
-      "supply_shock_probability": "elevated",
-      "sector_dispersion": "widening"
-    },
-    "generated_at": "2026-03-15T14:32:00Z"
-  }
-]
+    {
+      "instrument": "XLE",
+      "structure": "call_spread",
+      "expiration": 21,
+      "edge_score": 0.38,
+      "signals": {
+        "supply_shock_probability": "elevated",
+        "volatility_gap": "positive",
+        "futures_curve_steepness": "steep"
+      },
+      "generated_at": "2026-03-15T14:30:00Z"
+    }
+  ]
+}
 ```
 
-### Reading the Edge Score
+### Understanding the Edge Score
 
-The `edge_score` is a composite float in the range 0.0–1.0. It reflects how many signals are aligned in support of a given strategy, weighted by their intensity.
+The `edge_score` is a composite float in the range **0.0–1.0** that reflects the degree of signal confluence supporting a given candidate. A higher score means more contributing signals are aligned in the same directional thesis.
 
 | Edge Score Range | Interpretation |
 |---|---|
-| `0.00 – 0.19` | Weak / suppressed (filtered out by default) |
-| `0.20 – 0.34` | Low conviction — monitor for confirmation |
-| `0.35 – 0.49` | Moderate confluence — warrants closer review |
-| `0.50 – 0.69` | Strong signal alignment — high-priority candidate |
-| `0.70 – 1.00` | Very strong confluence — investigate immediately |
+| `0.00 – 0.29` | Weak or insufficient signal confluence; filtered out by default threshold |
+| `0.30 – 0.44` | Moderate confluence; worth monitoring |
+| `0.45 – 0.64` | Strong confluence; primary review candidates |
+| `0.65 – 1.00` | High conviction; strongest signal alignment |
 
-> The scoring function is intentionally heuristic in the MVP. Complexity and ML-based weighting are deferred to Phase 4.
+> Candidates below `EDGE_SCORE_THRESHOLD` (default `0.30`) are excluded from output. Adjust this variable in `.env` to widen or narrow the result set.
 
-### Understanding the `signals` Map
+### Understanding the Signals Map
 
-Each key in the `signals` object corresponds to a derived feature computed by the Feature Generation Agent. Use these to understand *why* a candidate was surfaced:
+The `signals` object shows which derived features contributed to the edge score and their qualitative state at the time of evaluation.
 
-| Signal Key | Computed From | Possible Values |
+| Signal Key | Source Agent | What It Measures |
 |---|---|---|
-| `volatility_gap` | Realised IV vs. implied IV | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | WTI/Brent futures curve shape | `steep`, `flat`, `inverted` |
-| `sector_dispersion` | XOM vs. CVX vs. XLE spread | `widening`, `stable`, `narrowing` |
-| `insider_conviction_score` | SEC EDGAR / Quiver Quant flows | `high`, `moderate`, `low` |
-| `narrative_velocity` | Reddit / Stocktwits headline rate | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | EIA data + event detection | `elevated`, `moderate`, `low` |
-| `tanker_disruption_index` | MarineTraffic / VesselFinder | `high`, `moderate`, `low` |
+| `volatility_gap` | Feature Generation | Gap between realised and implied volatility |
+| `futures_curve_steepness` | Feature Generation | Contango / backwardation degree of the futures curve |
+| `supply_shock_probability` | Feature Generation | Probability of a near-term supply disruption |
+| `narrative_velocity` | Feature Generation | Acceleration of energy-related headline volume |
+| `insider_conviction` | Feature Generation | Strength of recent executive insider trading signals |
+| `tanker_disruption_index` | Event Detection | Severity of tanker chokepoint or shipping disruptions |
+| `sector_dispersion` | Feature Generation | Cross-sector correlation divergence within energy equities |
 
-### Consuming Output in thinkorswim or Another Dashboard
+### Viewing Output in thinkorswim or a Dashboard
 
-The JSON output is compatible with any JSON-capable visualization tool. To import into thinkorswim or a custom dashboard:
+The output JSON is compatible with any JSON-capable dashboard. For thinkorswim:
 
-1. Point your tool at the file path set in `OUTPUT_PATH`.
-2. Refresh after each pipeline run (or after each cycle in continuous mode).
-3. Sort or filter on `
+1. Set `OUTPUT_DIR` to a path accessible by your local machine.
+2. Load `candidates.json` via a thinkorswim **thinkScript** watchlist or use the **Scan** tab with a custom script that reads from the file.
+3. Use `edge_score` as the primary sort key and `expiration` to filter by desired time horizon.
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Symptom | Likely Cause | Resolution |
+|---|---|---|
+| `KeyError: ALPHA_VANTAGE_API_KEY` | `.env` file not loaded or variable missing | Confirm `.env` exists in the project root; check `python-dotenv` is installed |
+| `candidates.json` is empty

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> Advisory only. This system surfaces ranked trading candidates; it does **not** execute trades automatically.
+> This guide walks a developer through setting up, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
 
 ---
 
@@ -18,54 +18,47 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then ranks candidate options strategies by a computed **edge score**.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline composed of four loosely coupled agents. It ingests market data, geopolitical signals, news events, and alternative datasets to produce structured, ranked candidate options strategies for oil-related instruments.
 
 ### Pipeline Architecture
-
-Data flows unidirectionally through four loosely coupled agents that communicate via a shared market state object and a derived features store.
 
 ```mermaid
 flowchart LR
     subgraph Inputs
         A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
+        A2[ETF & Equity Prices\nyfinance]
         A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[Supply & Inventory\nEIA API]
+        A4[EIA Inventory\nEIA API]
         A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nSEC EDGAR / Quiver Quant]
-        A7[Shipping & Logistics\nMarineTraffic / VesselFinder]
-        A8[Narrative / Sentiment\nReddit / Stocktwits]
+        A6[Insider Activity\nEDGAR / Quiver Quant]
+        A7[Shipping Data\nMarineTraffic]
+        A8[Sentiment\nReddit / Stocktwits]
     end
 
-    subgraph Pipeline
-        direction TB
-        P1["🟦 Data Ingestion Agent\nFetch & Normalize"]
-        P2["🟨 Event Detection Agent\nSupply & Geo Signals"]
-        P3["🟩 Feature Generation Agent\nDerived Signal Computation"]
-        P4["🟥 Strategy Evaluation Agent\nOpportunity Ranking"]
+    subgraph Agent_1 [" Agent 1 · Data Ingestion"]
+        B[Fetch & Normalize\nMarket State Object]
     end
 
-    subgraph Output
-        O1[Ranked Candidates\nJSON / Dashboard]
+    subgraph Agent_2 [" Agent 2 · Event Detection"]
+        C[Supply & Geo\nSignal Scoring]
     end
 
-    Inputs --> P1
-    P1 -->|Unified market state object| P2
-    P2 -->|Scored events| P3
-    P3 -->|Derived features store| P4
-    P4 --> O1
+    subgraph Agent_3 [" Agent 3 · Feature Generation"]
+        D[Derived Signal\nComputation]
+    end
+
+    subgraph Agent_4 [" Agent 4 · Strategy Evaluation"]
+        E[Opportunity Ranking\nEdge Score Output]
+    end
+
+    Inputs --> Agent_1
+    Agent_1 -->|market state object| Agent_2
+    Agent_2 -->|scored events| Agent_3
+    Agent_3 -->|derived features| Agent_4
+    Agent_4 -->|JSON candidates| F[(Output / Dashboard)]
 ```
 
-### Agent Responsibilities at a Glance
-
-| Agent | Role | Key Outputs |
-|---|---|---|
-| **Data Ingestion Agent** | Fetch & Normalize | Unified market state object; historical data store |
-| **Event Detection Agent** | Supply & Geo Signals | Scored supply disruptions, outages, chokepoints |
-| **Feature Generation Agent** | Derived Signal Computation | Volatility gaps, curve steepness, shock probability, etc. |
-| **Strategy Evaluation Agent** | Opportunity Ranking | Ranked candidates with edge scores and signal references |
-
-### In-Scope Instruments (MVP)
+### In-Scope Instruments
 
 | Category | Instruments |
 |---|---|
@@ -82,7 +75,7 @@ flowchart LR
 | Put Spread | `put_spread` |
 | Calendar Spread | `calendar_spread` |
 
-> **Out of scope (MVP):** Exotic or multi-legged strategies, regional refined product pricing (OPIS), and automated trade execution.
+> **Advisory only.** Automated trade execution is explicitly out of scope. All output is for informational and analytical purposes.
 
 ---
 
@@ -92,36 +85,45 @@ flowchart LR
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| Operating System | Linux, macOS, or Windows (WSL recommended) |
+| Python | 3.10 or later |
+| OS | Linux, macOS, or Windows (WSL recommended) |
 | RAM | 2 GB |
-| Disk | 10 GB free (for 6–12 months of historical data) |
-| Network | Outbound HTTPS access to all data source APIs |
+| Disk | 10 GB (for 6–12 months of historical data) |
+| Deployment target | Local machine, single VM, or container |
 
-### Required Knowledge
+### Required Tools
 
-- Comfortable running Python scripts and CLI commands
-- Familiarity with virtual environments (`venv` or `conda`)
-- Basic understanding of options trading concepts (IV, straddles, spreads)
+```bash
+# Verify Python version
+python --version   # must be >= 3.10
 
-### API Accounts
+# Verify pip
+pip --version
 
-Register for the following free (or free-tier) services before proceeding. All are zero- or low-cost.
+# Recommended: create an isolated environment
+python -m venv .venv
+source .venv/bin/activate        # macOS / Linux
+.venv\Scripts\activate           # Windows PowerShell
+```
 
-| Service | Used For | Cost | Sign-Up URL |
+### External API Accounts
+
+Obtain free-tier credentials from each provider before proceeding. All listed sources are free or low-cost.
+
+| Data Layer | Provider | Registration URL | Notes |
 |---|---|---|---|
-| Alpha Vantage | WTI / Brent crude prices | Free | https://www.alphavantage.co |
-| Yahoo Finance / yfinance | ETF, equity, options data | Free | *(no account needed for yfinance)* |
-| Polygon.io | Options chains (fallback) | Free tier | https://polygon.io |
-| EIA API | Inventory & refinery data | Free | https://www.eia.gov/opendata |
-| GDELT | News & geopolitical events | Free | https://www.gdeltproject.org |
-| NewsAPI | News headlines | Free tier | https://newsapi.org |
-| SEC EDGAR | Insider trading filings | Free | https://www.sec.gov/developer |
-| Quiver Quant | Insider conviction scores | Free/Limited | https://www.quiverquant.com |
-| MarineTraffic | Tanker shipping data | Free tier | https://www.marinetraffic.com |
-| VesselFinder | Tanker flows (fallback) | Free tier | https://www.vesselfinder.com |
-| Reddit API | Narrative / sentiment | Free | https://www.reddit.com/dev/api |
-| Stocktwits API | Retail sentiment | Free | https://api.stocktwits.com |
+| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free key; minutes cadence |
+| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free tier |
+| ETF / Equity Prices | yfinance (Yahoo) | No key required | Library-level access |
+| Options Chains | Polygon.io | https://polygon.io | Free tier; daily delay |
+| Supply / Inventory | EIA API | https://www.eia.gov/opendata | Free; weekly updates |
+| News & Geo Events | NewsAPI | https://newsapi.org | Free tier |
+| News & Geo Events (alt) | GDELT | https://www.gdeltproject.org | No key; public dataset |
+| Insider Activity | SEC EDGAR | https://efts.sec.gov/LATEST/search-index | No key required |
+| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free limited tier |
+| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
+| Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free OAuth app |
+| Sentiment (alt) | Stocktwits | https://api.stocktwits.com | Free public API |
 
 ---
 
@@ -134,241 +136,254 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Install Dependencies
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate        # Linux / macOS
-# .venv\Scripts\activate.bat    # Windows CMD
-# .venv\Scripts\Activate.ps1   # Windows PowerShell
-```
-
-### 3. Install Dependencies
-
-```bash
-pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 3. Configure Environment Variables
 
-The pipeline is configured entirely through environment variables. Copy the provided template and fill in your credentials:
+All runtime configuration is supplied via environment variables. Copy the provided template and populate each value:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set each variable as described in the table below.
+Then edit `.env` with your credentials:
 
-#### Complete Environment Variable Reference
+```bash
+# .env
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+METALPRICE_API_KEY=your_metalprice_key
+POLYGON_API_KEY=your_polygon_key
+EIA_API_KEY=your_eia_key
+NEWS_API_KEY=your_newsapi_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-options-agent/1.0
+QUIVER_QUANT_API_KEY=your_quiver_key
+MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
+```
+
+#### Full Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| **Data Ingestion** | | | |
-| `ALPHA_VANTAGE_API_KEY` | ✅ | — | API key for crude price feeds (WTI, Brent) |
-| `POLYGON_API_KEY` | ⚠️ | — | Polygon.io key; used as options chain fallback when Yahoo Finance is unavailable |
-| `EIA_API_KEY` | ✅ | — | EIA Open Data API key for inventory and refinery utilization |
-| `MARKET_DATA_REFRESH_INTERVAL_SECONDS` | ❌ | `60` | Polling interval for minute-level market data feeds |
-| `OPTIONS_DATA_REFRESH_INTERVAL_SECONDS` | ❌ | `86400` | Polling interval for options chain data (daily by default) |
-| `EIA_REFRESH_INTERVAL_SECONDS` | ❌ | `604800` | Polling interval for EIA data (weekly by default) |
-| **Event Detection** | | | |
-| `NEWSAPI_KEY` | ✅ | — | NewsAPI key for energy headline ingestion |
-| `GDELT_ENABLED` | ❌ | `true` | Set to `false` to disable GDELT event monitoring |
-| `EVENT_CONFIDENCE_THRESHOLD` | ❌ | `0.5` | Minimum confidence score `[0.0–1.0]` for an event to be forwarded to feature generation |
-| **Feature Generation** | | | |
-| `QUIVER_QUANT_API_KEY` | ⚠️ | — | Quiver Quant key for insider conviction scores (optional; falls back to raw EDGAR) |
-| `REDDIT_CLIENT_ID` | ⚠️ | — | Reddit API client ID for narrative velocity computation |
-| `REDDIT_CLIENT_SECRET` | ⚠️ | — | Reddit API client secret |
-| `REDDIT_USER_AGENT` | ⚠️ | — | Reddit API user-agent string, e.g. `energy-agent/1.0` |
-| `STOCKTWITS_ENABLED` | ❌ | `true` | Set to `false` to disable Stocktwits sentiment ingestion |
-| `MARINE_TRAFFIC_API_KEY` | ⚠️ | — | MarineTraffic API key for tanker flow data |
-| **Strategy Evaluation** | | | |
-| `EDGE_SCORE_MIN_THRESHOLD` | ❌ | `0.0` | Candidates with an edge score below this value are excluded from output |
-| `MAX_CANDIDATES_OUTPUT` | ❌ | `20` | Maximum number of ranked candidates written per pipeline run |
-| `TARGET_EXPIRATION_DAYS` | ❌ | `30` | Default target expiration window (calendar days) for generated candidates |
-| **Storage & Output** | | | |
-| `DATA_STORE_PATH` | ❌ | `./data` | Local directory for raw and derived historical data |
-| `HISTORICAL_RETENTION_DAYS` | ❌ | `365` | Number of days of historical data to retain (minimum 180 recommended) |
-| `OUTPUT_PATH` | ❌ | `./output` | Directory where JSON output files are written |
-| `OUTPUT_FORMAT` | ❌ | `json` | Output format; currently only `json` is supported |
-| **Deployment** | | | |
-| `LOG_LEVEL` | ❌ | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_MODE` | ❌ | `continuous` | `continuous` (polling loop) or `once` (single run and exit) |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for WTI/Brent spot and futures prices (minutes cadence) |
+| `METALPRICE_API_KEY` | No | — | Alternative crude price source; used as fallback |
+| `POLYGON_API_KEY` | Yes | — | Options chain data: strike, expiry, IV, volume (daily) |
+| `EIA_API_KEY` | Yes | — | EIA inventory and refinery utilization data (weekly) |
+| `NEWS_API_KEY` | Yes | — | NewsAPI key for energy disruption and geopolitical headlines |
+| `GDELT_ENABLED` | No | `true` | Set to `false` to disable GDELT ingestion |
+| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth app client ID for sentiment ingestion |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth app client secret |
+| `REDDIT_USER_AGENT` | No | `energy-options-agent/1.0` | Reddit API user agent string |
+| `QUIVER_QUANT_API_KEY` | No | — | Quiver Quant key for insider conviction data |
+| `MARINE_TRAFFIC_API_KEY` | No | — | MarineTraffic free-tier key for tanker flow data |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
+| `HISTORICAL_DATA_DIR` | No | `./data` | Root directory for raw and derived historical data |
+| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (minimum 180 for backtesting) |
+| `MARKET_DATA_POLL_INTERVAL_SECONDS` | No | `60` | Polling interval for minutes-cadence market data feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `PIPELINE_PHASE` | No | `1` | Active MVP phase (1–3). Controls which agents and signals are enabled |
 
-> **Legend:** ✅ Required · ⚠️ Recommended (pipeline degrades gracefully without it) · ❌ Optional
+> **Tip — missing optional keys:** The pipeline is designed to tolerate delayed or missing data without failing. If an optional key (e.g., `MARINE_TRAFFIC_API_KEY`) is absent, the corresponding signal layer is skipped and a warning is logged. Required keys will raise a `ConfigurationError` at startup.
 
-#### Example `.env` File
-
-```dotenv
-# --- Data Ingestion ---
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key_here
-POLYGON_API_KEY=your_polygon_key_here
-EIA_API_KEY=your_eia_key_here
-MARKET_DATA_REFRESH_INTERVAL_SECONDS=60
-OPTIONS_DATA_REFRESH_INTERVAL_SECONDS=86400
-EIA_REFRESH_INTERVAL_SECONDS=604800
-
-# --- Event Detection ---
-NEWSAPI_KEY=your_newsapi_key_here
-GDELT_ENABLED=true
-EVENT_CONFIDENCE_THRESHOLD=0.5
-
-# --- Feature Generation ---
-QUIVER_QUANT_API_KEY=your_quiver_key_here
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=energy-agent/1.0
-STOCKTWITS_ENABLED=true
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key_here
-
-# --- Strategy Evaluation ---
-EDGE_SCORE_MIN_THRESHOLD=0.25
-MAX_CANDIDATES_OUTPUT=20
-TARGET_EXPIRATION_DAYS=30
-
-# --- Storage & Output ---
-DATA_STORE_PATH=./data
-HISTORICAL_RETENTION_DAYS=365
-OUTPUT_PATH=./output
-OUTPUT_FORMAT=json
-
-# --- Deployment ---
-LOG_LEVEL=INFO
-PIPELINE_MODE=continuous
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation script once before the first pipeline execution. It creates the directory structure and seeds the historical data store.
+### 4. Verify Configuration
 
 ```bash
-python -m agent.init
+python -m agent.cli verify-config
 ```
 
 Expected output:
 
 ```
-[INFO] Data store initialised at ./data
-[INFO] Output directory created at ./output
-[INFO] Schema validation: OK
-[INFO] Ready to run.
+[OK]  ALPHA_VANTAGE_API_KEY  set
+[OK]  POLYGON_API_KEY        set
+[OK]  EIA_API_KEY            set
+[OK]  NEWS_API_KEY           set
+[WARN] MARINE_TRAFFIC_API_KEY not set — shipping signals disabled
+[WARN] QUIVER_QUANT_API_KEY  not set — insider signals disabled
+Configuration valid. Active phase: 1
+```
+
+### 5. Initialise the Data Store
+
+Run the initialisation command to create the local directory structure and, if configured, seed the historical data store:
+
+```bash
+python -m agent.cli init
+```
+
+```
+Creating data directories...
+  ./data/raw/prices
+  ./data/raw/options
+  ./data/raw/events
+  ./data/derived
+  ./output
+Initialisation complete.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Quick Start — Single Run
+### Pipeline Execution Flow
 
-To execute all four agents once and write output to `./output`, set `PIPELINE_MODE=once` in your `.env` (or override inline):
+```mermaid
+sequenceDiagram
+    participant CLI as CLI / Scheduler
+    participant DIA as Agent 1<br/>Data Ingestion
+    participant EDA as Agent 2<br/>Event Detection
+    participant FGA as Agent 3<br/>Feature Generation
+    participant SEA as Agent 4<br/>Strategy Evaluation
+    participant OUT as Output (JSON)
+
+    CLI->>DIA: trigger run
+    DIA->>DIA: fetch crude, ETF, equity, options data
+    DIA->>DIA: normalise → market state object
+    DIA-->>EDA: market state object
+    EDA->>EDA: scan news, GDELT, shipping feeds
+    EDA->>EDA: score events (confidence, intensity)
+    EDA-->>FGA: scored events + market state
+    FGA->>FGA: compute volatility gaps, curve steepness,\nsector dispersion, narrative velocity,\ninsider conviction, supply shock prob.
+    FGA-->>SEA: derived features store
+    SEA->>SEA: evaluate option structures\nrank by edge score
+    SEA-->>OUT: write JSON candidates
+    OUT-->>CLI: run complete
+```
+
+### Single Run (One-Shot)
+
+Execute all four agents sequentially for a single evaluation cycle:
 
 ```bash
-PIPELINE_MODE=once python -m agent.pipeline
+python -m agent.cli run
 ```
 
-### Continuous Mode (Default)
+### Continuous Mode (Polling)
 
-In continuous mode the pipeline polls market data on the configured intervals without manual intervention:
+Run the pipeline on a repeating schedule. Market data refreshes at the interval defined by `MARKET_DATA_POLL_INTERVAL_SECONDS` (default: 60 s). Slower feeds (EIA, EDGAR) update on their own daily/weekly schedules:
 
 ```bash
-python -m agent.pipeline
+python -m agent.cli run --continuous
 ```
 
-The agents execute in sequence on each polling cycle:
+To stop: `Ctrl+C`. The pipeline completes the current cycle before exiting.
 
-```
-[INFO] Cycle 1 starting at 2026-03-15T09:30:00Z
-[INFO] [DataIngestionAgent]     Fetching crude prices ... OK
-[INFO] [DataIngestionAgent]     Fetching ETF/equity prices ... OK
-[INFO] [DataIngestionAgent]     Fetching options chains ... OK
-[INFO] [EventDetectionAgent]    Processing GDELT feed ... 3 events detected
-[INFO] [EventDetectionAgent]    Processing NewsAPI feed ... 1 event detected
-[INFO] [FeatureGenerationAgent] Computing volatility gaps ... OK
-[INFO] [FeatureGenerationAgent] Computing supply shock probability ... OK
-[INFO] [StrategyEvaluationAgent] Evaluating structures ... 5 candidates generated
-[INFO] Output written to ./output/candidates_20260315T093012Z.json
-[INFO] Cycle 1 complete. Next cycle in 60s.
-```
+### Run Individual Agents
 
-### Running Individual Agents
-
-Each agent can be invoked independently for testing or incremental development:
+Each agent can be run in isolation for development or debugging:
 
 ```bash
-# Run only the Data Ingestion Agent
-python -m agent.ingestion
+# Agent 1: Data Ingestion only
+python -m agent.cli run --agent ingestion
 
-# Run only the Event Detection Agent
-python -m agent.events
+# Agent 2: Event Detection only (requires existing market state)
+python -m agent.cli run --agent event-detection
 
-# Run only the Feature Generation Agent
-python -m agent.features
+# Agent 3: Feature Generation only (requires market state + events)
+python -m agent.cli run --agent feature-generation
 
-# Run only the Strategy Evaluation Agent
-python -m agent.strategy
+# Agent 4: Strategy Evaluation only (requires derived features store)
+python -m agent.cli run --agent strategy-evaluation
 ```
 
-> **Note:** Agents downstream of Data Ingestion read from the shared market state object written to `DATA_STORE_PATH`. Run ingestion at least once before running downstream agents in isolation.
+### Selecting a Pipeline Phase
 
-### Running with Docker
-
-A single-container deployment is supported for local or cloud VM use:
+Set `PIPELINE_PHASE` in `.env`, or override at runtime with the `--phase` flag:
 
 ```bash
-# Build the image
-docker build -t energy-options-agent:1.0 .
+# Phase 1: Core market signals + options (default)
+python -m agent.cli run --phase 1
 
-# Run with your .env file mounted
-docker run --env-file .env \
-           -v $(pwd)/data:/app/data \
-           -v $(pwd)/output:/app/output \
-           energy-options-agent:1.0
+# Phase 2: Adds EIA supply data + GDELT/NewsAPI event detection
+python -m agent.cli run --phase 2
+
+# Phase 3: Adds insider, sentiment, and shipping signals
+python -m agent.cli run --phase 3
 ```
 
-### Scheduling (Cron Example)
+| Phase | Name | Key Additions |
+|---|---|---|
+| 1 | Core Market Signals & Options | WTI/Brent prices, USO/XLE, IV surface, long straddles, call/put spreads |
+| 2 | Supply & Event Augmentation | EIA inventory/refinery, GDELT/NewsAPI events, supply disruption indices |
+| 3 | Alternative / Contextual Signals | Insider trades (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), tanker shipping data |
+| 4 | High-Fidelity Enhancements | Deferred — exotic structures, automated execution (see [Future Considerations](#future-considerations)) |
 
-To run a single pipeline pass on a schedule, set `PIPELINE_MODE=once` and use cron:
+### Logging
 
-```cron
-# Run every weekday at 09:00 and 15:00 UTC
-0 9,15 * * 1-5 /path/to/.venv/bin/python -m agent.pipeline >> /var/log/energy-agent.log 2>&1
+Logs are written to `stdout` and to `./logs/agent.log`. To increase verbosity:
+
+```bash
+LOG_LEVEL=DEBUG python -m agent.cli run
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output File Location
+### Output Location
 
-Each pipeline run writes a timestamped JSON file to `OUTPUT_PATH`:
+After each run, candidate files are written to `OUTPUT_DIR` (default: `./output`):
 
 ```
-./output/candidates_20260315T093012Z.json
+./output/
+  candidates_2026-03-15T14:30:00Z.json
+  candidates_2026-03-15T15:30:00Z.json
+  ...
 ```
 
 ### Output Schema
 
-Each file contains a JSON array of candidate objects. Every candidate has the following fields:
+Each JSON file contains an array of strategy candidates. Every candidate object has the following fields:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their assessed levels |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum string | One of `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signals and their qualitative state |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Example Output
+### Example Candidate
 
 ```json
-[
-  {
-    "instrument": "USO",
-    "structure": "long_straddle",
-    "expiration": 30,
-    "edge_score": 0.47,
-    "signals": {
-      "tanker_disruption_index": "high",
-      "volatility_gap": "positive",
-      "narrative_velocity
+{
+  "instrument": "USO",
+  "structure": "long_straddle",
+  "expiration": 30,
+  "edge_score": 0.47,
+  "signals": {
+    "tanker_disruption_index": "high",
+    "volatility_gap": "positive",
+    "narrative_velocity": "rising"
+  },
+  "generated_at": "2026-03-15T14:30:00Z"
+}
+```
+
+### Reading the Edge Score
+
+| Edge Score Range | Interpretation |
+|---|---|
+| `0.75 – 1.00` | Strong signal confluence — multiple independent signals aligned |
+| `0.50 – 0.74` | Moderate confluence — worth monitoring; confirm with additional research |
+| `0.25 – 0.49` | Weak confluence — early or thin signal; treat as a watch-list item |
+| `0.00 – 0.24` | Low confluence — insufficient signal strength; generally not actionable |
+
+> The edge score is a composite heuristic, not a probability of profit. It reflects the degree to which available signals agree that a mispricing opportunity may exist.
+
+### Reading the Signals Map
+
+Each key in the `signals` object corresponds to a derived feature computed by Agent 3. Common signals and their qualitative states are:
+
+| Signal Key | Possible Values | What It Means |
+|---|---|---|
+| `volatility_gap` | `positive`, `neutral`, `negative` | Realized vol significantly above (`positive`) or below (`negative`) implied vol |
+| `narrative_velocity` | `rising`, `stable`, `falling` | Rate of acceleration of energy-related headlines |
+| `tanker_disruption_index` | `high`, `medium`, `low` | Severity of detected tanker chokepoint or shipping disruption events |
+|

--- a/src/agents/alternative_data/alternative_data_agent.py
+++ b/src/agents/alternative_data/alternative_data_agent.py
@@ -1,0 +1,310 @@
+"""
+Alternative Data Agent — Phase 3 fetch functions.
+
+Fetches alternative signals for the energy options opportunity agent:
+  - fetch_edgar_insider_trades: SEC EDGAR Form 4 insider trade filings (issue #149)
+
+ESOD constraints: @with_retry() on all external API calls, Pydantic boundary
+models, type hints on all public functions, WARNING logs for missing/malformed
+records, no silent failures.
+
+EDGAR API notes:
+  - Full-text search: https://efts.sec.gov/LATEST/search-index
+  - Archives:         https://www.sec.gov/Archives/edgar/data
+  - No API key required; User-Agent header mandatory (EDGAR Terms of Service).
+  - WTI/BZ (crude futures) have no equity insider filings — returns empty list.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import logging
+from typing import Any
+from xml.etree import ElementTree as ET
+
+import requests
+
+from src.agents.alternative_data.models import InsiderTrade
+from src.core.retry import with_retry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_EFTS_SEARCH_URL = "https://efts.sec.gov/LATEST/search-index"
+_ARCHIVES_BASE = "https://www.sec.gov/Archives/edgar/data"
+
+# EDGAR Terms of Service require a descriptive User-Agent
+_USER_AGENT = "EnergyOptionsOpportunityAgent research@energy-options-agent.example"
+
+# How many recent days to scan for Form 4 filings
+_LOOKBACK_DAYS = 90
+
+# Maximum EFTS hits to process per instrument (avoids runaway pagination)
+_MAX_HITS_PER_INSTRUMENT = 10
+
+# Form 4 transaction codes → trade_type values (matches DB CHECK constraint)
+_TX_CODE_MAP: dict[str, str] = {
+    "P": "buy",  # Open-market purchase
+    "S": "sell",  # Open-market sale
+    "A": "grant",  # Award / grant
+    "M": "exercise",  # Option exercise
+}
+
+# ---------------------------------------------------------------------------
+# Public fetch function
+# ---------------------------------------------------------------------------
+
+
+@with_retry()
+def fetch_edgar_insider_trades(instruments: list[str]) -> list[InsiderTrade]:
+    """
+    Fetch recent Form 4 insider trade filings for energy instruments.
+
+    Searches SEC EDGAR full-text search API (free, no key required) for
+    Form 4 filings mentioning each ticker. Downloads and parses the Form 4
+    XML to extract trade details.
+
+    Instruments with no equity insider filings (e.g. WTI crude futures)
+    silently return zero records. Missing or malformed individual filings
+    are logged as WARNING and skipped — the function never raises for
+    per-filing errors.
+
+    Args:
+        instruments: Ticker symbols to search (e.g. ["XOM", "CVX", "USO", "XLE"]).
+
+    Returns:
+        List of InsiderTrade records across all instruments, ordered by
+        instrument then most-recent-first as returned by EDGAR.
+
+    Raises:
+        requests.exceptions.RequestException: Propagated on network failure
+            so tenacity can retry the full call.
+    """
+    all_trades: list[InsiderTrade] = []
+    start_dt = (datetime.now(tz=UTC) - timedelta(days=_LOOKBACK_DAYS)).strftime("%Y-%m-%d")
+
+    for ticker in instruments:
+        try:
+            hits = _efts_search(ticker, start_dt)
+        except requests.exceptions.RequestException:
+            raise  # let tenacity retry
+        except Exception:
+            logger.warning("fetch_edgar_insider_trades: EFTS search error for ticker=%s", ticker)
+            continue
+
+        for hit in hits:
+            accession_no: str = hit.get("_id", "")
+            src: dict[str, Any] = hit.get("_source", {})
+            # entity_id is zero-padded CIK (e.g. "0000034088"); strip leading zeros
+            raw_cik = str(src.get("entity_id", "")).lstrip("0")
+            if not accession_no or not raw_cik:
+                logger.warning(
+                    "fetch_edgar_insider_trades: missing accession_no or CIK in "
+                    "EFTS hit for ticker=%s",
+                    ticker,
+                )
+                continue
+
+            try:
+                xml_text = _fetch_form4_xml(raw_cik, accession_no)
+            except requests.exceptions.RequestException:
+                raise  # let tenacity retry
+            except Exception:
+                logger.warning(
+                    "fetch_edgar_insider_trades: failed to fetch XML for " "ticker=%s accession=%s",
+                    ticker,
+                    accession_no,
+                )
+                continue
+
+            if xml_text is None:
+                logger.warning(
+                    "fetch_edgar_insider_trades: no XML document found for "
+                    "ticker=%s accession=%s",
+                    ticker,
+                    accession_no,
+                )
+                continue
+
+            try:
+                trades = _parse_form4_xml(xml_text, ticker)
+                all_trades.extend(trades)
+            except Exception:
+                logger.warning(
+                    "fetch_edgar_insider_trades: failed to parse Form 4 XML for "
+                    "ticker=%s accession=%s",
+                    ticker,
+                    accession_no,
+                )
+
+    return all_trades
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _efts_search(ticker: str, start_dt: str) -> list[dict[str, Any]]:
+    """
+    Search EDGAR full-text search for Form 4 filings matching ticker.
+
+    Args:
+        ticker:   Ticker symbol (e.g. "XOM").
+        start_dt: ISO date string (YYYY-MM-DD) for the lookback window start.
+
+    Returns:
+        Raw EFTS hit list (up to _MAX_HITS_PER_INSTRUMENT entries).
+
+    Raises:
+        requests.exceptions.RequestException: On HTTP or network failure.
+    """
+    resp = requests.get(
+        _EFTS_SEARCH_URL,
+        params={
+            "q": f'"{ticker}"',
+            "forms": "4",
+            "dateRange": "custom",
+            "startdt": start_dt,
+        },
+        headers={"User-Agent": _USER_AGENT},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    data: dict[str, Any] = resp.json()
+    hits: list[dict[str, Any]] = data.get("hits", {}).get("hits", [])
+    return hits[:_MAX_HITS_PER_INSTRUMENT]
+
+
+def _fetch_form4_xml(cik: str, accession_no: str) -> str | None:
+    """
+    Download Form 4 XML for a single EDGAR filing.
+
+    Fetches the filing index JSON to discover the XML document filename,
+    then downloads the XML document. Returns None if no .xml document
+    is listed in the filing index.
+
+    Args:
+        cik:          CIK without leading zeros (e.g. "34088").
+        accession_no: Hyphenated accession number (e.g. "0001610717-24-000004").
+
+    Returns:
+        XML text string, or None if no XML document found in the index.
+
+    Raises:
+        requests.exceptions.RequestException: On HTTP or network failure.
+    """
+    accession_nodash = accession_no.replace("-", "")
+    index_url = f"{_ARCHIVES_BASE}/{cik}/{accession_nodash}/{accession_nodash}-index.json"
+
+    index_resp = requests.get(index_url, headers={"User-Agent": _USER_AGENT}, timeout=30)
+    index_resp.raise_for_status()
+    index_data: dict[str, Any] = index_resp.json()
+
+    items: list[dict[str, Any]] = index_data.get("directory", {}).get("item", [])
+    xml_name: str | None = next(
+        (item["name"] for item in items if item.get("name", "").endswith(".xml")),
+        None,
+    )
+    if xml_name is None:
+        return None
+
+    xml_url = f"{_ARCHIVES_BASE}/{cik}/{accession_nodash}/{xml_name}"
+    xml_resp = requests.get(xml_url, headers={"User-Agent": _USER_AGENT}, timeout=30)
+    xml_resp.raise_for_status()
+    return xml_resp.text
+
+
+def _parse_form4_xml(xml_text: str, instrument: str) -> list[InsiderTrade]:
+    """
+    Parse Form 4 XML into InsiderTrade records.
+
+    Extracts nonDerivativeTransaction elements only. Transactions with
+    unmapped transaction codes (e.g. "F" for tax withholding) are silently
+    skipped. Malformed dates or amounts log a WARNING and skip the transaction.
+
+    Args:
+        xml_text:   Raw Form 4 XML string.
+        instrument: Ticker symbol to attach to each InsiderTrade.
+
+    Returns:
+        List of InsiderTrade records. Empty list on parse error or no
+        matching transactions.
+    """
+    try:
+        root = ET.fromstring(xml_text)  # noqa: S314 — XML from SEC.gov (trusted source)
+    except ET.ParseError as exc:
+        logger.warning(
+            "fetch_edgar_insider_trades: Form 4 XML parse error for %s: %s",
+            instrument,
+            exc,
+        )
+        return []
+
+    officer_name: str | None = None
+    owner_elem = root.find(".//reportingOwner/reportingOwnerId/rptOwnerName")
+    if owner_elem is not None and owner_elem.text:
+        officer_name = owner_elem.text.strip()
+
+    trades: list[InsiderTrade] = []
+    for tx in root.findall(".//nonDerivativeTable/nonDerivativeTransaction"):
+        code_elem = tx.find(".//transactionCoding/transactionCode")
+        date_elem = tx.find(".//transactionDate/value")
+
+        if code_elem is None or date_elem is None:
+            logger.warning(
+                "fetch_edgar_insider_trades: missing code or date in Form 4 "
+                "transaction for instrument=%s",
+                instrument,
+            )
+            continue
+
+        trade_type: str | None = _TX_CODE_MAP.get(code_elem.text or "")
+        if trade_type is None:
+            # Unknown/unsupported transaction code (F, J, etc.) — skip silently
+            continue
+
+        try:
+            trade_date = datetime.strptime((date_elem.text or "").strip(), "%Y-%m-%d").replace(
+                tzinfo=UTC
+            )
+        except ValueError:
+            logger.warning(
+                "fetch_edgar_insider_trades: invalid transactionDate %r for " "instrument=%s",
+                date_elem.text,
+                instrument,
+            )
+            continue
+
+        shares: int | None = None
+        shares_elem = tx.find(".//transactionAmounts/transactionShares/value")
+        if shares_elem is not None and shares_elem.text:
+            try:
+                shares = int(float(shares_elem.text))
+            except ValueError:
+                pass
+
+        value_usd: float | None = None
+        price_elem = tx.find(".//transactionAmounts/transactionPricePerShare/value")
+        if shares is not None and price_elem is not None and price_elem.text:
+            try:
+                value_usd = round(shares * float(price_elem.text), 2)
+            except ValueError:
+                pass
+
+        trades.append(
+            InsiderTrade(
+                instrument=instrument,
+                trade_date=trade_date,
+                trade_type=trade_type,
+                shares=shares,
+                value_usd=value_usd,
+                officer_name=officer_name,
+                source="edgar",
+            )
+        )
+
+    return trades

--- a/src/agents/alternative_data/alternative_data_agent.py
+++ b/src/agents/alternative_data/alternative_data_agent.py
@@ -91,7 +91,7 @@ def fetch_edgar_insider_trades(instruments: list[str]) -> list[InsiderTrade]:
             hits = _efts_search(ticker, start_dt)
         except requests.exceptions.RequestException:
             raise  # let tenacity retry
-        except Exception:
+        except (ValueError, KeyError):
             logger.warning("fetch_edgar_insider_trades: EFTS search error for ticker=%s", ticker)
             continue
 
@@ -112,7 +112,7 @@ def fetch_edgar_insider_trades(instruments: list[str]) -> list[InsiderTrade]:
                 xml_text = _fetch_form4_xml(raw_cik, accession_no)
             except requests.exceptions.RequestException:
                 raise  # let tenacity retry
-            except Exception:
+            except (ValueError, KeyError):
                 logger.warning(
                     "fetch_edgar_insider_trades: failed to fetch XML for " "ticker=%s accession=%s",
                     ticker,
@@ -129,16 +129,10 @@ def fetch_edgar_insider_trades(instruments: list[str]) -> list[InsiderTrade]:
                 )
                 continue
 
-            try:
-                trades = _parse_form4_xml(xml_text, ticker)
-                all_trades.extend(trades)
-            except Exception:
-                logger.warning(
-                    "fetch_edgar_insider_trades: failed to parse Form 4 XML for "
-                    "ticker=%s accession=%s",
-                    ticker,
-                    accession_no,
-                )
+            # _parse_form4_xml handles ET.ParseError internally and returns [].
+            # Unexpected exceptions propagate so the caller (tenacity) can retry.
+            trades = _parse_form4_xml(xml_text, ticker)
+            all_trades.extend(trades)
 
     return all_trades
 

--- a/src/agents/alternative_data/models.py
+++ b/src/agents/alternative_data/models.py
@@ -1,0 +1,41 @@
+"""
+Pydantic models for the Alternative Data Agent (Phase 3).
+
+All external feed data must be validated through these models before
+any downstream processing (ESOD Section 6).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+from src.core.compat import StrEnum
+
+
+class TradeType(StrEnum):
+    """Supported insider trade types (matches insider_trades.trade_type CHECK constraint)."""
+
+    BUY = "buy"
+    SELL = "sell"
+    GRANT = "grant"
+    EXERCISE = "exercise"
+
+
+class InsiderTrade(BaseModel):
+    """
+    Validated insider trade record from SEC EDGAR Form 4.
+
+    Maps to the insider_trades table schema (db/schema.sql).
+    Missing or optional fields are allowed to be None — partial
+    filings are persisted rather than dropped (ESOD §6).
+    """
+
+    instrument: str
+    trade_date: datetime
+    trade_type: str
+    shares: int | None = None
+    value_usd: float | None = None
+    officer_name: str | None = None
+    source: str = "edgar"

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -1,0 +1,320 @@
+"""
+Unit tests for fetch_edgar_insider_trades (issue #149).
+
+Tests use mocked HTTP responses — no real EDGAR API calls.
+Integration tests (real network) belong in a separate integration test file.
+
+Coverage:
+  - Happy path: EFTS hit → XML fetch → parse → InsiderTrade records returned
+  - Malformed XML: parse error logged as WARNING, empty list returned
+  - Empty EFTS result: no hits, empty list returned
+  - HTTP error propagates: RequestException raised for tenacity retry
+  - Instrument filter: only specified instruments searched
+  - Unmapped transaction code: skipped silently (no InsiderTrade for "F")
+  - Missing officer name: officer_name=None allowed
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from src.agents.alternative_data.alternative_data_agent import (
+    _efts_search,
+    _parse_form4_xml,
+    fetch_edgar_insider_trades,
+)
+from src.agents.alternative_data.models import InsiderTrade
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EFTS_URL = "https://efts.sec.gov/LATEST/search-index"
+_ARCHIVES_BASE = "https://www.sec.gov/Archives/edgar/data"
+
+
+def _make_efts_response(ticker: str, cik: str = "34088") -> dict:
+    """Minimal EFTS JSON with one Form 4 hit."""
+    return {
+        "hits": {
+            "hits": [
+                {
+                    "_id": "0001610717-24-000004",
+                    "_source": {
+                        "entity_id": cik.zfill(10),
+                        "form_type": "4",
+                        "file_date": "2024-01-17",
+                        "period_of_report": "2024-01-15",
+                    },
+                }
+            ]
+        }
+    }
+
+
+_FILING_INDEX = {
+    "directory": {
+        "item": [
+            {"name": "wf-form4_20240117.xml", "type": "4"},
+            {"name": "wf-form4_20240117.htm", "type": "4"},
+        ]
+    }
+}
+
+_FORM4_XML_BUY = """<?xml version="1.0"?>
+<ownershipDocument>
+  <periodOfReport>2024-01-15</periodOfReport>
+  <reportingOwner>
+    <reportingOwnerId>
+      <rptOwnerName>DOE JOHN</rptOwnerName>
+    </reportingOwnerId>
+  </reportingOwner>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionDate><value>2024-01-15</value></transactionDate>
+      <transactionCoding>
+        <transactionCode>P</transactionCode>
+      </transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>500</value></transactionShares>
+        <transactionPricePerShare><value>110.00</value></transactionPricePerShare>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>"""
+
+_FORM4_XML_SELL = _FORM4_XML_BUY.replace(
+    "<transactionCode>P</transactionCode>",
+    "<transactionCode>S</transactionCode>",
+)
+
+
+def _mock_resp(payload: dict | str, status: int = 200) -> MagicMock:
+    """Return a mock requests.Response with raise_for_status as no-op."""
+    mock = MagicMock()
+    mock.raise_for_status.return_value = None
+    if isinstance(payload, dict):
+        mock.json.return_value = payload
+    else:
+        mock.text = payload
+    return mock
+
+
+def _error_resp(exc_class: type = requests.HTTPError) -> MagicMock:
+    """Return a mock whose raise_for_status raises exc_class."""
+    mock = MagicMock()
+    mock.raise_for_status.side_effect = exc_class("error")
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_form4_xml (pure XML parser — no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestParseForm4Xml:
+    def test_parses_buy_transaction(self) -> None:
+        trades = _parse_form4_xml(_FORM4_XML_BUY, "XOM")
+
+        assert len(trades) == 1
+        t = trades[0]
+        assert t.instrument == "XOM"
+        assert t.trade_type == "buy"
+        assert t.trade_date == datetime(2024, 1, 15, tzinfo=UTC)
+        assert t.shares == 500
+        assert t.value_usd == pytest.approx(55_000.0)
+        assert t.officer_name == "DOE JOHN"
+        assert t.source == "edgar"
+
+    def test_parses_sell_transaction(self) -> None:
+        trades = _parse_form4_xml(_FORM4_XML_SELL, "XOM")
+
+        assert len(trades) == 1
+        assert trades[0].trade_type == "sell"
+
+    def test_malformed_xml_returns_empty_and_logs_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = _parse_form4_xml("<<NOT VALID XML>>", "XOM")
+
+        assert result == []
+        assert any("parse error" in r.message.lower() for r in caplog.records)
+
+    def test_unmapped_transaction_code_skipped(self) -> None:
+        """Transaction code 'F' (tax withholding) is not in the map — silently skipped."""
+        xml = _FORM4_XML_BUY.replace(
+            "<transactionCode>P</transactionCode>",
+            "<transactionCode>F</transactionCode>",
+        )
+        trades = _parse_form4_xml(xml, "XOM")
+        assert trades == []
+
+    def test_missing_officer_name_yields_none(self) -> None:
+        xml = """<?xml version="1.0"?>
+<ownershipDocument>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionDate><value>2024-01-15</value></transactionDate>
+      <transactionCoding><transactionCode>P</transactionCode></transactionCoding>
+      <transactionAmounts>
+        <transactionShares><value>100</value></transactionShares>
+        <transactionPricePerShare><value>50.00</value></transactionPricePerShare>
+      </transactionAmounts>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>"""
+        trades = _parse_form4_xml(xml, "CVX")
+        assert len(trades) == 1
+        assert trades[0].officer_name is None
+
+    def test_invalid_date_skipped_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        xml = _FORM4_XML_BUY.replace(
+            "<value>2024-01-15</value>",
+            "<value>NOT-A-DATE</value>",
+        )
+        with caplog.at_level(logging.WARNING):
+            trades = _parse_form4_xml(xml, "XOM")
+
+        assert trades == []
+        assert any("transactiondate" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _efts_search (one HTTP call)
+# ---------------------------------------------------------------------------
+
+
+class TestEftsSearch:
+    def test_returns_hits_list(self) -> None:
+        with patch("requests.get", return_value=_mock_resp(_make_efts_response("XOM"))) as mock_get:
+            hits = _efts_search("XOM", "2024-01-01")
+
+        assert len(hits) == 1
+        assert hits[0]["_id"] == "0001610717-24-000004"
+        # Verify User-Agent header was sent
+        _, kwargs = mock_get.call_args
+        assert "User-Agent" in kwargs.get("headers", {})
+
+    def test_empty_hits_returns_empty_list(self) -> None:
+        empty = {"hits": {"hits": []}}
+        with patch("requests.get", return_value=_mock_resp(empty)):
+            hits = _efts_search("WTI", "2024-01-01")
+
+        assert hits == []
+
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("TENACITY_MAX_RETRIES", "1")
+        with patch("requests.get", return_value=_error_resp(requests.HTTPError)):
+            with pytest.raises(requests.HTTPError):
+                _efts_search("XOM", "2024-01-01")
+
+
+# ---------------------------------------------------------------------------
+# Tests: fetch_edgar_insider_trades (full integration of helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEdgarInsiderTrades:
+    def _make_get_side_effect(
+        self,
+        efts_payload: dict,
+        index_payload: dict,
+        xml_text: str,
+    ) -> list[MagicMock]:
+        """Three sequential mock responses: EFTS → index → XML."""
+        efts_resp = _mock_resp(efts_payload)
+        index_resp = _mock_resp(index_payload)
+        xml_resp = _mock_resp({})
+        xml_resp.text = xml_text
+        xml_resp.raise_for_status.return_value = None
+        return [efts_resp, index_resp, xml_resp]
+
+    def test_happy_path_returns_insider_trades(self) -> None:
+        side_effects = self._make_get_side_effect(
+            _make_efts_response("XOM"), _FILING_INDEX, _FORM4_XML_BUY
+        )
+        with patch("requests.get", side_effect=side_effects):
+            trades = fetch_edgar_insider_trades(["XOM"])
+
+        assert len(trades) == 1
+        assert isinstance(trades[0], InsiderTrade)
+        assert trades[0].instrument == "XOM"
+        assert trades[0].trade_type == "buy"
+        assert trades[0].shares == 500
+
+    def test_empty_efts_returns_empty_list(self) -> None:
+        empty_efts = {"hits": {"hits": []}}
+        with patch("requests.get", return_value=_mock_resp(empty_efts)):
+            trades = fetch_edgar_insider_trades(["WTI"])
+
+        assert trades == []
+
+    def test_only_requested_instruments_searched(self) -> None:
+        """Verify EFTS is only called for the given tickers."""
+        empty_efts = {"hits": {"hits": []}}
+        with patch("requests.get", return_value=_mock_resp(empty_efts)) as mock_get:
+            fetch_edgar_insider_trades(["XOM"])
+
+        # Only one EFTS call for XOM — not for CVX, USO, etc.
+        assert mock_get.call_count == 1
+        call_url = mock_get.call_args[0][0]
+        assert "efts.sec.gov" in call_url
+
+    def test_malformed_xml_logs_warning_and_continues(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        efts_resp = _mock_resp(_make_efts_response("XOM"))
+        index_resp = _mock_resp(_FILING_INDEX)
+        xml_resp = MagicMock()
+        xml_resp.raise_for_status.return_value = None
+        xml_resp.text = "<<BROKEN XML>>"
+
+        with patch("requests.get", side_effect=[efts_resp, index_resp, xml_resp]):
+            with caplog.at_level(logging.WARNING):
+                trades = fetch_edgar_insider_trades(["XOM"])
+
+        assert trades == []
+
+    def test_http_error_on_efts_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Network failure on EFTS search should propagate for tenacity to retry."""
+        monkeypatch.setenv("TENACITY_MAX_RETRIES", "1")
+        with patch(
+            "requests.get",
+            side_effect=requests.ConnectionError("timeout"),
+        ):
+            with pytest.raises(requests.ConnectionError):
+                fetch_edgar_insider_trades(["XOM"])
+
+    def test_multiple_instruments_all_searched(self) -> None:
+        """Each instrument triggers its own EFTS call."""
+        empty_efts = {"hits": {"hits": []}}
+        with patch("requests.get", return_value=_mock_resp(empty_efts)) as mock_get:
+            fetch_edgar_insider_trades(["XOM", "CVX", "USO"])
+
+        # 3 EFTS calls, one per instrument
+        assert mock_get.call_count == 3
+
+    def test_no_xml_document_in_index_skips_filing(self, caplog: pytest.LogCaptureFixture) -> None:
+        import logging
+
+        no_xml_index = {"directory": {"item": [{"name": "form4.htm", "type": "4"}]}}
+        efts_resp = _mock_resp(_make_efts_response("CVX", cik="93410"))
+        index_resp = _mock_resp(no_xml_index)
+
+        with patch("requests.get", side_effect=[efts_resp, index_resp]):
+            with caplog.at_level(logging.WARNING):
+                trades = fetch_edgar_insider_trades(["CVX"])
+
+        assert trades == []
+        assert any("no xml" in r.message.lower() for r in caplog.records)

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -267,7 +267,7 @@ class TestFetchEdgarInsiderTrades:
         # Only one EFTS call for XOM — not for CVX, USO, etc.
         assert mock_get.call_count == 1
         call_url = mock_get.call_args[0][0]
-        assert "efts.sec.gov" in call_url
+        assert call_url.startswith("https://efts.sec.gov")
 
     def test_malformed_xml_logs_warning_and_continues(
         self, caplog: pytest.LogCaptureFixture

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 import requests
@@ -267,7 +268,7 @@ class TestFetchEdgarInsiderTrades:
         # Only one EFTS call for XOM — not for CVX, USO, etc.
         assert mock_get.call_count == 1
         call_url = mock_get.call_args[0][0]
-        assert call_url.startswith("https://efts.sec.gov")
+        assert urlparse(call_url).netloc == "efts.sec.gov"
 
     def test_malformed_xml_logs_warning_and_continues(
         self, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
## Summary

- Implements `fetch_edgar_insider_trades(instruments: list[str]) -> list[InsiderTrade]` in `src/agents/alternative_data/alternative_data_agent.py`
- Queries SEC EDGAR EFTS full-text search API (no key required), downloads Form 4 XML filing index, parses `nonDerivativeTransaction` elements
- `InsiderTrade` Pydantic model: `instrument`, `trade_date`, `trade_type`, `shares`, `value_usd`, `officer_name`, `source="edgar"`
- `@with_retry()` applied; per-filing errors logged as WARNING, never raised; WTI/BZ return empty list (no equity filings)
- 16 unit tests across `TestParseForm4Xml`, `TestEftsSearch`, `TestFetchEdgarInsiderTrades`

## AC Checklist

- [x] `fetch_edgar_insider_trades` implemented in `alternative_data_agent.py`
- [x] Uses EDGAR EFTS API (free, no key); parses Form 4 XML
- [x] `InsiderTrade` Pydantic model with all required fields
- [x] `@with_retry()` applied
- [x] Missing/malformed filings → WARNING, not raised
- [x] Type hints on all public functions (mypy strict)
- [x] 16 unit tests (≥ 5 required): happy path, malformed XML, empty result, HTTP error propagation, instrument filter, unmapped tx code, missing officer name
- [x] `bash scripts/local_check.sh` exits 0 (all 5 stages pass)

## Test plan

- [ ] `pytest tests/agents/alternative_data/ -v` — all 16 pass
- [ ] `bash scripts/local_check.sh` — all 5 stages pass
- [ ] Verify no new packages added to requirements.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)