### PR TITLE
feat(alternative-data): implement fetch_quiver_enrichment — Quiver insider enrichment (#150)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,9 @@ GDELT_BASE_URL=http://api.gdeltproject.org/api/v2
 
 # --- Insider Activity ---
 EDGAR_BASE_URL=https://efts.sec.gov/LATEST/search-index
-QUIVER_API_KEY=YOUR_QUIVER_API_KEY
+# QUIVER_API_KEY is optional — if unset, fetch_quiver_enrichment() skips gracefully (logs INFO).
+# Sign up at https://www.quiverquant.com to obtain a key.
+QUIVER_API_KEY=
 
 # --- Shipping / Logistics ---
 MARINETRAFFIC_API_KEY=YOUR_MARINETRAFFIC_API_KEY

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through setting up, configuring, and running the full Energy Options Opportunity Agent pipeline end-to-end.
+> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
 
 ---
 
@@ -18,377 +18,360 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
+The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
 
-The pipeline is **advisory only** — it produces ranked recommendations but does not execute trades.
-
-### Pipeline Architecture
-
-Data flows unidirectionally through four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**.
+The system is composed of **four loosely coupled agents** that communicate via a shared market state object and a derived features store:
 
 ```mermaid
 flowchart LR
-    subgraph Inputs
-        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
-        A2([ETF & Equity\nyfinance / Yahoo Finance])
-        A3([Options Chains\nYahoo Finance / Polygon.io])
-        A4([EIA Supply\nEIA API])
-        A5([News & Geo\nGDELT / NewsAPI])
-        A6([Insider Activity\nEDGAR / Quiver Quant])
-        A7([Shipping\nMarineTraffic / VesselFinder])
-        A8([Sentiment\nReddit / Stocktwits])
+    subgraph Ingestion["1 · Data Ingestion Agent"]
+        A1[Fetch crude prices\nETF / equity data\noptions chains]
+        A2[Normalize → Unified\nMarket State Object]
+        A1 --> A2
     end
 
-    subgraph Pipeline
-        B[Data Ingestion Agent\nFetch & Normalize]
-        C[Event Detection Agent\nSupply & Geo Signals]
-        D[Feature Generation Agent\nDerived Signal Computation]
-        E[Strategy Evaluation Agent\nOpportunity Ranking]
+    subgraph Events["2 · Event Detection Agent"]
+        B1[Monitor news &\ngeo feeds]
+        B2[Score supply disruptions\nrefinery outages\nchokepoints]
+        B1 --> B2
     end
 
-    subgraph Output
-        F[(Market State Object\n& Features Store)]
-        G([Ranked Candidates\nJSON / Dashboard])
+    subgraph Features["3 · Feature Generation Agent"]
+        C1[Compute derived signals\nvol gap · curve steepness\nsector dispersion · etc.]
     end
 
-    A1 & A2 & A3 & A4 --> B
-    A5 --> C
-    A6 & A7 & A8 --> C
-    B --> F
-    C --> F
-    F --> D
-    D --> F
-    F --> E
-    E --> G
+    subgraph Strategy["4 · Strategy Evaluation Agent"]
+        D1[Evaluate eligible\noption structures]
+        D2[Rank by edge score\nwith signal references]
+        D1 --> D2
+    end
+
+    RawFeeds([Raw Data Feeds]) --> Ingestion
+    Ingestion -->|Market State| Events
+    Ingestion -->|Market State| Features
+    Events -->|Event Scores| Features
+    Features -->|Derived Features| Strategy
+    Strategy -->|JSON Output| Output([Ranked Candidates])
 ```
 
-### In-Scope Instruments & Strategies
+### What the pipeline produces
 
-| Category | Items |
+For each candidate opportunity the pipeline emits a JSON object containing:
+
+| Field | Description |
 |---|---|
-| **Crude futures** | Brent Crude, WTI (`CL=F`) |
-| **ETFs** | USO, XLE |
-| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
-| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
+| `instrument` | Target instrument (e.g. `USO`, `XLE`, `CL=F`) |
+| `structure` | Options structure type |
+| `expiration` | Days to target expiration |
+| `edge_score` | Composite opportunity score `[0.0 – 1.0]` |
+| `signals` | Map of contributing signals and their states |
+| `generated_at` | UTC ISO 8601 timestamp |
 
-> **Out of scope (initially):** Exotic/multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
+> **Advisory only.** The system does **not** execute trades. All output is informational.
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| Memory | 2 GB RAM |
-| Disk | 5 GB free (for 6–12 months of historical data) |
-| Deployment target | Local machine, single VM, or container |
+| Python | 3.10 or later |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| RAM | 2 GB |
+| Disk | 10 GB free (for 6–12 months of historical data) |
+| Network | Outbound HTTPS access to all data sources |
 
-### Python Dependencies
+### External accounts and API keys
 
-Install all dependencies from the project root:
+All sources are free or free-tier. Register for each before running the pipeline.
+
+| Service | Used by | Registration URL |
+|---|---|---|
+| Alpha Vantage | Crude prices (WTI, Brent) | https://www.alphavantage.co/support/#api-key |
+| Yahoo Finance / yfinance | ETF, equity, options data | No key required (library-based) |
+| Polygon.io | Options chains (optional upgrade) | https://polygon.io/dashboard/signup |
+| EIA API | Supply/inventory data | https://www.eia.gov/opendata/register.php |
+| GDELT | News & geopolitical events | No key required |
+| NewsAPI | News events | https://newsapi.org/register |
+| SEC EDGAR | Insider activity | No key required |
+| Quiver Quant | Insider activity (enhanced) | https://www.quiverquant.com/signup |
+| MarineTraffic | Tanker/shipping data | https://www.marinetraffic.com/en/p/register |
+| Reddit API | Narrative/sentiment | https://www.reddit.com/prefs/apps |
+
+> **Phase 1 minimum.** For an initial MVP (Phase 1), you only need **Alpha Vantage** and **yfinance**. Additional keys become required as you enable later phases.
+
+### Python dependencies
 
 ```bash
 pip install -r requirements.txt
 ```
 
-Key packages the pipeline depends on:
+A representative `requirements.txt` includes:
 
-| Package | Purpose |
-|---|---|
-| `yfinance` | ETF, equity, and options chain data |
-| `requests` | REST calls to EIA, Alpha Vantage, GDELT, etc. |
-| `pandas` / `numpy` | Data normalization and feature computation |
-| `pydantic` | Market state object and output schema validation |
-| `schedule` / `apscheduler` | Cadenced polling for each feed layer |
-| `sqlitedict` / `tinydb` | Lightweight local historical data store |
-
-### External API Keys
-
-You must obtain free-tier credentials for the following services before running the pipeline:
-
-| Service | Where to register | Required for |
-|---|---|---|
-| Alpha Vantage | [alphavantage.co](https://www.alphavantage.co/support/#api-key) | WTI / Brent spot prices |
-| EIA Open Data | [eia.gov/opendata](https://www.eia.gov/opendata/register.php) | Inventory & refinery utilization |
-| NewsAPI | [newsapi.org](https://newsapi.org/register) | Energy news headlines |
-| Polygon.io *(optional)* | [polygon.io](https://polygon.io) | Higher-fidelity options chains |
-| Quiver Quant *(optional)* | [quiverquant.com](https://www.quiverquant.com) | Insider conviction scores |
-
-> **Note:** Yahoo Finance (via `yfinance`), GDELT, SEC EDGAR, MarineTraffic free tier, Reddit, and Stocktwits do not require API keys at the free tier.
+```text
+yfinance>=0.2
+requests>=2.31
+pandas>=2.0
+numpy>=1.26
+pydantic>=2.0
+python-dotenv>=1.0
+schedule>=1.2
+```
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create a virtual environment
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate        # macOS / Linux
-.venv\Scripts\activate           # Windows
+source .venv/bin/activate        # Linux / macOS
+# .venv\Scripts\activate.bat     # Windows CMD
+# .venv\Scripts\Activate.ps1     # Windows PowerShell
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the provided template and populate your credentials:
+Copy the provided template and populate your keys:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in each value. The full set of supported environment variables is described in the table below.
+Then edit `.env`. The table below documents every supported variable.
 
-#### Environment Variable Reference
+#### Environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | **Yes** | — | API key for crude spot/futures prices (Alpha Vantage) |
-| `EIA_API_KEY` | **Yes** | — | API key for EIA supply and inventory data |
-| `NEWSAPI_KEY` | **Yes** | — | API key for energy-related news headlines |
-| `POLYGON_API_KEY` | No | `""` | Polygon.io key for options chain data (falls back to `yfinance`) |
-| `QUIVER_QUANT_API_KEY` | No | `""` | Quiver Quant key for insider activity (Phase 3) |
-| `DATA_STORE_PATH` | No | `./data` | Local directory for raw and derived historical data |
-| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain (minimum 180 for backtesting) |
-| `MARKET_DATA_POLL_INTERVAL_SECONDS` | No | `60` | Cadence for minute-level market data refresh |
-| `EIA_POLL_INTERVAL_HOURS` | No | `24` | Cadence for EIA weekly feed check |
-| `GDELT_POLL_INTERVAL_HOURS` | No | `1` | Cadence for GDELT geopolitical event check |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `OUTPUT_PATH` | No | `./output` | Directory where ranked candidate JSON files are written |
-| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F` | Comma-separated list of instruments to track |
-| `MIN_EDGE_SCORE` | No | `0.25` | Minimum edge score threshold for a candidate to appear in output |
-| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates to emit per pipeline run |
+| `ALPHA_VANTAGE_API_KEY` | Yes (Phase 1+) | — | API key for crude price feeds (WTI, Brent) |
+| `EIA_API_KEY` | Yes (Phase 2+) | — | API key for EIA inventory and refinery utilization data |
+| `NEWS_API_KEY` | Yes (Phase 2+) | — | API key for NewsAPI news/geo event feed |
+| `POLYGON_API_KEY` | No | — | Polygon.io key for enhanced options chain data |
+| `QUIVER_QUANT_API_KEY` | No | — | Quiver Quant key for insider conviction signals |
+| `MARINE_TRAFFIC_API_KEY` | No | — | MarineTraffic key for tanker flow data |
+| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth client ID for sentiment feed |
+| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth client secret |
+| `REDDIT_USER_AGENT` | No | `energy-agent/1.0` | Reddit API user-agent string |
+| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
+| `HISTORICAL_DATA_DIR` | No | `./data/historical` | Directory for persisted raw and derived data |
+| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (180–365 recommended) |
+| `PIPELINE_PHASE` | No | `1` | Active feature phase: `1`, `2`, or `3` |
+| `REFRESH_INTERVAL_MINUTES` | No | `5` | Cadence for market data refresh (minutes-level feeds) |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
+| `EDGE_SCORE_THRESHOLD` | No | `0.30` | Minimum edge score for a candidate to appear in output |
 
-> **Tip:** Set `LOG_LEVEL=DEBUG` during your first run to see verbose per-agent output.
+#### Example `.env` file
 
-### 5. Verify Configuration
+```dotenv
+# --- Required (Phase 1) ---
+ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
 
-Run the built-in configuration check before executing the full pipeline:
+# --- Required (Phase 2) ---
+EIA_API_KEY=YOUR_EIA_KEY_HERE
+NEWS_API_KEY=YOUR_NEWSAPI_KEY_HERE
+
+# --- Optional enhancements ---
+POLYGON_API_KEY=
+QUIVER_QUANT_API_KEY=
+MARINE_TRAFFIC_API_KEY=
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT=energy-agent/1.0
+
+# --- Pipeline behaviour ---
+PIPELINE_PHASE=1
+REFRESH_INTERVAL_MINUTES=5
+OUTPUT_DIR=./output
+HISTORICAL_DATA_DIR=./data/historical
+RETENTION_DAYS=365
+EDGE_SCORE_THRESHOLD=0.30
+LOG_LEVEL=INFO
+```
+
+### 5. Initialise the data directories
 
 ```bash
-python -m agent.cli check-config
+python scripts/init_storage.py
 ```
 
-Expected output on success:
-
-```
-[OK] ALPHA_VANTAGE_API_KEY     reachable
-[OK] EIA_API_KEY               reachable
-[OK] NEWSAPI_KEY               reachable
-[--] POLYGON_API_KEY           not set — falling back to yfinance (options data)
-[--] QUIVER_QUANT_API_KEY      not set — insider signals disabled (Phase 3)
-[OK] DATA_STORE_PATH           ./data (writable)
-[OK] OUTPUT_PATH               ./output (writable)
-Configuration check complete. Pipeline is ready to run.
-```
+This creates the `OUTPUT_DIR` and `HISTORICAL_DATA_DIR` directories and validates that required API keys for the configured `PIPELINE_PHASE` are present.
 
 ---
 
 ## Running the Pipeline
 
-### Agent Execution Order
+### Pipeline execution modes
 
-Each agent must complete before the next begins. The diagram below shows the sequence for a single pipeline run.
+| Mode | Command | Use case |
+|---|---|---|
+| Single run | `python run_pipeline.py --once` | Ad-hoc evaluation; CI/testing |
+| Scheduled loop | `python run_pipeline.py` | Continuous operation at `REFRESH_INTERVAL_MINUTES` cadence |
+| Individual agent | `python run_agent.py <agent_name>` | Debug or develop a single agent in isolation |
 
-```mermaid
-sequenceDiagram
-    participant CLI as CLI / Scheduler
-    participant DIA as Data Ingestion Agent
-    participant EDA as Event Detection Agent
-    participant FGA as Feature Generation Agent
-    participant SEA as Strategy Evaluation Agent
-    participant Store as Market State & Features Store
-    participant Out as Output (JSON)
-
-    CLI->>DIA: run()
-    DIA->>Store: write normalized market state
-    DIA-->>CLI: done
-
-    CLI->>EDA: run()
-    EDA->>Store: read market state
-    EDA->>Store: write event scores
-    EDA-->>CLI: done
-
-    CLI->>FGA: run()
-    FGA->>Store: read market state + event scores
-    FGA->>Store: write derived features
-    FGA-->>CLI: done
-
-    CLI->>SEA: run()
-    SEA->>Store: read all signals
-    SEA->>Out: write ranked candidates JSON
-    SEA-->>CLI: done
-```
-
-### Running the Full Pipeline Once
-
-Execute a single end-to-end pipeline run from the project root:
+### Single run
 
 ```bash
-python -m agent.cli run --all
+python run_pipeline.py --once
 ```
 
-This invokes all four agents in sequence and writes output to `$OUTPUT_PATH`.
+The pipeline will:
 
-### Running Individual Agents
+1. Invoke the **Data Ingestion Agent** to fetch and normalize all configured feeds.
+2. Invoke the **Event Detection Agent** to score supply and geopolitical signals.
+3. Invoke the **Feature Generation Agent** to compute derived signals.
+4. Invoke the **Strategy Evaluation Agent** to rank and emit candidate opportunities.
+5. Write results to `OUTPUT_DIR/candidates_<ISO8601_timestamp>.json`.
 
-You can run each agent independently for development or debugging:
+### Continuous scheduled run
 
 ```bash
-# Data Ingestion Agent only
-python -m agent.cli run --agent ingestion
-
-# Event Detection Agent only
-python -m agent.cli run --agent events
-
-# Feature Generation Agent only
-python -m agent.cli run --agent features
-
-# Strategy Evaluation Agent only
-python -m agent.cli run --agent strategy
+python run_pipeline.py
 ```
 
-> **Note:** Running agents out of order is supported for debugging, but the pipeline will use whatever data is currently in the store. Stale data will produce stale recommendations.
+The scheduler wakes every `REFRESH_INTERVAL_MINUTES` minutes for market data. Slower feeds (EIA, EDGAR) are refreshed on their own daily/weekly schedules automatically.
 
-### Running the Pipeline on a Schedule
-
-To run the full pipeline continuously at the cadence defined by `MARKET_DATA_POLL_INTERVAL_SECONDS`:
-
-```bash
-python -m agent.cli run --all --loop
+```
+[2026-03-15 09:00:00 UTC] INFO  Pipeline started. Phase=1, Interval=5min
+[2026-03-15 09:00:02 UTC] INFO  [DataIngestion] Fetched WTI: 82.14, Brent: 85.30
+[2026-03-15 09:00:04 UTC] INFO  [DataIngestion] Fetched USO, XLE, XOM, CVX options chains
+[2026-03-15 09:00:05 UTC] INFO  [EventDetection] 0 supply disruption events detected
+[2026-03-15 09:00:06 UTC] INFO  [FeatureGen] vol_gap=+0.04, curve_steepness=contango
+[2026-03-15 09:00:07 UTC] INFO  [StrategyEval] 3 candidates above threshold (0.30)
+[2026-03-15 09:00:07 UTC] INFO  Output written → ./output/candidates_2026-03-15T090007Z.json
 ```
 
-The scheduler respects each feed's appropriate cadence:
+### Running an individual agent
 
-| Feed layer | Cadence |
-|---|---|
-| Crude prices, ETF/equity prices | Minutes (configurable via `MARKET_DATA_POLL_INTERVAL_SECONDS`) |
-| Options chains, insider activity | Daily |
-| EIA inventory / refinery data | Daily/weekly |
-| News, GDELT, shipping, sentiment | Continuous / hourly |
-
-### Running in a Container
-
-A `Dockerfile` is included for containerized deployment:
+Use this for development, debugging, or incremental integration:
 
 ```bash
-docker build -t energy-options-agent .
+python run_agent.py data_ingestion
+python run_agent.py event_detection
+python run_agent.py feature_generation
+python run_agent.py strategy_evaluation
+```
 
-docker run --env-file .env \
-  -v $(pwd)/data:/app/data \
-  -v $(pwd)/output:/app/output \
-  energy-options-agent python -m agent.cli run --all --loop
+Each agent reads its expected inputs from the shared state store on disk and writes its outputs back to the same store.
+
+### Activating pipeline phases
+
+Set `PIPELINE_PHASE` in `.env` to enable progressively richer signals:
+
+| Phase | Agents active | New data sources enabled |
+|---|---|---|
+| `1` | All four (core only) | Alpha Vantage, yfinance |
+| `2` | All four + event scoring | EIA API, GDELT, NewsAPI |
+| `3` | All four + alt signals | EDGAR, Quiver Quant, MarineTraffic, Reddit/Stocktwits |
+
+```bash
+# Switch to Phase 2
+echo "PIPELINE_PHASE=2" >> .env
+python run_pipeline.py --once
 ```
 
 ---
 
 ## Interpreting the Output
 
-### Output Location
-
-Each pipeline run writes a timestamped JSON file to `$OUTPUT_PATH`:
+### Output file location
 
 ```
 output/
-└── candidates_2026-03-15T14:30:00Z.json
+└── candidates_2026-03-15T090007Z.json
 ```
 
-The file contains a JSON array of ranked strategy candidates, ordered from highest to lowest `edge_score`.
+Each run produces a timestamped file. The scheduler does not overwrite prior runs, supporting audit trails and backtesting.
 
-### Output Schema
-
-Each candidate object conforms to the following schema:
-
-| Field | Type | Description |
-|---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
-| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher values indicate stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative values |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
-
-### Example Candidate
+### Output schema
 
 ```json
-{
-  "instrument": "USO",
-  "structure": "long_straddle",
-  "expiration": 30,
-  "edge_score": 0.47,
-  "signals": {
-    "tanker_disruption_index": "high",
-    "volatility_gap": "positive",
-    "narrative_velocity": "rising"
-  },
-  "generated_at": "2026-03-15T14:30:00Z"
-}
+[
+  {
+    "instrument":   "USO",
+    "structure":    "long_straddle",
+    "expiration":   30,
+    "edge_score":   0.47,
+    "signals": {
+      "tanker_disruption_index": "high",
+      "volatility_gap":          "positive",
+      "narrative_velocity":      "rising"
+    },
+    "generated_at": "2026-03-15T09:00:07Z"
+  }
+]
 ```
 
-### Reading the `edge_score`
+### Field-by-field reference
 
-The `edge_score` is a composite \[0.0–1.0\] float derived from the confluence of all active signals. Use the table below as a rough interpretive guide:
-
-| Score range | Interpretation |
-|---|---|
-| `0.75 – 1.0` | Strong signal confluence — high-priority candidate |
-| `0.50 – 0.74` | Moderate confluence — worth reviewing |
-| `0.25 – 0.49` | Weak signal overlap — marginal candidate (default minimum threshold) |
-| `< 0.25` | Below threshold — filtered out by default |
-
-> Adjust `MIN_EDGE_SCORE` in `.env` to raise or lower the filter threshold.
-
-### Reading the `signals` Map
-
-Each key in the `signals` object maps to one of the derived features computed by the Feature Generation Agent:
-
-| Signal key | Source agent | What it represents |
+| Field | Type | Notes |
 |---|---|---|
-| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence |
-| `futures_curve_steepness` | Feature Generation | Contango / backwardation signal from futures curve |
-| `sector_dispersion` | Feature Generation | Cross-sector correlation breakdown |
-| `insider_conviction_score` | Feature Generation | Aggregated insider trade signal (EDGAR/Quiver) |
-| `narrative_velocity` | Feature Generation | Headline acceleration from news and social feeds |
-| `supply_shock_probability` | Feature Generation | Probability estimate of near-term supply disruption |
-| `tanker_disruption_index` | Event Detection | Shipping flow anomalies at key chokepoints |
-| `refinery_outage_index` | Event Detection | Detected refinery disruption events |
-| `geopolitical_event_score` | Event Detection | Confidence-weighted geopolitical event intensity |
+| `instrument` | string | One of: `USO`, `XLE`, `XOM`, `CVX`, `CL=F` (WTI), `BZ=F` (Brent) |
+| `structure` | enum | `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
+| `expiration` | integer | Calendar days from the evaluation date to the target expiration |
+| `edge_score` | float `[0.0–1.0]` | Higher = stronger signal confluence; candidates below `EDGE_SCORE_THRESHOLD` are suppressed |
+| `signals` | object | Key–value map of the signals that contributed to this candidate's score |
+| `generated_at` | ISO 8601 UTC | Timestamp of candidate generation |
 
-### Consuming Output in thinkorswim or a Dashboard
+### Signal values
 
-The JSON output is compatible with any JSON-capable dashboard or thinkorswim's script import. Point your tool at the latest file in `$OUTPUT_PATH`, or configure the pipeline to write to a fixed path:
+| Signal key | Possible values | What it means |
+|---|---|---|
+| `volatility_gap` | `positive`, `negative`, `neutral` | Realized vol minus implied vol; `positive` = IV may be underpriced |
+| `curve_steepness` | `contango`, `backwardation`, `flat` | Shape of the WTI/Brent futures curve |
+| `supply_shock_probability` | `low`, `medium`, `high` | Probability score from supply disruption model |
+| `tanker_disruption_index` | `low`, `medium`, `high` | Derived from shipping/logistics feed (Phase 3) |
+| `narrative_velocity` | `falling`, `stable`, `rising` | Rate of change of energy-related headline volume |
+| `insider_conviction` | `low`, `medium`, `high` | Aggregated insider trade signal (Phase 3) |
+| `sector_dispersion` | `low`, `medium`, `high` | Cross-sector correlation divergence indicator |
 
-```bash
-# Write to a fixed filename for easy dashboard polling
-python -m agent.cli run --all --output-file output/latest_candidates.json
+### Ranking and acting on candidates
+
+- Candidates are ordered **descending by `edge_score`**.
+- A score above **0.50** indicates strong multi-signal confluence; treat with higher priority.
+- Always cross-reference the `signals` map to understand *why* a candidate scored highly before considering any position.
+- The output is designed to be consumed directly in **thinkorswim** or any JSON-capable dashboard.
+
+### Loading output in Python
+
+```python
+import json
+from pathlib import Path
+
+latest = sorted(Path("output").glob("candidates_*.json"))[-1]
+candidates = json.loads(latest.read_text())
+
+for c in sorted(candidates, key=lambda x: x["edge_score"], reverse=True):
+    print(f"{c['edge_score']:.2f}  {c['instrument']:6s}  {c['structure']}")
 ```
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
+### Common issues
 
 | Symptom | Likely cause | Resolution |
 |---|---|---|
-| `check-config` reports an API key as unreachable | Invalid or missing key in `.env` | Re-check the key value; verify the service is not rate-limiting your IP |
-| Pipeline run exits with no candidates in output | All candidates below `MIN_EDGE_SCORE` | Lower `MIN_EDGE_SCORE` temporarily, or run in `DEBUG` mode to inspect signal values |
-| `yfinance` returns empty options chain | Market is closed or data is delayed | Options data updates daily; run during market hours or accept previous day's chain |
-| Event Detection Agent produces no events | GDELT/NewsAPI returning no matching articles | Verify `NEWSAPI_KEY` is valid; check GDELT connectivity; inspect logs for HTTP errors |
-| Feature Generation Agent raises `KeyError` on market state | Data Ingestion Agent did not complete successfully | Re-run ingestion step first: `python -m agent.cli run --agent ingestion` |
-| Historical store grows beyond available disk | Retention policy not enforced | Verify `HISTORY_RETENTION_DAYS` is set; run `python -m agent.cli pr
+| `KeyError: ALPHA_VANTAGE_API_KEY` | Missing key in `.env` | Add the key and re-run `init_storage.py` to validate |
+| `No candidates above threshold` | `EDGE_SCORE_THRESHOLD` too high, or low-signal market conditions | Lower `EDGE_SCORE_THRESHOLD` temporarily, or inspect feature output with `LOG_LEVEL=DEBUG` |
+| `Rate limit exceeded` (Alpha Vantage) | Free tier allows 5 req/min, 500 req/day | Increase `REFRESH_INTERVAL_MINUTES` to `≥ 15` |
+| `yfinance returned empty options chain` | Options data not yet available for the trading session | Run after market open; options chains update once daily |
+| Agent exits with `ConnectionError` | Transient network issue | The pipeline is designed to tolerate missing data; re-run

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
 > **Version 1.0 • March 2026**
-> This guide walks a developer through setting up, configuring, and running the full four-agent pipeline that identifies oil-market-driven options trading opportunities.
+> This guide walks a developer through setting up, configuring, and running the full Energy Options Opportunity Agent pipeline end-to-end.
 
 ---
 
@@ -18,64 +18,60 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is an autonomous, modular Python pipeline composed of four loosely coupled agents. It ingests market data, geopolitical signals, news events, and alternative datasets to produce structured, ranked candidate options strategies for oil-related instruments.
+The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
+
+The pipeline is **advisory only** — it produces ranked recommendations but does not execute trades.
 
 ### Pipeline Architecture
+
+Data flows unidirectionally through four loosely coupled agents that communicate via a shared **market state object** and a **derived features store**.
 
 ```mermaid
 flowchart LR
     subgraph Inputs
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
-        A4[EIA Inventory\nEIA API]
-        A5[News & Geo Events\nGDELT / NewsAPI]
-        A6[Insider Activity\nEDGAR / Quiver Quant]
-        A7[Shipping Data\nMarineTraffic]
-        A8[Sentiment\nReddit / Stocktwits]
+        A1([Crude Prices\nAlpha Vantage / MetalpriceAPI])
+        A2([ETF & Equity\nyfinance / Yahoo Finance])
+        A3([Options Chains\nYahoo Finance / Polygon.io])
+        A4([EIA Supply\nEIA API])
+        A5([News & Geo\nGDELT / NewsAPI])
+        A6([Insider Activity\nEDGAR / Quiver Quant])
+        A7([Shipping\nMarineTraffic / VesselFinder])
+        A8([Sentiment\nReddit / Stocktwits])
     end
 
-    subgraph Agent_1 [" Agent 1 · Data Ingestion"]
-        B[Fetch & Normalize\nMarket State Object]
+    subgraph Pipeline
+        B[Data Ingestion Agent\nFetch & Normalize]
+        C[Event Detection Agent\nSupply & Geo Signals]
+        D[Feature Generation Agent\nDerived Signal Computation]
+        E[Strategy Evaluation Agent\nOpportunity Ranking]
     end
 
-    subgraph Agent_2 [" Agent 2 · Event Detection"]
-        C[Supply & Geo\nSignal Scoring]
+    subgraph Output
+        F[(Market State Object\n& Features Store)]
+        G([Ranked Candidates\nJSON / Dashboard])
     end
 
-    subgraph Agent_3 [" Agent 3 · Feature Generation"]
-        D[Derived Signal\nComputation]
-    end
-
-    subgraph Agent_4 [" Agent 4 · Strategy Evaluation"]
-        E[Opportunity Ranking\nEdge Score Output]
-    end
-
-    Inputs --> Agent_1
-    Agent_1 -->|market state object| Agent_2
-    Agent_2 -->|scored events| Agent_3
-    Agent_3 -->|derived features| Agent_4
-    Agent_4 -->|JSON candidates| F[(Output / Dashboard)]
+    A1 & A2 & A3 & A4 --> B
+    A5 --> C
+    A6 & A7 & A8 --> C
+    B --> F
+    C --> F
+    F --> D
+    D --> F
+    F --> E
+    E --> G
 ```
 
-### In-Scope Instruments
+### In-Scope Instruments & Strategies
 
-| Category | Instruments |
+| Category | Items |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
-| ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| **Crude futures** | Brent Crude, WTI (`CL=F`) |
+| **ETFs** | USO, XLE |
+| **Energy equities** | Exxon Mobil (XOM), Chevron (CVX) |
+| **Option structures (MVP)** | Long straddles, call/put spreads, calendar spreads |
 
-### In-Scope Option Structures (MVP)
-
-| Structure | Enum Value |
-|---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
-
-> **Advisory only.** Automated trade execution is explicitly out of scope. All output is for informational and analytical purposes.
+> **Out of scope (initially):** Exotic/multi-legged strategies, regional refined product pricing (OPIS), automated trade execution.
 
 ---
 
@@ -85,45 +81,43 @@ flowchart LR
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10 or later |
-| OS | Linux, macOS, or Windows (WSL recommended) |
-| RAM | 2 GB |
-| Disk | 10 GB (for 6–12 months of historical data) |
+| Python | 3.10+ |
+| Memory | 2 GB RAM |
+| Disk | 5 GB free (for 6–12 months of historical data) |
 | Deployment target | Local machine, single VM, or container |
 
-### Required Tools
+### Python Dependencies
+
+Install all dependencies from the project root:
 
 ```bash
-# Verify Python version
-python --version   # must be >= 3.10
-
-# Verify pip
-pip --version
-
-# Recommended: create an isolated environment
-python -m venv .venv
-source .venv/bin/activate        # macOS / Linux
-.venv\Scripts\activate           # Windows PowerShell
+pip install -r requirements.txt
 ```
 
-### External API Accounts
+Key packages the pipeline depends on:
 
-Obtain free-tier credentials from each provider before proceeding. All listed sources are free or low-cost.
+| Package | Purpose |
+|---|---|
+| `yfinance` | ETF, equity, and options chain data |
+| `requests` | REST calls to EIA, Alpha Vantage, GDELT, etc. |
+| `pandas` / `numpy` | Data normalization and feature computation |
+| `pydantic` | Market state object and output schema validation |
+| `schedule` / `apscheduler` | Cadenced polling for each feed layer |
+| `sqlitedict` / `tinydb` | Lightweight local historical data store |
 
-| Data Layer | Provider | Registration URL | Notes |
-|---|---|---|---|
-| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free key; minutes cadence |
-| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free tier |
-| ETF / Equity Prices | yfinance (Yahoo) | No key required | Library-level access |
-| Options Chains | Polygon.io | https://polygon.io | Free tier; daily delay |
-| Supply / Inventory | EIA API | https://www.eia.gov/opendata | Free; weekly updates |
-| News & Geo Events | NewsAPI | https://newsapi.org | Free tier |
-| News & Geo Events (alt) | GDELT | https://www.gdeltproject.org | No key; public dataset |
-| Insider Activity | SEC EDGAR | https://efts.sec.gov/LATEST/search-index | No key required |
-| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free limited tier |
-| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
-| Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free OAuth app |
-| Sentiment (alt) | Stocktwits | https://api.stocktwits.com | Free public API |
+### External API Keys
+
+You must obtain free-tier credentials for the following services before running the pipeline:
+
+| Service | Where to register | Required for |
+|---|---|---|
+| Alpha Vantage | [alphavantage.co](https://www.alphavantage.co/support/#api-key) | WTI / Brent spot prices |
+| EIA Open Data | [eia.gov/opendata](https://www.eia.gov/opendata/register.php) | Inventory & refinery utilization |
+| NewsAPI | [newsapi.org](https://newsapi.org/register) | Energy news headlines |
+| Polygon.io *(optional)* | [polygon.io](https://polygon.io) | Higher-fidelity options chains |
+| Quiver Quant *(optional)* | [quiverquant.com](https://www.quiverquant.com) | Insider conviction scores |
+
+> **Note:** Yahoo Finance (via `yfinance`), GDELT, SEC EDGAR, MarineTraffic free tier, Reddit, and Stocktwits do not require API keys at the free tier.
 
 ---
 
@@ -136,189 +130,169 @@ git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Install Dependencies
+### 2. Create and Activate a Virtual Environment
+
+```bash
+python -m venv .venv
+source .venv/bin/activate        # macOS / Linux
+.venv\Scripts\activate           # Windows
+```
+
+### 3. Install Dependencies
 
 ```bash
 pip install -r requirements.txt
 ```
 
-### 3. Configure Environment Variables
+### 4. Configure Environment Variables
 
-All runtime configuration is supplied via environment variables. Copy the provided template and populate each value:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Then edit `.env` with your credentials:
+Open `.env` in your editor and fill in each value. The full set of supported environment variables is described in the table below.
 
-```bash
-# .env
-ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
-METALPRICE_API_KEY=your_metalprice_key
-POLYGON_API_KEY=your_polygon_key
-EIA_API_KEY=your_eia_key
-NEWS_API_KEY=your_newsapi_key
-REDDIT_CLIENT_ID=your_reddit_client_id
-REDDIT_CLIENT_SECRET=your_reddit_client_secret
-REDDIT_USER_AGENT=energy-options-agent/1.0
-QUIVER_QUANT_API_KEY=your_quiver_key
-MARINE_TRAFFIC_API_KEY=your_marinetraffic_key
-```
-
-#### Full Environment Variable Reference
+#### Environment Variable Reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for WTI/Brent spot and futures prices (minutes cadence) |
-| `METALPRICE_API_KEY` | No | — | Alternative crude price source; used as fallback |
-| `POLYGON_API_KEY` | Yes | — | Options chain data: strike, expiry, IV, volume (daily) |
-| `EIA_API_KEY` | Yes | — | EIA inventory and refinery utilization data (weekly) |
-| `NEWS_API_KEY` | Yes | — | NewsAPI key for energy disruption and geopolitical headlines |
-| `GDELT_ENABLED` | No | `true` | Set to `false` to disable GDELT ingestion |
-| `REDDIT_CLIENT_ID` | No | — | Reddit OAuth app client ID for sentiment ingestion |
-| `REDDIT_CLIENT_SECRET` | No | — | Reddit OAuth app client secret |
-| `REDDIT_USER_AGENT` | No | `energy-options-agent/1.0` | Reddit API user agent string |
-| `QUIVER_QUANT_API_KEY` | No | — | Quiver Quant key for insider conviction data |
-| `MARINE_TRAFFIC_API_KEY` | No | — | MarineTraffic free-tier key for tanker flow data |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON candidate files are written |
-| `HISTORICAL_DATA_DIR` | No | `./data` | Root directory for raw and derived historical data |
-| `RETENTION_DAYS` | No | `365` | Days of historical data to retain (minimum 180 for backtesting) |
-| `MARKET_DATA_POLL_INTERVAL_SECONDS` | No | `60` | Polling interval for minutes-cadence market data feeds |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `PIPELINE_PHASE` | No | `1` | Active MVP phase (1–3). Controls which agents and signals are enabled |
+| `ALPHA_VANTAGE_API_KEY` | **Yes** | — | API key for crude spot/futures prices (Alpha Vantage) |
+| `EIA_API_KEY` | **Yes** | — | API key for EIA supply and inventory data |
+| `NEWSAPI_KEY` | **Yes** | — | API key for energy-related news headlines |
+| `POLYGON_API_KEY` | No | `""` | Polygon.io key for options chain data (falls back to `yfinance`) |
+| `QUIVER_QUANT_API_KEY` | No | `""` | Quiver Quant key for insider activity (Phase 3) |
+| `DATA_STORE_PATH` | No | `./data` | Local directory for raw and derived historical data |
+| `HISTORY_RETENTION_DAYS` | No | `365` | Days of historical data to retain (minimum 180 for backtesting) |
+| `MARKET_DATA_POLL_INTERVAL_SECONDS` | No | `60` | Cadence for minute-level market data refresh |
+| `EIA_POLL_INTERVAL_HOURS` | No | `24` | Cadence for EIA weekly feed check |
+| `GDELT_POLL_INTERVAL_HOURS` | No | `1` | Cadence for GDELT geopolitical event check |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `OUTPUT_PATH` | No | `./output` | Directory where ranked candidate JSON files are written |
+| `INSTRUMENTS` | No | `USO,XLE,XOM,CVX,CL=F` | Comma-separated list of instruments to track |
+| `MIN_EDGE_SCORE` | No | `0.25` | Minimum edge score threshold for a candidate to appear in output |
+| `MAX_CANDIDATES` | No | `20` | Maximum number of ranked candidates to emit per pipeline run |
 
-> **Tip — missing optional keys:** The pipeline is designed to tolerate delayed or missing data without failing. If an optional key (e.g., `MARINE_TRAFFIC_API_KEY`) is absent, the corresponding signal layer is skipped and a warning is logged. Required keys will raise a `ConfigurationError` at startup.
+> **Tip:** Set `LOG_LEVEL=DEBUG` during your first run to see verbose per-agent output.
 
-### 4. Verify Configuration
+### 5. Verify Configuration
 
-```bash
-python -m agent.cli verify-config
-```
-
-Expected output:
-
-```
-[OK]  ALPHA_VANTAGE_API_KEY  set
-[OK]  POLYGON_API_KEY        set
-[OK]  EIA_API_KEY            set
-[OK]  NEWS_API_KEY           set
-[WARN] MARINE_TRAFFIC_API_KEY not set — shipping signals disabled
-[WARN] QUIVER_QUANT_API_KEY  not set — insider signals disabled
-Configuration valid. Active phase: 1
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation command to create the local directory structure and, if configured, seed the historical data store:
+Run the built-in configuration check before executing the full pipeline:
 
 ```bash
-python -m agent.cli init
+python -m agent.cli check-config
 ```
 
+Expected output on success:
+
 ```
-Creating data directories...
-  ./data/raw/prices
-  ./data/raw/options
-  ./data/raw/events
-  ./data/derived
-  ./output
-Initialisation complete.
+[OK] ALPHA_VANTAGE_API_KEY     reachable
+[OK] EIA_API_KEY               reachable
+[OK] NEWSAPI_KEY               reachable
+[--] POLYGON_API_KEY           not set — falling back to yfinance (options data)
+[--] QUIVER_QUANT_API_KEY      not set — insider signals disabled (Phase 3)
+[OK] DATA_STORE_PATH           ./data (writable)
+[OK] OUTPUT_PATH               ./output (writable)
+Configuration check complete. Pipeline is ready to run.
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Execution Flow
+### Agent Execution Order
+
+Each agent must complete before the next begins. The diagram below shows the sequence for a single pipeline run.
 
 ```mermaid
 sequenceDiagram
     participant CLI as CLI / Scheduler
-    participant DIA as Agent 1<br/>Data Ingestion
-    participant EDA as Agent 2<br/>Event Detection
-    participant FGA as Agent 3<br/>Feature Generation
-    participant SEA as Agent 4<br/>Strategy Evaluation
-    participant OUT as Output (JSON)
+    participant DIA as Data Ingestion Agent
+    participant EDA as Event Detection Agent
+    participant FGA as Feature Generation Agent
+    participant SEA as Strategy Evaluation Agent
+    participant Store as Market State & Features Store
+    participant Out as Output (JSON)
 
-    CLI->>DIA: trigger run
-    DIA->>DIA: fetch crude, ETF, equity, options data
-    DIA->>DIA: normalise → market state object
-    DIA-->>EDA: market state object
-    EDA->>EDA: scan news, GDELT, shipping feeds
-    EDA->>EDA: score events (confidence, intensity)
-    EDA-->>FGA: scored events + market state
-    FGA->>FGA: compute volatility gaps, curve steepness,\nsector dispersion, narrative velocity,\ninsider conviction, supply shock prob.
-    FGA-->>SEA: derived features store
-    SEA->>SEA: evaluate option structures\nrank by edge score
-    SEA-->>OUT: write JSON candidates
-    OUT-->>CLI: run complete
+    CLI->>DIA: run()
+    DIA->>Store: write normalized market state
+    DIA-->>CLI: done
+
+    CLI->>EDA: run()
+    EDA->>Store: read market state
+    EDA->>Store: write event scores
+    EDA-->>CLI: done
+
+    CLI->>FGA: run()
+    FGA->>Store: read market state + event scores
+    FGA->>Store: write derived features
+    FGA-->>CLI: done
+
+    CLI->>SEA: run()
+    SEA->>Store: read all signals
+    SEA->>Out: write ranked candidates JSON
+    SEA-->>CLI: done
 ```
 
-### Single Run (One-Shot)
+### Running the Full Pipeline Once
 
-Execute all four agents sequentially for a single evaluation cycle:
+Execute a single end-to-end pipeline run from the project root:
 
 ```bash
-python -m agent.cli run
+python -m agent.cli run --all
 ```
 
-### Continuous Mode (Polling)
+This invokes all four agents in sequence and writes output to `$OUTPUT_PATH`.
 
-Run the pipeline on a repeating schedule. Market data refreshes at the interval defined by `MARKET_DATA_POLL_INTERVAL_SECONDS` (default: 60 s). Slower feeds (EIA, EDGAR) update on their own daily/weekly schedules:
+### Running Individual Agents
 
-```bash
-python -m agent.cli run --continuous
-```
-
-To stop: `Ctrl+C`. The pipeline completes the current cycle before exiting.
-
-### Run Individual Agents
-
-Each agent can be run in isolation for development or debugging:
+You can run each agent independently for development or debugging:
 
 ```bash
-# Agent 1: Data Ingestion only
+# Data Ingestion Agent only
 python -m agent.cli run --agent ingestion
 
-# Agent 2: Event Detection only (requires existing market state)
-python -m agent.cli run --agent event-detection
+# Event Detection Agent only
+python -m agent.cli run --agent events
 
-# Agent 3: Feature Generation only (requires market state + events)
-python -m agent.cli run --agent feature-generation
+# Feature Generation Agent only
+python -m agent.cli run --agent features
 
-# Agent 4: Strategy Evaluation only (requires derived features store)
-python -m agent.cli run --agent strategy-evaluation
+# Strategy Evaluation Agent only
+python -m agent.cli run --agent strategy
 ```
 
-### Selecting a Pipeline Phase
+> **Note:** Running agents out of order is supported for debugging, but the pipeline will use whatever data is currently in the store. Stale data will produce stale recommendations.
 
-Set `PIPELINE_PHASE` in `.env`, or override at runtime with the `--phase` flag:
+### Running the Pipeline on a Schedule
+
+To run the full pipeline continuously at the cadence defined by `MARKET_DATA_POLL_INTERVAL_SECONDS`:
 
 ```bash
-# Phase 1: Core market signals + options (default)
-python -m agent.cli run --phase 1
-
-# Phase 2: Adds EIA supply data + GDELT/NewsAPI event detection
-python -m agent.cli run --phase 2
-
-# Phase 3: Adds insider, sentiment, and shipping signals
-python -m agent.cli run --phase 3
+python -m agent.cli run --all --loop
 ```
 
-| Phase | Name | Key Additions |
-|---|---|---|
-| 1 | Core Market Signals & Options | WTI/Brent prices, USO/XLE, IV surface, long straddles, call/put spreads |
-| 2 | Supply & Event Augmentation | EIA inventory/refinery, GDELT/NewsAPI events, supply disruption indices |
-| 3 | Alternative / Contextual Signals | Insider trades (EDGAR/Quiver), narrative velocity (Reddit/Stocktwits), tanker shipping data |
-| 4 | High-Fidelity Enhancements | Deferred — exotic structures, automated execution (see [Future Considerations](#future-considerations)) |
+The scheduler respects each feed's appropriate cadence:
 
-### Logging
+| Feed layer | Cadence |
+|---|---|
+| Crude prices, ETF/equity prices | Minutes (configurable via `MARKET_DATA_POLL_INTERVAL_SECONDS`) |
+| Options chains, insider activity | Daily |
+| EIA inventory / refinery data | Daily/weekly |
+| News, GDELT, shipping, sentiment | Continuous / hourly |
 
-Logs are written to `stdout` and to `./logs/agent.log`. To increase verbosity:
+### Running in a Container
+
+A `Dockerfile` is included for containerized deployment:
 
 ```bash
-LOG_LEVEL=DEBUG python -m agent.cli run
+docker build -t energy-options-agent .
+
+docker run --env-file .env \
+  -v $(pwd)/data:/app/data \
+  -v $(pwd)/output:/app/output \
+  energy-options-agent python -m agent.cli run --all --loop
 ```
 
 ---
@@ -327,27 +301,27 @@ LOG_LEVEL=DEBUG python -m agent.cli run
 
 ### Output Location
 
-After each run, candidate files are written to `OUTPUT_DIR` (default: `./output`):
+Each pipeline run writes a timestamped JSON file to `$OUTPUT_PATH`:
 
 ```
-./output/
-  candidates_2026-03-15T14:30:00Z.json
-  candidates_2026-03-15T15:30:00Z.json
-  ...
+output/
+└── candidates_2026-03-15T14:30:00Z.json
 ```
+
+The file contains a JSON array of ranked strategy candidates, ordered from highest to lowest `edge_score`.
 
 ### Output Schema
 
-Each JSON file contains an array of strategy candidates. Every candidate object has the following fields:
+Each candidate object conforms to the following schema:
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | enum string | One of `long_straddle`, `call_spread`, `put_spread`, `calendar_spread` |
-| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
-| `edge_score` | float [0.0–1.0] | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | object | Map of contributing signals and their qualitative state |
-| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
+| `instrument` | `string` | Target instrument, e.g. `"USO"`, `"XLE"`, `"CL=F"` |
+| `structure` | `enum` | Option structure: `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
+| `expiration` | `integer` | Target expiration in calendar days from the evaluation date |
+| `edge_score` | `float [0.0–1.0]` | Composite opportunity score — higher values indicate stronger signal confluence |
+| `signals` | `object` | Map of contributing signals and their qualitative values |
+| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
 
 ### Example Candidate
 
@@ -366,24 +340,55 @@ Each JSON file contains an array of strategy candidates. Every candidate object 
 }
 ```
 
-### Reading the Edge Score
+### Reading the `edge_score`
 
-| Edge Score Range | Interpretation |
+The `edge_score` is a composite \[0.0–1.0\] float derived from the confluence of all active signals. Use the table below as a rough interpretive guide:
+
+| Score range | Interpretation |
 |---|---|
-| `0.75 – 1.00` | Strong signal confluence — multiple independent signals aligned |
-| `0.50 – 0.74` | Moderate confluence — worth monitoring; confirm with additional research |
-| `0.25 – 0.49` | Weak confluence — early or thin signal; treat as a watch-list item |
-| `0.00 – 0.24` | Low confluence — insufficient signal strength; generally not actionable |
+| `0.75 – 1.0` | Strong signal confluence — high-priority candidate |
+| `0.50 – 0.74` | Moderate confluence — worth reviewing |
+| `0.25 – 0.49` | Weak signal overlap — marginal candidate (default minimum threshold) |
+| `< 0.25` | Below threshold — filtered out by default |
 
-> The edge score is a composite heuristic, not a probability of profit. It reflects the degree to which available signals agree that a mispricing opportunity may exist.
+> Adjust `MIN_EDGE_SCORE` in `.env` to raise or lower the filter threshold.
 
-### Reading the Signals Map
+### Reading the `signals` Map
 
-Each key in the `signals` object corresponds to a derived feature computed by Agent 3. Common signals and their qualitative states are:
+Each key in the `signals` object maps to one of the derived features computed by the Feature Generation Agent:
 
-| Signal Key | Possible Values | What It Means |
+| Signal key | Source agent | What it represents |
 |---|---|---|
-| `volatility_gap` | `positive`, `neutral`, `negative` | Realized vol significantly above (`positive`) or below (`negative`) implied vol |
-| `narrative_velocity` | `rising`, `stable`, `falling` | Rate of acceleration of energy-related headlines |
-| `tanker_disruption_index` | `high`, `medium`, `low` | Severity of detected tanker chokepoint or shipping disruption events |
-|
+| `volatility_gap` | Feature Generation | Realized vs. implied volatility divergence |
+| `futures_curve_steepness` | Feature Generation | Contango / backwardation signal from futures curve |
+| `sector_dispersion` | Feature Generation | Cross-sector correlation breakdown |
+| `insider_conviction_score` | Feature Generation | Aggregated insider trade signal (EDGAR/Quiver) |
+| `narrative_velocity` | Feature Generation | Headline acceleration from news and social feeds |
+| `supply_shock_probability` | Feature Generation | Probability estimate of near-term supply disruption |
+| `tanker_disruption_index` | Event Detection | Shipping flow anomalies at key chokepoints |
+| `refinery_outage_index` | Event Detection | Detected refinery disruption events |
+| `geopolitical_event_score` | Event Detection | Confidence-weighted geopolitical event intensity |
+
+### Consuming Output in thinkorswim or a Dashboard
+
+The JSON output is compatible with any JSON-capable dashboard or thinkorswim's script import. Point your tool at the latest file in `$OUTPUT_PATH`, or configure the pipeline to write to a fixed path:
+
+```bash
+# Write to a fixed filename for easy dashboard polling
+python -m agent.cli run --all --output-file output/latest_candidates.json
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+| Symptom | Likely cause | Resolution |
+|---|---|---|
+| `check-config` reports an API key as unreachable | Invalid or missing key in `.env` | Re-check the key value; verify the service is not rate-limiting your IP |
+| Pipeline run exits with no candidates in output | All candidates below `MIN_EDGE_SCORE` | Lower `MIN_EDGE_SCORE` temporarily, or run in `DEBUG` mode to inspect signal values |
+| `yfinance` returns empty options chain | Market is closed or data is delayed | Options data updates daily; run during market hours or accept previous day's chain |
+| Event Detection Agent produces no events | GDELT/NewsAPI returning no matching articles | Verify `NEWSAPI_KEY` is valid; check GDELT connectivity; inspect logs for HTTP errors |
+| Feature Generation Agent raises `KeyError` on market state | Data Ingestion Agent did not complete successfully | Re-run ingestion step first: `python -m agent.cli run --agent ingestion` |
+| Historical store grows beyond available disk | Retention policy not enforced | Verify `HISTORY_RETENTION_DAYS` is set; run `python -m agent.cli pr

--- a/src/agents/alternative_data/alternative_data_agent.py
+++ b/src/agents/alternative_data/alternative_data_agent.py
@@ -3,6 +3,7 @@ Alternative Data Agent — Phase 3 fetch functions.
 
 Fetches alternative signals for the energy options opportunity agent:
   - fetch_edgar_insider_trades: SEC EDGAR Form 4 insider trade filings (issue #149)
+  - fetch_quiver_enrichment: Quiver Quantitative optional insider enrichment (issue #150)
 
 ESOD constraints: @with_retry() on all external API calls, Pydantic boundary
 models, type hints on all public functions, WARNING logs for missing/malformed
@@ -13,12 +14,19 @@ EDGAR API notes:
   - Archives:         https://www.sec.gov/Archives/edgar/data
   - No API key required; User-Agent header mandatory (EDGAR Terms of Service).
   - WTI/BZ (crude futures) have no equity insider filings — returns empty list.
+
+Quiver Quantitative API notes:
+  - Endpoint: https://api.quiverquant.com/beta/live/insiders/{ticker}
+  - Auth: Authorization: Token {QUIVER_API_KEY}
+  - Optional enrichment — if QUIVER_API_KEY is absent, returns [] (graceful no-op).
+  - HTTP errors logged as WARNING and swallowed; enrichment is best-effort.
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 import logging
+import os
 from typing import Any
 from xml.etree import ElementTree as ET
 
@@ -51,6 +59,20 @@ _TX_CODE_MAP: dict[str, str] = {
     "S": "sell",  # Open-market sale
     "A": "grant",  # Award / grant
     "M": "exercise",  # Option exercise
+}
+
+# ---------------------------------------------------------------------------
+# Quiver Quantitative constants
+# ---------------------------------------------------------------------------
+
+_QUIVER_BASE_URL = "https://api.quiverquant.com"
+
+# Quiver transaction labels → trade_type values
+_QUIVER_TX_MAP: dict[str, str] = {
+    "Buy": "buy",
+    "Sale": "sell",
+    "Award": "grant",
+    "Option Exercise": "exercise",
 }
 
 # ---------------------------------------------------------------------------
@@ -302,3 +324,136 @@ def _parse_form4_xml(xml_text: str, instrument: str) -> list[InsiderTrade]:
         )
 
     return trades
+
+
+# ---------------------------------------------------------------------------
+# Quiver Quantitative fetch function
+# ---------------------------------------------------------------------------
+
+
+@with_retry()
+def fetch_quiver_enrichment(instruments: list[str]) -> list[InsiderTrade]:
+    """
+    Optionally enrich insider trade data via Quiver Quantitative API.
+
+    Returns an empty list and logs INFO if ``QUIVER_API_KEY`` is not set.
+    HTTP errors are logged as WARNING and swallowed — this is best-effort
+    optional enrichment; a Quiver outage must not block the pipeline.
+
+    Args:
+        instruments: Ticker symbols to enrich (e.g. ["XOM", "CVX"]).
+
+    Returns:
+        List of InsiderTrade records with ``source="quiver"``, or ``[]``
+        if the API key is absent or all requests fail.
+    """
+    api_key = os.environ.get("QUIVER_API_KEY", "").strip()
+    if not api_key:
+        logger.info("fetch_quiver_enrichment: QUIVER_API_KEY not set — skipping enrichment")
+        return []
+
+    all_trades: list[InsiderTrade] = []
+    for ticker in instruments:
+        trades = _fetch_quiver_ticker(ticker, api_key)
+        all_trades.extend(trades)
+    return all_trades
+
+
+def _fetch_quiver_ticker(ticker: str, api_key: str) -> list[InsiderTrade]:
+    """
+    Fetch insider trades for a single ticker from Quiver Quantitative.
+
+    HTTP errors are logged as WARNING and return an empty list so a
+    single failed ticker does not abort the whole enrichment pass.
+
+    Args:
+        ticker:  Ticker symbol (e.g. "XOM").
+        api_key: Quiver Quantitative API key.
+
+    Returns:
+        List of InsiderTrade records for the ticker, or ``[]`` on failure.
+    """
+    url = f"{_QUIVER_BASE_URL}/beta/live/insiders/{ticker}"
+    try:
+        resp = requests.get(
+            url,
+            headers={"Authorization": f"Token {api_key}"},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        rows: list[dict[str, Any]] = resp.json()
+    except requests.exceptions.HTTPError as exc:
+        logger.warning("fetch_quiver_enrichment: HTTP error for ticker=%s: %s", ticker, exc)
+        return []
+    except requests.exceptions.RequestException as exc:
+        logger.warning("fetch_quiver_enrichment: request failed for ticker=%s: %s", ticker, exc)
+        return []
+
+    trades: list[InsiderTrade] = []
+    for row in rows:
+        trade = _parse_quiver_row(row, ticker)
+        if trade is not None:
+            trades.append(trade)
+    return trades
+
+
+def _parse_quiver_row(row: dict[str, Any], instrument: str) -> InsiderTrade | None:
+    """
+    Parse a single Quiver API response row into an InsiderTrade.
+
+    Rows with unmapped transaction types or unparseable dates are
+    logged as WARNING and return None.
+
+    Args:
+        row:        Single dict from the Quiver API response list.
+        instrument: Ticker symbol to attach to the record.
+
+    Returns:
+        InsiderTrade on success, None if the row should be skipped.
+    """
+    raw_type = str(row.get("Transaction", ""))
+    trade_type = _QUIVER_TX_MAP.get(raw_type)
+    if trade_type is None:
+        logger.warning(
+            "fetch_quiver_enrichment: unmapped transaction type %r for ticker=%s — skipping",
+            raw_type,
+            instrument,
+        )
+        return None
+
+    raw_date = str(row.get("Date", "")).strip()
+    try:
+        trade_date = datetime.strptime(raw_date, "%Y-%m-%d").replace(tzinfo=UTC)
+    except ValueError:
+        logger.warning(
+            "fetch_quiver_enrichment: unparseable date %r for ticker=%s — skipping",
+            raw_date,
+            instrument,
+        )
+        return None
+
+    shares: int | None = None
+    raw_shares = row.get("Shares")
+    if raw_shares is not None:
+        try:
+            shares = int(float(raw_shares))
+        except (ValueError, TypeError):
+            pass
+
+    value_usd: float | None = None
+    raw_price = row.get("Price")
+    if shares is not None and raw_price is not None:
+        try:
+            value_usd = round(shares * float(raw_price), 2)
+        except (ValueError, TypeError):
+            pass
+
+    return InsiderTrade(
+        instrument=instrument,
+        trade_date=trade_date,
+        trade_type=trade_type,
+        shares=shares,
+        value_usd=value_usd,
+        officer_name=str(row.get("Name", "")).strip() or None,
+        source="quiver",
+    )

--- a/src/agents/alternative_data/alternative_data_agent.py
+++ b/src/agents/alternative_data/alternative_data_agent.py
@@ -32,7 +32,7 @@ from xml.etree import ElementTree as ET
 
 import requests
 
-from src.agents.alternative_data.models import InsiderTrade
+from src.agents.alternative_data.models import InsiderTrade, QuiverInsiderRow
 from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
@@ -66,6 +66,7 @@ _TX_CODE_MAP: dict[str, str] = {
 # ---------------------------------------------------------------------------
 
 _QUIVER_BASE_URL = "https://api.quiverquant.com"
+_QUIVER_HTTP_TIMEOUT = 30  # seconds; consistent with EDGAR helpers above
 
 # Quiver transaction labels → trade_type values
 _QUIVER_TX_MAP: dict[str, str] = {
@@ -363,55 +364,74 @@ def _fetch_quiver_ticker(ticker: str, api_key: str) -> list[InsiderTrade]:
     """
     Fetch insider trades for a single ticker from Quiver Quantitative.
 
-    HTTP errors are logged as WARNING and return an empty list so a
-    single failed ticker does not abort the whole enrichment pass.
+    HTTP errors (4xx/5xx) are logged as WARNING and return ``[]`` — a bad
+    ticker or auth failure must not abort the enrichment pass. Transient
+    network errors (timeout, connection refused) are re-raised so the
+    ``@with_retry()`` on ``fetch_quiver_enrichment`` can retry them.
 
     Args:
         ticker:  Ticker symbol (e.g. "XOM").
         api_key: Quiver Quantitative API key.
 
     Returns:
-        List of InsiderTrade records for the ticker, or ``[]`` on failure.
+        List of InsiderTrade records for the ticker, or ``[]`` on HTTP failure.
+
+    Raises:
+        requests.exceptions.RequestException: On transient network failure,
+            propagated so tenacity can retry the full enrichment call.
     """
     url = f"{_QUIVER_BASE_URL}/beta/live/insiders/{ticker}"
     try:
         resp = requests.get(
             url,
             headers={"Authorization": f"Token {api_key}"},
-            timeout=30,
+            timeout=_QUIVER_HTTP_TIMEOUT,
         )
         resp.raise_for_status()
-        rows: list[dict[str, Any]] = resp.json()
     except requests.exceptions.HTTPError as exc:
+        # HTTP 4xx/5xx: log and degrade gracefully — retrying won't help
         logger.warning("fetch_quiver_enrichment: HTTP error for ticker=%s: %s", ticker, exc)
         return []
-    except requests.exceptions.RequestException as exc:
-        logger.warning("fetch_quiver_enrichment: request failed for ticker=%s: %s", ticker, exc)
+    # Network-level errors (Timeout, ConnectionError, etc.) propagate to tenacity
+
+    raw_response = resp.json()
+    if not isinstance(raw_response, list):
+        logger.warning(
+            "fetch_quiver_enrichment: unexpected response shape for ticker=%s (not a list)",
+            ticker,
+        )
         return []
 
     trades: list[InsiderTrade] = []
-    for row in rows:
-        trade = _parse_quiver_row(row, ticker)
+    for raw_row in raw_response:
+        try:
+            validated_row = QuiverInsiderRow.model_validate(raw_row)
+        except Exception as exc:  # Pydantic ValidationError is broad — catch-all intentional
+            logger.warning(
+                "fetch_quiver_enrichment: row validation failed for ticker=%s: %s", ticker, exc
+            )
+            continue
+        trade = _parse_quiver_row(validated_row, ticker)
         if trade is not None:
             trades.append(trade)
     return trades
 
 
-def _parse_quiver_row(row: dict[str, Any], instrument: str) -> InsiderTrade | None:
+def _parse_quiver_row(row: QuiverInsiderRow, instrument: str) -> InsiderTrade | None:
     """
-    Parse a single Quiver API response row into an InsiderTrade.
+    Parse a validated ``QuiverInsiderRow`` into an ``InsiderTrade``.
 
     Rows with unmapped transaction types or unparseable dates are
     logged as WARNING and return None.
 
     Args:
-        row:        Single dict from the Quiver API response list.
+        row:        Validated ``QuiverInsiderRow`` from the API response.
         instrument: Ticker symbol to attach to the record.
 
     Returns:
         InsiderTrade on success, None if the row should be skipped.
     """
-    raw_type = str(row.get("Transaction", ""))
+    raw_type = str(row.Transaction or "")
     trade_type = _QUIVER_TX_MAP.get(raw_type)
     if trade_type is None:
         logger.warning(
@@ -421,7 +441,7 @@ def _parse_quiver_row(row: dict[str, Any], instrument: str) -> InsiderTrade | No
         )
         return None
 
-    raw_date = str(row.get("Date", "")).strip()
+    raw_date = str(row.Date or "").strip()
     try:
         trade_date = datetime.strptime(raw_date, "%Y-%m-%d").replace(tzinfo=UTC)
     except ValueError:
@@ -432,21 +452,10 @@ def _parse_quiver_row(row: dict[str, Any], instrument: str) -> InsiderTrade | No
         )
         return None
 
-    shares: int | None = None
-    raw_shares = row.get("Shares")
-    if raw_shares is not None:
-        try:
-            shares = int(float(raw_shares))
-        except (ValueError, TypeError):
-            pass
-
-    value_usd: float | None = None
-    raw_price = row.get("Price")
-    if shares is not None and raw_price is not None:
-        try:
-            value_usd = round(shares * float(raw_price), 2)
-        except (ValueError, TypeError):
-            pass
+    shares: int | None = int(row.Shares) if row.Shares is not None else None
+    value_usd: float | None = (
+        round(shares * row.Price, 2) if shares is not None and row.Price is not None else None
+    )
 
     return InsiderTrade(
         instrument=instrument,
@@ -454,6 +463,6 @@ def _parse_quiver_row(row: dict[str, Any], instrument: str) -> InsiderTrade | No
         trade_type=trade_type,
         shares=shares,
         value_usd=value_usd,
-        officer_name=str(row.get("Name", "")).strip() or None,
+        officer_name=str(row.Name or "").strip() or None,
         source="quiver",
     )

--- a/src/agents/alternative_data/models.py
+++ b/src/agents/alternative_data/models.py
@@ -23,6 +23,21 @@ class TradeType(StrEnum):
     EXERCISE = "exercise"
 
 
+class QuiverInsiderRow(BaseModel):
+    """
+    Raw row from Quiver Quantitative ``/beta/live/insiders/{ticker}`` API.
+
+    All fields are optional — the Pydantic boundary validates the shape before
+    any field access in ``_parse_quiver_row`` (ESOD §6).
+    """
+
+    Transaction: str | None = None
+    Date: str | None = None
+    Name: str | None = None
+    Shares: float | None = None  # API may return float; cast to int downstream
+    Price: float | None = None
+
+
 class InsiderTrade(BaseModel):
     """
     Validated insider trade record from SEC EDGAR Form 4.

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -451,3 +451,34 @@ class TestFetchQuiverEnrichment:
 
         assert result == []
         assert any("unmapped transaction type" in r.message.lower() for r in caplog.records)
+
+    def test_network_error_propagates_for_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Transient network errors propagate so @with_retry() can retry them."""
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+        monkeypatch.setenv("TENACITY_MAX_RETRIES", "1")
+
+        with patch(
+            "requests.get",
+            side_effect=requests.exceptions.ConnectionError("connection refused"),
+        ):
+            with pytest.raises(requests.exceptions.ConnectionError):
+                fetch_quiver_enrichment(["XOM"])
+
+    def test_non_list_response_returns_empty_list_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If the API returns a dict instead of a list, log WARNING and return []."""
+        import logging
+
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"error": "unexpected shape"}
+
+        with patch("requests.get", return_value=mock_resp):
+            with caplog.at_level(logging.WARNING):
+                result = fetch_quiver_enrichment(["XOM"])
+
+        assert result == []
+        assert any("unexpected response shape" in r.message.lower() for r in caplog.records)

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -1,10 +1,10 @@
 """
-Unit tests for fetch_edgar_insider_trades (issue #149).
+Unit tests for alternative_data_agent (issues #149, #150).
 
-Tests use mocked HTTP responses — no real EDGAR API calls.
+Tests use mocked HTTP responses — no real API calls.
 Integration tests (real network) belong in a separate integration test file.
 
-Coverage:
+Coverage (EDGAR #149):
   - Happy path: EFTS hit → XML fetch → parse → InsiderTrade records returned
   - Malformed XML: parse error logged as WARNING, empty list returned
   - Empty EFTS result: no hits, empty list returned
@@ -12,6 +12,13 @@ Coverage:
   - Instrument filter: only specified instruments searched
   - Unmapped transaction code: skipped silently (no InsiderTrade for "F")
   - Missing officer name: officer_name=None allowed
+
+Coverage (Quiver #150):
+  - No API key: logs INFO, returns [] (graceful no-op)
+  - Happy path: API response → InsiderTrade records with source="quiver"
+  - HTTP error: logged as WARNING, returns [] (not raised)
+  - Empty response: returns []
+  - Unmapped transaction type: skipped with WARNING
 """
 
 from __future__ import annotations
@@ -27,6 +34,7 @@ from src.agents.alternative_data.alternative_data_agent import (
     _efts_search,
     _parse_form4_xml,
     fetch_edgar_insider_trades,
+    fetch_quiver_enrichment,
 )
 from src.agents.alternative_data.models import InsiderTrade
 
@@ -319,3 +327,127 @@ class TestFetchEdgarInsiderTrades:
 
         assert trades == []
         assert any("no xml" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# fetch_quiver_enrichment tests (issue #150)
+# ---------------------------------------------------------------------------
+
+
+def _quiver_row(
+    ticker: str = "XOM",
+    transaction: str = "Buy",
+    date: str = "2024-06-01",
+    shares: int = 5000,
+    price: float = 110.00,
+    name: str = "Jane Smith",
+) -> dict:
+    """Minimal Quiver API response row."""
+    return {
+        "Transaction": transaction,
+        "Date": date,
+        "Shares": shares,
+        "Price": price,
+        "Name": name,
+    }
+
+
+class TestFetchQuiverEnrichment:
+    def test_no_api_key_returns_empty_list_and_logs_info(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """If QUIVER_API_KEY is absent, return [] and log INFO — no HTTP call made."""
+        import logging
+
+        monkeypatch.delenv("QUIVER_API_KEY", raising=False)
+
+        with patch("requests.get") as mock_get:
+            with caplog.at_level(logging.INFO):
+                result = fetch_quiver_enrichment(["XOM", "CVX"])
+
+        assert result == []
+        mock_get.assert_not_called()
+        assert any("quiver_api_key not set" in r.message.lower() for r in caplog.records)
+
+    def test_happy_path_returns_insider_trade_records(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Valid API response produces InsiderTrade records with source='quiver'."""
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = [
+            _quiver_row("XOM", "Buy", "2024-06-01", 5000, 110.00, "Jane Smith"),
+            _quiver_row("XOM", "Sale", "2024-05-15", 2000, 108.50, "Bob Jones"),
+        ]
+
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_quiver_enrichment(["XOM"])
+
+        assert len(result) == 2
+        buy = result[0]
+        assert isinstance(buy, InsiderTrade)
+        assert buy.instrument == "XOM"
+        assert buy.trade_type == "buy"
+        assert buy.source == "quiver"
+        assert buy.shares == 5000
+        assert buy.value_usd == round(5000 * 110.00, 2)
+        assert buy.officer_name == "Jane Smith"
+        assert buy.trade_date == datetime(2024, 6, 1, tzinfo=UTC)
+
+        sell = result[1]
+        assert sell.trade_type == "sell"
+        assert sell.shares == 2000
+
+    def test_http_error_logged_as_warning_not_raised(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """HTTP errors are swallowed (logged WARNING, return []) — pipeline must not break."""
+        import logging
+
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("403 Forbidden")
+
+        with patch("requests.get", return_value=mock_resp):
+            with caplog.at_level(logging.WARNING):
+                result = fetch_quiver_enrichment(["XOM"])
+
+        assert result == []
+        assert any("http error" in r.message.lower() for r in caplog.records)
+
+    def test_empty_response_returns_empty_list(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty API response list returns [] without error."""
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = []
+
+        with patch("requests.get", return_value=mock_resp):
+            result = fetch_quiver_enrichment(["CVX"])
+
+        assert result == []
+
+    def test_unmapped_transaction_type_skipped_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Rows with unmapped transaction types are skipped and logged as WARNING."""
+        import logging
+
+        monkeypatch.setenv("QUIVER_API_KEY", "test-key-123")
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = [
+            _quiver_row("XOM", "Unknown Disposition", "2024-06-01"),
+        ]
+
+        with patch("requests.get", return_value=mock_resp):
+            with caplog.at_level(logging.WARNING):
+                result = fetch_quiver_enrichment(["XOM"])
+
+        assert result == []
+        assert any("unmapped transaction type" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary
- `fetch_quiver_enrichment(instruments)` queries Quiver Quantitative `/beta/live/insiders/{ticker}` for each instrument
- Guarded by `QUIVER_API_KEY` env var — absent key logs INFO and returns `[]` (graceful no-op, no HTTP call)
- HTTP errors swallowed as WARNING — optional enrichment must not block the pipeline
- Returns `InsiderTrade` records with `source="quiver"` via `_QUIVER_TX_MAP` (Buy/Sale/Award/Option Exercise)
- `@with_retry()` applied per ESOD; private helpers `_fetch_quiver_ticker` and `_parse_quiver_row`
- 5 unit tests: no-key skip, happy path, HTTP error, empty response, unmapped transaction type
- `.env.example`: `QUIVER_API_KEY` documented as optional with sign-up comment
- All 5 `local_check.sh` stages pass (271 unit tests)

## Test plan
- [ ] `pytest tests/agents/alternative_data/ -v` — all tests pass
- [ ] `bash scripts/local_check.sh` exits 0
- [ ] With `QUIVER_API_KEY` unset: `fetch_quiver_enrichment(["XOM"])` returns `[]` and logs INFO
- [ ] With valid key: returns `InsiderTrade` list with `source="quiver"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)