### PR TITLE
feat(alternative-data): implement fetch_tanker_flows — MarineTraffic chokepoint vessel events (#153)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ EDGAR_BASE_URL=https://efts.sec.gov/LATEST/search-index
 QUIVER_API_KEY=YOUR_QUIVER_API_KEY
 
 # --- Shipping / Logistics ---
+# Required by fetch_tanker_flows() (issue #153). Without this key the function
+# logs a WARNING and returns [] gracefully — no error raised.
+# Free tier: register at https://www.marinetraffic.com/en/online-services/plans
 MARINETRAFFIC_API_KEY=YOUR_MARINETRAFFIC_API_KEY
 
 # --- LLM Provider (via src/core/llm_wrapper.py only — never direct in agent code) ---

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -438,3 +438,18 @@ Implementation details:
 - 12 unit tests: bullish majority, bearish majority, neutral (equal), unlabeled neutral, multi-instrument, empty stream, 404, 429 graceful skip, mid-batch 429, HTTP error propagation.
 - All 5 local_check.sh stages pass (ruff, black 26.3.1, mypy strict, import scan, 288 unit tests).
 - #152 In Review, PR #184 opened 2026-03-22
+
+## Sprint Notes (2026-03-22, session 4)
+
+**#152 CLOSED** — PR #184 merged to develop by human lead 2026-03-22.
+
+**#153 IN REVIEW** — fetch_tanker_flows implemented. PR #185 open → develop.
+
+- `src/agents/alternative_data/alternative_data_agent.py`: `fetch_tanker_flows()` queries MarineTraffic getVesselsInArea v:8 for 3 chokepoints (Strait of Hormuz, Suez Canal, Bosphorus).
+- `src/agents/alternative_data/models.py`: `EventType` StrEnum + `ShippingEvent` Pydantic model added.
+- `MARINETRAFFIC_API_KEY` absent → WARNING + []; malformed vessel records → WARNING + skip.
+- Speed ≤ 0.5 knots → anchored; otherwise transit. `_CHOKEPOINTS` named constant with bounding boxes.
+- 11 unit tests covering all AC scenarios; 299 total passing.
+- `.env.example` updated with MARINETRAFFIC_API_KEY placeholder and comment.
+- All 5 local_check.sh stages pass (ruff, black 26.3.1, mypy strict, import scan).
+- #153 In Review, PR #185 opened 2026-03-22

--- a/docs/generated/user_guide_full-pipeline.md
+++ b/docs/generated/user_guide_full-pipeline.md
@@ -1,7 +1,7 @@
 # Energy Options Opportunity Agent — User Guide
 
-> **Version 1.0 · March 2026**
-> This guide covers the full pipeline: setup, configuration, execution, output interpretation, and troubleshooting.
+> **Version 1.0 • March 2026**
+> This guide walks you through installing, configuring, and running the full Energy Options Opportunity Agent pipeline. It assumes familiarity with Python (3.10+) and standard CLI tooling.
 
 ---
 
@@ -18,348 +18,324 @@
 
 ## Overview
 
-The **Energy Options Opportunity Agent** is a modular, four-agent Python pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets, then surfaces volatility mispricing in oil-related instruments and ranks candidate strategies by a computed **edge score**.
+The Energy Options Opportunity Agent is an autonomous, modular pipeline that identifies options trading opportunities driven by oil market instability. It ingests market data, supply signals, news events, and alternative datasets to produce structured, ranked candidate options strategies.
 
-The pipeline is **advisory only** — it produces ranked recommendations but does not execute trades.
-
-### Pipeline Architecture
+The pipeline is composed of **four loosely coupled agents** that execute in a fixed sequence, each writing results to a shared state store consumed by the next stage.
 
 ```mermaid
 flowchart LR
-    subgraph Ingestion["① Data Ingestion Agent"]
-        A1[Crude Prices\nAlpha Vantage / MetalpriceAPI]
-        A2[ETF & Equity Prices\nyfinance / Yahoo Finance]
-        A3[Options Chains\nYahoo Finance / Polygon.io]
+    subgraph Ingestion ["① Data Ingestion Agent"]
+        A1[Crude Prices\nWTI · Brent]
+        A2[ETF / Equity Prices\nUSO · XLE · XOM · CVX]
+        A3[Options Chains\nIV · Strike · Volume]
     end
 
-    subgraph Events["② Event Detection Agent"]
-        B1[News & Geo Events\nGDELT / NewsAPI]
-        B2[Supply & Inventory\nEIA API]
-        B3[Shipping / Logistics\nMarineTraffic / VesselFinder]
+    subgraph Event ["② Event Detection Agent"]
+        B1[News & Geo Feeds\nGDELT · NewsAPI]
+        B2[Supply Signals\nEIA · MarineTraffic]
+        B3[Confidence &\nIntensity Scores]
     end
 
-    subgraph Features["③ Feature Generation Agent"]
-        C1[Volatility Gap\nRealized vs Implied]
-        C2[Futures Curve Steepness]
-        C3[Sector Dispersion]
-        C4[Insider Conviction Score\nSEC EDGAR / Quiver Quant]
-        C5[Narrative Velocity\nReddit / Stocktwits]
-        C6[Supply Shock Probability]
+    subgraph Feature ["③ Feature Generation Agent"]
+        C1[Volatility Gap\nRealised vs Implied]
+        C2[Futures Curve\nSteepness]
+        C3[Supply Shock\nProbability]
+        C4[Narrative Velocity\nInsider Conviction]
     end
 
-    subgraph Strategy["④ Strategy Evaluation Agent"]
-        D1[Evaluate Option Structures]
-        D2[Compute Edge Scores]
-        D3[Ranked Candidates + Signals]
+    subgraph Strategy ["④ Strategy Evaluation Agent"]
+        D1[Score Candidate\nStructures]
+        D2[Rank by\nEdge Score]
+        D3[Emit JSON\nOutput]
     end
 
-    MS[(Shared Market\nState Object)]
-    FS[(Derived\nFeatures Store)]
-    OUT[📄 JSON Output]
-
-    Ingestion --> MS
-    Events --> MS
-    MS --> Features
-    Features --> FS
-    FS --> Strategy
-    Strategy --> OUT
+    RAW[(Market State\nObject)] --> Event
+    Ingestion --> RAW
+    Event --> FEAT[(Derived\nFeatures Store)]
+    Feature --> FEAT
+    FEAT --> Strategy
+    Strategy --> OUT[(candidates.json)]
 ```
 
-### In-Scope Instruments
+### Key design properties
 
-| Category | Instruments |
+| Property | Description |
 |---|---|
-| Crude Futures | Brent Crude, WTI (`CL=F`) |
+| **Advisory only** | No automated trade execution — all output is informational. |
+| **Explainable** | Every ranked candidate includes contributing signal references. |
+| **Resilient** | Tolerates delayed or missing data without pipeline failure. |
+| **Lightweight** | Runs on local hardware or a single low-cost VM / container. |
+| **Modular** | Each agent is independently deployable and updatable. |
+
+### In-scope instruments (MVP)
+
+| Type | Instruments |
+|---|---|
+| Crude futures | WTI (`CL=F`), Brent (`BZ=F`) |
 | ETFs | USO, XLE |
-| Energy Equities | Exxon Mobil (XOM), Chevron (CVX) |
+| Energy equities | XOM (Exxon Mobil), CVX (Chevron) |
 
-### In-Scope Option Structures (MVP)
+### In-scope option structures (MVP)
 
-| Structure | Enum Value |
-|---|---|
-| Long Straddle | `long_straddle` |
-| Call Spread | `call_spread` |
-| Put Spread | `put_spread` |
-| Calendar Spread | `calendar_spread` |
-
-> **Out of scope for MVP:** exotic/multi-legged structures, regional refined product pricing (OPIS), automated trade execution.
+`long_straddle` · `call_spread` · `put_spread` · `calendar_spread`
 
 ---
 
 ## Prerequisites
 
-### System Requirements
+### System requirements
 
 | Requirement | Minimum |
 |---|---|
-| Python | 3.10+ |
-| OS | Linux, macOS, or Windows (WSL2 recommended) |
+| Python | 3.10 or later |
 | RAM | 2 GB |
-| Disk | 5 GB (for 6–12 months of historical data) |
-| Deployment target | Local machine, single VM, or container |
+| Disk (data retention) | 10 GB (supports 6–12 months of historical data) |
+| OS | Linux, macOS, or Windows (WSL2 recommended) |
 
-### Software Dependencies
+### External accounts & API keys
 
-Ensure the following are installed before proceeding:
+All required data sources are free or free-tier. Register for the following before proceeding:
+
+| Service | Purpose | Sign-up URL |
+|---|---|---|
+| Alpha Vantage | WTI / Brent crude prices | <https://www.alphavantage.co/support/#api-key> |
+| Polygon.io | Options chains (supplementary) | <https://polygon.io/> |
+| EIA Open Data | Inventory & refinery utilization | <https://www.eia.gov/opendata/> |
+| NewsAPI | News & geopolitical headlines | <https://newsapi.org/register> |
+| SEC EDGAR | Insider activity (EDGAR full-text) | No key required — public API |
+| MarineTraffic | Tanker / shipping flows (free tier) | <https://www.marinetraffic.com/en/p/api-services> |
+
+> **Note:** `yfinance` and GDELT require no API key. Reddit / Stocktwits public endpoints are unauthenticated at free-tier usage volumes.
+
+### Python dependencies
 
 ```bash
-# Verify Python version
-python --version   # Expected: Python 3.10.x or higher
-
-# Verify pip
-pip --version
-
-# Verify git
-git --version
+pip install -r requirements.txt
 ```
 
-### API Accounts
+A minimal `requirements.txt` includes:
 
-Register for the following free or low-cost data sources before configuring the pipeline. All are free-tier unless noted.
-
-| Data Layer | Source | Sign-up URL | Cost |
-|---|---|---|---|
-| Crude Prices | Alpha Vantage | https://www.alphavantage.co | Free |
-| Crude Prices (alt) | MetalpriceAPI | https://metalpriceapi.com | Free |
-| ETF / Equity Prices | yfinance (Yahoo Finance) | No key required | Free |
-| Options Data | Polygon.io | https://polygon.io | Free / Limited |
-| Supply & Inventory | EIA API | https://www.eia.gov/opendata | Free |
-| News & Geo Events | GDELT | No key required | Free |
-| News & Geo Events (alt) | NewsAPI | https://newsapi.org | Free |
-| Insider Activity | SEC EDGAR | No key required | Free |
-| Insider Activity (alt) | Quiver Quant | https://www.quiverquant.com | Free / Limited |
-| Shipping / Logistics | MarineTraffic | https://www.marinetraffic.com | Free tier |
-| Narrative / Sentiment | Reddit (PRAW) | https://www.reddit.com/prefs/apps | Free |
-| Narrative / Sentiment | Stocktwits | https://api.stocktwits.com | Free |
+```text
+yfinance>=0.2
+requests>=2.31
+pandas>=2.0
+numpy>=1.26
+python-dotenv>=1.0
+```
 
 ---
 
 ## Setup & Configuration
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/your-org/energy-options-agent.git
 cd energy-options-agent
 ```
 
-### 2. Create and Activate a Virtual Environment
+### 2. Create and activate a virtual environment
 
 ```bash
 python -m venv .venv
-
-# macOS / Linux
-source .venv/bin/activate
-
-# Windows (PowerShell)
-.venv\Scripts\Activate.ps1
+source .venv/bin/activate        # macOS / Linux
+# .venv\Scripts\activate         # Windows (PowerShell)
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
-pip install --upgrade pip
 pip install -r requirements.txt
 ```
 
-### 4. Configure Environment Variables
+### 4. Configure environment variables
 
-Copy the provided template and populate it with your API credentials:
+Copy the provided template and populate your credentials:
 
 ```bash
 cp .env.example .env
 ```
 
-Open `.env` in your editor and fill in every value. The full set of supported environment variables is documented in the table below.
+Open `.env` in your editor and fill in each value:
 
-#### Environment Variable Reference
+```dotenv
+# --- Data Ingestion ---
+ALPHA_VANTAGE_API_KEY=your_alpha_vantage_key
+POLYGON_API_KEY=your_polygon_key
+EIA_API_KEY=your_eia_key
+
+# --- Event Detection ---
+NEWS_API_KEY=your_newsapi_key
+GDELT_ENABLED=true                  # set false to disable GDELT polling
+
+# --- Alternative Signals ---
+MARINE_TRAFFIC_API_KEY=your_mt_key
+REDDIT_CLIENT_ID=your_reddit_client_id
+REDDIT_CLIENT_SECRET=your_reddit_client_secret
+REDDIT_USER_AGENT=energy-agent/1.0
+
+# --- Storage ---
+DATA_DIR=./data                     # root directory for raw and derived data
+RETENTION_DAYS=365                  # 6–12 months; 180–365 recommended
+
+# --- Pipeline Behaviour ---
+MARKET_DATA_INTERVAL_MINUTES=5      # cadence for minute-level market data refresh
+LOG_LEVEL=INFO                      # DEBUG | INFO | WARNING | ERROR
+OUTPUT_PATH=./output/candidates.json
+```
+
+#### Full environment variable reference
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `ALPHA_VANTAGE_API_KEY` | Yes | — | API key for Alpha Vantage crude price feed |
-| `METALPRICE_API_KEY` | Optional | — | Fallback API key for MetalpriceAPI crude feed |
-| `POLYGON_API_KEY` | Optional | — | API key for Polygon.io options chain data |
-| `EIA_API_KEY` | Yes | — | API key for EIA supply/inventory data |
-| `NEWSAPI_KEY` | Optional | — | API key for NewsAPI news/geo-event feed |
-| `REDDIT_CLIENT_ID` | Optional | — | Reddit OAuth client ID (PRAW) |
-| `REDDIT_CLIENT_SECRET` | Optional | — | Reddit OAuth client secret (PRAW) |
-| `REDDIT_USER_AGENT` | Optional | `energy-agent/1.0` | Reddit PRAW user-agent string |
-| `QUIVER_API_KEY` | Optional | — | API key for Quiver Quant insider data |
-| `MARINE_TRAFFIC_API_KEY` | Optional | — | API key for MarineTraffic shipping data |
-| `DATA_DIR` | No | `./data` | Root directory for persisted raw and derived data |
-| `OUTPUT_DIR` | No | `./output` | Directory where JSON output files are written |
-| `LOG_LEVEL` | No | `INFO` | Logging verbosity: `DEBUG`, `INFO`, `WARNING`, `ERROR` |
-| `HISTORY_MONTHS` | No | `12` | Months of historical data to retain (minimum: `6`) |
-| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for market price feeds (minutes) |
-| `PIPELINE_MODE` | No | `full` | Run mode: `full` \| `ingest_only` \| `features_only` \| `strategy_only` |
+| `ALPHA_VANTAGE_API_KEY` | Yes | — | Crude price feed (WTI, Brent) |
+| `POLYGON_API_KEY` | Recommended | — | Options chain data (strike, expiry, IV, volume) |
+| `EIA_API_KEY` | Yes (Phase 2+) | — | Weekly inventory & refinery utilization |
+| `NEWS_API_KEY` | Yes (Phase 2+) | — | Energy news headlines |
+| `GDELT_ENABLED` | No | `true` | Toggle GDELT geopolitical feed |
+| `MARINE_TRAFFIC_API_KEY` | No (Phase 3+) | — | Tanker flow data |
+| `REDDIT_CLIENT_ID` | No (Phase 3+) | — | Reddit API OAuth client ID |
+| `REDDIT_CLIENT_SECRET` | No (Phase 3+) | — | Reddit API OAuth client secret |
+| `REDDIT_USER_AGENT` | No (Phase 3+) | `energy-agent/1.0` | Reddit API user-agent string |
+| `DATA_DIR` | No | `./data` | Root path for raw and derived data storage |
+| `RETENTION_DAYS` | No | `365` | Days of historical data to retain |
+| `MARKET_DATA_INTERVAL_MINUTES` | No | `5` | Polling cadence for market price feeds |
+| `LOG_LEVEL` | No | `INFO` | Logging verbosity |
+| `OUTPUT_PATH` | No | `./output/candidates.json` | File path for JSON candidate output |
 
-> **Tip:** Optional variables activate specific data layers. The pipeline tolerates missing feeds and continues without them; however, edge score completeness depends on how many layers are active. See [Troubleshooting](#troubleshooting) for degraded-mode behaviour.
+> **Security:** Never commit `.env` to version control. The repository's `.gitignore` excludes it by default.
 
-#### Example `.env` File
-
-```dotenv
-# --- Required ---
-ALPHA_VANTAGE_API_KEY=YOUR_AV_KEY_HERE
-EIA_API_KEY=YOUR_EIA_KEY_HERE
-
-# --- Optional: enriches options data ---
-POLYGON_API_KEY=YOUR_POLYGON_KEY_HERE
-
-# --- Optional: news & geo-event layer ---
-NEWSAPI_KEY=YOUR_NEWSAPI_KEY_HERE
-
-# --- Optional: narrative velocity layer ---
-REDDIT_CLIENT_ID=YOUR_REDDIT_CLIENT_ID
-REDDIT_CLIENT_SECRET=YOUR_REDDIT_CLIENT_SECRET
-REDDIT_USER_AGENT=energy-agent/1.0
-
-# --- Optional: insider activity layer ---
-QUIVER_API_KEY=YOUR_QUIVER_KEY_HERE
-
-# --- Optional: shipping/logistics layer ---
-MARINE_TRAFFIC_API_KEY=YOUR_MT_KEY_HERE
-
-# --- Pipeline settings ---
-DATA_DIR=./data
-OUTPUT_DIR=./output
-LOG_LEVEL=INFO
-HISTORY_MONTHS=12
-MARKET_DATA_INTERVAL_MINUTES=5
-PIPELINE_MODE=full
-```
-
-### 5. Initialise the Data Store
-
-Run the initialisation command to create the required directory structure and seed the historical data store for the configured retention window:
+### 5. Initialise the data directory
 
 ```bash
-python -m agent init
+python -m agent.init_storage
 ```
 
-Expected output:
+This creates the subdirectory structure under `DATA_DIR`:
 
 ```
-[INFO] Initialising data store at ./data
-[INFO] Creating directories: raw/, derived/, options/
-[INFO] Seeding historical data (12 months)... done
-[INFO] Data store ready.
+data/
+├── raw/          # unprocessed feed snapshots
+├── derived/      # computed features and scored events
+└── archive/      # data older than RETENTION_DAYS (pruned on each run)
 ```
 
 ---
 
 ## Running the Pipeline
 
-### Pipeline Execution Flow
+### Pipeline sequence
+
+Each run executes all four agents in order. The diagram below shows the sequence for a single pipeline invocation:
 
 ```mermaid
 sequenceDiagram
-    participant User
-    participant CLI as CLI / Scheduler
+    participant CLI as User / Scheduler
     participant DIA as Data Ingestion Agent
     participant EDA as Event Detection Agent
     participant FGA as Feature Generation Agent
     participant SEA as Strategy Evaluation Agent
-    participant Store as Data Store
-    participant Out as JSON Output
+    participant Store as Shared State & Features Store
+    participant Out as candidates.json
 
-    User->>CLI: python -m agent run
-    CLI->>DIA: fetch & normalise feeds
-    DIA->>Store: write market state object
-    CLI->>EDA: scan news, EIA, shipping
-    EDA->>Store: write event scores
-    CLI->>FGA: compute derived signals
-    FGA->>Store: write features store
-    CLI->>SEA: evaluate option structures
-    SEA->>Out: write ranked candidates (JSON)
-    Out-->>User: ./output/candidates_<timestamp>.json
+    CLI->>DIA: python -m agent.run
+    DIA->>Store: write unified market state object
+    DIA-->>CLI: ✓ ingestion complete
+
+    CLI->>EDA: (automatic)
+    EDA->>Store: read market state
+    EDA->>Store: write scored events (confidence + intensity)
+    EDA-->>CLI: ✓ event detection complete
+
+    CLI->>FGA: (automatic)
+    FGA->>Store: read market state + scored events
+    FGA->>Store: write derived features (vol gap, curve steepness, etc.)
+    FGA-->>CLI: ✓ features generated
+
+    CLI->>SEA: (automatic)
+    SEA->>Store: read all derived features
+    SEA->>Out: write ranked candidates with edge scores
+    SEA-->>CLI: ✓ strategy evaluation complete
 ```
 
-### Running a Full Pipeline Cycle
+### Run once (manual)
 
 ```bash
-python -m agent run
+python -m agent.run
 ```
 
-This executes all four agents in sequence: Data Ingestion → Event Detection → Feature Generation → Strategy Evaluation.
+On success you will see console output similar to:
 
-### Running Individual Agents
+```
+[INFO]  2026-03-15T09:00:01Z  Data Ingestion Agent    — complete (4 instruments, 3 chains fetched)
+[INFO]  2026-03-15T09:00:04Z  Event Detection Agent   — complete (2 events scored)
+[INFO]  2026-03-15T09:00:06Z  Feature Generation Agent — complete (6 signals computed)
+[INFO]  2026-03-15T09:00:09Z  Strategy Evaluation Agent — complete (5 candidates ranked)
+[INFO]  2026-03-15T09:00:09Z  Output written to ./output/candidates.json
+```
 
-Each agent is independently deployable and can be invoked in isolation:
+### Run a single agent in isolation
+
+Each agent exposes its own entry point, useful during development or when re-running a single stage after a data update:
 
 ```bash
-# Data Ingestion Agent only
-python -m agent run --mode ingest_only
-
-# Event Detection Agent only
-python -m agent run --mode events_only
-
-# Feature Generation Agent only
-python -m agent run --mode features_only
-
-# Strategy Evaluation Agent only
-python -m agent run --mode strategy_only
+python -m agent.ingest          # Data Ingestion Agent only
+python -m agent.detect_events   # Event Detection Agent only
+python -m agent.generate_features  # Feature Generation Agent only
+python -m agent.evaluate_strategies  # Strategy Evaluation Agent only
 ```
 
-### Scheduling Continuous Execution
+> **Dependency note:** Each agent reads from the shared state written by the prior stage. Running an agent in isolation without a populated store from the preceding stage will log a warning and fall back to the most recent persisted snapshot.
 
-For continuous operation, use `cron` (Linux/macOS) or Task Scheduler (Windows). The recommended cadence matches the `MARKET_DATA_INTERVAL_MINUTES` setting.
+### Schedule recurring runs
 
-**Example cron entry (every 5 minutes):**
+For continuous operation, use `cron` (Linux/macOS) or Task Scheduler (Windows).
+
+**Example: run every 5 minutes during market hours (cron)**
 
 ```cron
-*/5 * * * * /path/to/.venv/bin/python -m agent run >> /var/log/energy-agent.log 2>&1
+*/5 9-16 * * 1-5  cd /path/to/energy-options-agent && .venv/bin/python -m agent.run >> logs/pipeline.log 2>&1
 ```
 
-**Using the built-in scheduler loop:**
+**Example: run with Docker**
 
 ```bash
-python -m agent run --loop --interval 5
+docker build -t energy-options-agent .
+docker run --env-file .env -v $(pwd)/data:/app/data -v $(pwd)/output:/app/output \
+  energy-options-agent python -m agent.run
 ```
 
-> **Note:** EIA and EDGAR feeds operate on daily/weekly schedules. The pipeline fetches these on a slower internal timer regardless of the market data cadence.
+### Phased feature flags
 
-### Command-Line Reference
+The pipeline respects MVP phasing via environment flags. Features from later phases are no-ops unless the relevant keys and flags are present:
 
-| Flag | Type | Default | Description |
-|---|---|---|---|
-| `--mode` | string | `full` | Execution mode (see table in Configuration) |
-| `--loop` | flag | off | Run continuously on a timer |
-| `--interval` | int (minutes) | `5` | Polling interval when `--loop` is set |
-| `--output-dir` | path | `$OUTPUT_DIR` | Override output directory for this run |
-| `--log-level` | string | `$LOG_LEVEL` | Override log level for this run |
-| `--dry-run` | flag | off | Execute all agents but suppress file output |
-
-```bash
-# Example: run once in debug mode with a custom output directory
-python -m agent run --log-level DEBUG --output-dir ./debug_output
-```
+| Phase | Activated by |
+|---|---|
+| Phase 1 — Core market signals | `ALPHA_VANTAGE_API_KEY` + `POLYGON_API_KEY` present |
+| Phase 2 — Supply & event augmentation | `EIA_API_KEY` + `NEWS_API_KEY` present |
+| Phase 3 — Alternative / contextual signals | `MARINE_TRAFFIC_API_KEY` and/or Reddit credentials present |
+| Phase 4 — High-fidelity enhancements | Not included in MVP; see [Future Considerations](#future-considerations) |
 
 ---
 
 ## Interpreting the Output
 
-### Output File
+### Output file
 
-Each pipeline cycle writes one JSON file to `OUTPUT_DIR`:
+The pipeline writes results to the path specified by `OUTPUT_PATH` (default `./output/candidates.json`). The file contains a JSON array of candidate objects, sorted by `edge_score` descending.
 
-```
-./output/candidates_2026-03-15T14:32:00Z.json
-```
-
-The file contains an array of ranked strategy candidate objects, ordered from highest to lowest `edge_score`.
-
-### Output Schema
+### Output schema
 
 | Field | Type | Description |
 |---|---|---|
-| `instrument` | `string` | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
-| `structure` | `enum` | `long_straddle` \| `call_spread` \| `put_spread` \| `calendar_spread` |
-| `expiration` | `integer` (days) | Target expiration in calendar days from evaluation date |
-| `edge_score` | `float [0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
-| `signals` | `object` | Map of contributing signals and their qualitative state |
-| `generated_at` | `ISO 8601 datetime` | UTC timestamp of candidate generation |
+| `instrument` | string | Target instrument, e.g. `USO`, `XLE`, `CL=F` |
+| `structure` | enum | `long_straddle` · `call_spread` · `put_spread` · `calendar_spread` |
+| `expiration` | integer (days) | Calendar days from evaluation date to target expiration |
+| `edge_score` | float `[0.0–1.0]` | Composite opportunity score; higher = stronger signal confluence |
+| `signals` | object | Map of contributing signals and their current state |
+| `generated_at` | ISO 8601 datetime | UTC timestamp of candidate generation |
 
-### Annotated Example Candidate
+### Example candidate
 
 ```json
 {
@@ -372,36 +348,43 @@ The file contains an array of ranked strategy candidate objects, ordered from hi
     "volatility_gap": "positive",
     "narrative_velocity": "rising"
   },
-  "generated_at": "2026-03-15T14:32:00Z"
+  "generated_at": "2026-03-15T09:00:09Z"
 }
 ```
 
-**Reading this candidate:**
+### Reading the edge score
 
-- **`instrument: "USO"`** — The opportunity is on the USO crude oil ETF.
-- **`structure: "long_straddle"`** — The system recommends a long straddle, appropriate when a large move is expected in either direction.
-- **`expiration: 30`** — Target options expiring approximately 30 calendar days out.
-- **`edge_score: 0.47`** — Moderate signal confluence. Scores closer to `1.0` indicate stronger agreement across more layers.
-- **`signals`** — Three signals contributed to this candidate. `volatility_gap: "positive"` means realised volatility is running above implied volatility (options may be underpriced). `tanker_disruption_index: "high"` and `narrative_velocity: "rising"` indicate an active geopolitical catalyst.
+| Range | Interpretation |
+|---|---|
+| `0.70 – 1.00` | Strong signal confluence — high priority for review |
+| `0.40 – 0.69` | Moderate confluence — worth monitoring |
+| `0.20 – 0.39` | Weak signal — low confidence, informational only |
+| `0.00 – 0.19` | Negligible edge — typically filtered from default output |
 
-### Signal Reference
+### Signal map keys
 
-The `signals` object may contain any of the following keys, depending on which data layers are active:
-
-| Signal Key | Source Layer | Possible Values |
+| Signal key | Source agent | What it measures |
 |---|---|---|
-| `volatility_gap` | Feature Generation | `positive`, `negative`, `neutral` |
-| `futures_curve_steepness` | Feature Generation | `contango`, `backwardation`, `flat` |
-| `sector_dispersion` | Feature Generation | `high`, `moderate`, `low` |
-| `insider_conviction_score` | Feature Generation (EDGAR) | `high`, `moderate`, `low` |
-| `narrative_velocity` | Feature Generation (Reddit/Stocktwits) | `rising`, `stable`, `falling` |
-| `supply_shock_probability` | Feature Generation (EIA) | `high`, `moderate`, `low` |
-| `tanker_disruption_index` | Event Detection (MarineTraffic) | `high`, `moderate`, `low` |
-| `geo_event_confidence` | Event Detection (GDELT/NewsAPI) | `high`, `moderate`, `low` |
-| `refinery_outage_flag` | Event Detection (EIA/NewsAPI) | `true`, `false` |
+| `volatility_gap` | Feature Generation | Realised vs. implied volatility difference |
+| `futures_curve_steepness` | Feature Generation | Contango / backwardation of crude futures curve |
+| `sector_dispersion` | Feature Generation | Cross-sector price dispersion in energy equities |
+| `insider_conviction_score` | Feature Generation | Aggregated insider trade activity (EDGAR / Quiver) |
+| `narrative_velocity` | Feature Generation | Headline acceleration across news and social feeds |
+| `supply_shock_probability` | Feature Generation | Probability score from EIA + shipping + event signals |
+| `tanker_disruption_index` | Event Detection | Severity of tanker chokepoint disruptions |
+| `refinery_outage_index` | Event Detection | Confidence-weighted refinery outage signal |
+| `geopolitical_intensity` | Event Detection | Geopolitical event intensity from GDELT / NewsAPI |
 
-### Edge Score Interpretation
+### Consuming output in thinkorswim
 
-| Edge Score Range | Interpretation | Suggested Action |
+Export the `candidates.json` file and use thinkorswim's **thinkScript** `LoadStudy` or the **Studies → Import** workflow to load the JSON as a watchlist or alert source. Any JSON-capable charting or dashboard tool (e.g., Grafana with a JSON datasource plugin) is also compatible.
+
+---
+
+## Troubleshooting
+
+### Common errors and fixes
+
+| Symptom | Likely cause | Fix |
 |---|---|---|
-| `0.75 – 1.00` | Strong signal confluence | High-priority candidate
+| `KeyError: 'ALPHA_VANTAGE_API_KEY'` | `.env` not loaded or key missing | Confirm `.env` exists, is populated, and

--- a/src/agents/alternative_data/alternative_data_agent.py
+++ b/src/agents/alternative_data/alternative_data_agent.py
@@ -28,18 +28,31 @@ Stocktwits API notes:
   - Message sentiment label "Bullish" → positive, "Bearish" → negative, absent → neutral.
   - 429 responses logged as WARNING and return [] (not retried).
   - Symbols with no stream data (404 or empty messages) logged as WARNING, return [].
+
+MarineTraffic API notes:
+  - Requires MARINETRAFFIC_API_KEY env var; absent → WARNING + return [].
+  - Uses getVesselsInArea v:8 endpoint with lat/lon bounding boxes for each chokepoint.
+  - Chokepoints: Strait of Hormuz, Suez Canal, Bosphorus (see _CHOKEPOINTS constant).
+  - MMSI used as vessel_id; speed < threshold → "anchored", otherwise "transit".
 """
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
 import logging
+import os
 from typing import Any
 from xml.etree import ElementTree as ET
 
 import requests
 
-from src.agents.alternative_data.models import InsiderTrade, NarrativeSignal, Sentiment
+from src.agents.alternative_data.models import (
+    EventType,
+    InsiderTrade,
+    NarrativeSignal,
+    Sentiment,
+    ShippingEvent,
+)
 from src.core.retry import with_retry
 
 logger = logging.getLogger(__name__)
@@ -663,3 +676,191 @@ def _stocktwits_stream(instrument: str) -> list[dict[str, Any]] | None:
         logger.warning("fetch_stocktwits_sentiment: empty stream for instrument=%s", instrument)
 
     return messages
+
+
+# ===========================================================================
+# fetch_tanker_flows — issue #153
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_MARINETRAFFIC_API_URL = (
+    "https://services.marinetraffic.com/api/getVesselsInArea/v:8"
+    "/{api_key}"
+    "/MINLAT:{minlat}/MAXLAT:{maxlat}/MINLON:{minlon}/MAXLON:{maxlon}"
+    "/TIMESPAN:{timespan}/msgtype:json"
+)
+
+# Request timeout in seconds for MarineTraffic API calls
+_MARINETRAFFIC_TIMEOUT = 30
+
+# How many minutes back to scan for vessel positions
+_MARINETRAFFIC_TIMESPAN_MINUTES = 60
+
+# Vessels with speed (knots) at or below this threshold are classified "anchored"
+_ANCHORED_SPEED_THRESHOLD = 0.5
+
+# Named chokepoint bounding boxes — (minlat, maxlat, minlon, maxlon)
+# Each entry is: (name, minlat, maxlat, minlon, maxlon)
+_CHOKEPOINTS: list[tuple[str, float, float, float, float]] = [
+    ("strait_of_hormuz", 25.5, 27.0, 55.5, 57.5),
+    ("suez_canal", 29.5, 31.5, 32.0, 33.5),
+    ("bosphorus", 41.0, 41.5, 28.5, 29.5),
+]
+
+
+# ---------------------------------------------------------------------------
+# Public fetch function
+# ---------------------------------------------------------------------------
+
+
+@with_retry()
+def fetch_tanker_flows() -> list[ShippingEvent]:
+    """
+    Fetch vessel positions at key energy supply chokepoints.
+
+    Queries the MarineTraffic getVesselsInArea API for each chokepoint
+    bounding box and classifies vessels as "transit" or "anchored" based
+    on reported speed. Returns [] and logs a WARNING when
+    MARINETRAFFIC_API_KEY is absent.
+
+    Args:
+        None — scans all three configured chokepoints unconditionally.
+
+    Returns:
+        List of ShippingEvent records across all chokepoints.
+        Returns [] if MARINETRAFFIC_API_KEY env var is not set.
+
+    Raises:
+        requests.exceptions.RequestException: Propagated on network failure
+            so tenacity can retry the full call.
+    """
+    api_key = os.environ.get("MARINETRAFFIC_API_KEY", "")
+    if not api_key:
+        logger.warning(
+            "fetch_tanker_flows: MARINETRAFFIC_API_KEY not set — skipping tanker flow fetch"
+        )
+        return []
+
+    fetched_at = datetime.now(tz=UTC)
+    all_events: list[ShippingEvent] = []
+
+    for name, minlat, maxlat, minlon, maxlon in _CHOKEPOINTS:
+        try:
+            vessels = _fetch_vessels_in_area(api_key, minlat, maxlat, minlon, maxlon)
+        except requests.exceptions.RequestException:
+            raise  # let tenacity retry
+        except (ValueError, KeyError, TypeError) as exc:
+            logger.warning(
+                "fetch_tanker_flows: failed to fetch vessels for chokepoint=%s: %s", name, exc
+            )
+            continue
+
+        for vessel in vessels:
+            try:
+                event = _vessel_to_shipping_event(vessel, fetched_at)
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.warning(
+                    "fetch_tanker_flows: skipping malformed vessel record " "at chokepoint=%s: %s",
+                    name,
+                    exc,
+                )
+                continue
+            all_events.append(event)
+
+    return all_events
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_vessels_in_area(
+    api_key: str,
+    minlat: float,
+    maxlat: float,
+    minlon: float,
+    maxlon: float,
+) -> list[dict[str, Any]]:
+    """
+    Call MarineTraffic getVesselsInArea for a single bounding box.
+
+    Args:
+        api_key: MarineTraffic API key.
+        minlat: Southern latitude boundary.
+        maxlat: Northern latitude boundary.
+        minlon: Western longitude boundary.
+        maxlon: Eastern longitude boundary.
+
+    Returns:
+        List of vessel data dicts from the API response.
+
+    Raises:
+        requests.exceptions.RequestException: On HTTP or network failure.
+    """
+    url = _MARINETRAFFIC_API_URL.format(
+        api_key=api_key,
+        minlat=minlat,
+        maxlat=maxlat,
+        minlon=minlon,
+        maxlon=maxlon,
+        timespan=_MARINETRAFFIC_TIMESPAN_MINUTES,
+    )
+    resp = requests.get(url, timeout=_MARINETRAFFIC_TIMEOUT)
+    resp.raise_for_status()
+    data: list[dict[str, Any]] | dict[str, Any] = resp.json()
+    # MarineTraffic v8 returns a list directly or {"DATA": [...]}
+    if isinstance(data, list):
+        return data
+    return list(data.get("DATA", []))
+
+
+def _vessel_to_shipping_event(
+    vessel: dict[str, Any],
+    fetched_at: datetime,
+) -> ShippingEvent:
+    """
+    Convert a MarineTraffic vessel dict into a ShippingEvent record.
+
+    Vessels with SPEED <= _ANCHORED_SPEED_THRESHOLD knots are classified
+    as "anchored"; all others as "transit".
+
+    Args:
+        vessel:    Raw vessel dict from MarineTraffic API.
+        fetched_at: UTC timestamp when the batch was fetched.
+
+    Returns:
+        ShippingEvent with validated fields.
+
+    Raises:
+        KeyError: If a required field (MMSI, LAT, LON) is missing.
+        ValueError: If LAT/LON/SPEED cannot be converted to float.
+    """
+    vessel_id = str(vessel["MMSI"])
+    lat = float(vessel["LAT"])
+    lon = float(vessel["LON"])
+    speed = float(vessel.get("SPEED", 0))
+
+    event_type = EventType.ANCHORED if speed <= _ANCHORED_SPEED_THRESHOLD else EventType.TRANSIT
+
+    # TIMESTAMP field (UTC epoch seconds) is optional — fall back to fetched_at
+    ts_raw = vessel.get("TIMESTAMP")
+    if ts_raw:
+        try:
+            timestamp = datetime.fromtimestamp(int(ts_raw), tz=UTC)
+        except (ValueError, OSError):
+            timestamp = fetched_at
+    else:
+        timestamp = fetched_at
+
+    return ShippingEvent(
+        vessel_id=vessel_id,
+        event_type=event_type,
+        latitude=lat,
+        longitude=lon,
+        timestamp=timestamp,
+        source="marinetraffic",
+    )

--- a/src/agents/alternative_data/models.py
+++ b/src/agents/alternative_data/models.py
@@ -66,3 +66,29 @@ class NarrativeSignal(BaseModel):
     window_start: datetime
     window_end: datetime
     source: str = "reddit"
+
+
+class EventType(StrEnum):
+    """Vessel event types for shipping_events table (matches DB event_type values)."""
+
+    TRANSIT = "transit"
+    ANCHORED = "anchored"
+    DELAYED = "delayed"
+
+
+class ShippingEvent(BaseModel):
+    """
+    Validated vessel movement event near an energy supply chokepoint.
+
+    Maps to the shipping_events table schema (db/schema.sql).
+    instrument is nullable — a vessel in a chokepoint zone may affect
+    multiple instruments or none specifically.
+    """
+
+    vessel_id: str
+    event_type: EventType
+    latitude: float
+    longitude: float
+    timestamp: datetime
+    source: str = "marinetraffic"
+    instrument: str | None = None

--- a/tests/agents/alternative_data/test_alternative_data_agent.py
+++ b/tests/agents/alternative_data/test_alternative_data_agent.py
@@ -597,3 +597,172 @@ class TestFetchStocktwitsHttpError:
         with patch("requests.get", side_effect=requests.ConnectionError("timeout")):
             with pytest.raises(requests.ConnectionError):
                 fetch_stocktwits_sentiment(["XOM"])
+
+
+# ===========================================================================
+# fetch_tanker_flows tests — issue #153
+# ===========================================================================
+
+from src.agents.alternative_data.alternative_data_agent import (  # noqa: E402
+    _vessel_to_shipping_event,
+    fetch_tanker_flows,
+)
+from src.agents.alternative_data.models import EventType, ShippingEvent  # noqa: E402
+
+_MARINETRAFFIC_URL_PREFIX = "https://services.marinetraffic.com/api/getVesselsInArea"
+
+
+def _make_vessel(
+    mmsi: str = "123456789",
+    lat: float = 26.5,
+    lon: float = 56.5,
+    speed: float = 5.0,
+    timestamp: int | None = None,
+) -> dict:
+    v: dict = {"MMSI": mmsi, "LAT": str(lat), "LON": str(lon), "SPEED": str(speed)}
+    if timestamp is not None:
+        v["TIMESTAMP"] = str(timestamp)
+    return v
+
+
+def _mt_resp(vessels: list[dict]) -> MagicMock:
+    """Mock MarineTraffic response returning vessel list directly."""
+    mock = MagicMock()
+    mock.status_code = 200
+    mock.raise_for_status.return_value = None
+    mock.json.return_value = vessels
+    return mock
+
+
+class TestFetchTankerFlowsNoKey:
+    def test_missing_api_key_returns_empty_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.delenv("MARINETRAFFIC_API_KEY", raising=False)
+        with caplog.at_level(logging.WARNING):
+            events = fetch_tanker_flows()
+
+        assert events == []
+        assert any("marinetraffic_api_key" in r.message.lower() for r in caplog.records)
+
+
+class TestFetchTankerFlowsHappyPath:
+    def test_transit_vessel_returned(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        vessel = _make_vessel(mmsi="111111111", lat=26.5, lon=56.5, speed=8.0)
+        # 3 chokepoints → 3 API calls; return vessel only on first, empty on others
+        resps = [_mt_resp([vessel]), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            events = fetch_tanker_flows()
+
+        assert len(events) == 1
+        e = events[0]
+        assert isinstance(e, ShippingEvent)
+        assert e.vessel_id == "111111111"
+        assert e.event_type == EventType.TRANSIT
+        assert e.latitude == pytest.approx(26.5)
+        assert e.longitude == pytest.approx(56.5)
+        assert e.source == "marinetraffic"
+
+    def test_anchored_vessel_below_speed_threshold(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        vessel = _make_vessel(speed=0.2)
+        resps = [_mt_resp([vessel]), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            events = fetch_tanker_flows()
+
+        assert events[0].event_type == EventType.ANCHORED
+
+    def test_speed_at_threshold_is_anchored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        vessel = _make_vessel(speed=0.5)  # exactly at threshold
+        resps = [_mt_resp([vessel]), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            events = fetch_tanker_flows()
+
+        assert events[0].event_type == EventType.ANCHORED
+
+    def test_all_three_chokepoints_queried(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        resps = [_mt_resp([_make_vessel()]), _mt_resp([_make_vessel("222")]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps) as mock_get:
+            events = fetch_tanker_flows()
+
+        assert mock_get.call_count == 3
+        assert len(events) == 2
+
+    def test_dict_envelope_response_handled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MarineTraffic v8 may return {'DATA': [...]} instead of a bare list."""
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        envelope = {"DATA": [_make_vessel()]}
+        resps = [_mock_resp(envelope), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            events = fetch_tanker_flows()
+
+        assert len(events) == 1
+
+
+class TestFetchTankerFlowsEmptyResponse:
+    def test_empty_vessel_list_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        resps = [_mt_resp([]), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            events = fetch_tanker_flows()
+
+        assert events == []
+
+
+class TestFetchTankerFlowsMalformedVessel:
+    def test_missing_mmsi_skips_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        bad_vessel = {"LAT": "26.5", "LON": "56.5", "SPEED": "5.0"}  # no MMSI
+        resps = [_mt_resp([bad_vessel]), _mt_resp([]), _mt_resp([])]
+
+        with patch("requests.get", side_effect=resps):
+            with caplog.at_level(logging.WARNING):
+                events = fetch_tanker_flows()
+
+        assert events == []
+        assert any("malformed" in r.message.lower() for r in caplog.records)
+
+
+class TestFetchTankerFlowsHttpError:
+    def test_http_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MARINETRAFFIC_API_KEY", "test-key")
+        monkeypatch.setenv("TENACITY_MAX_RETRIES", "1")
+
+        with patch("requests.get", side_effect=requests.ConnectionError("timeout")):
+            with pytest.raises(requests.ConnectionError):
+                fetch_tanker_flows()
+
+
+class TestVesselToShippingEvent:
+    def test_timestamp_field_parsed(self) -> None:
+        from datetime import UTC, datetime
+
+        vessel = _make_vessel(timestamp=1700000000)
+        fetched_at = datetime.now(tz=UTC)
+        event = _vessel_to_shipping_event(vessel, fetched_at)
+
+        assert event.timestamp == datetime.fromtimestamp(1700000000, tz=UTC)
+
+    def test_missing_timestamp_falls_back_to_fetched_at(self) -> None:
+        from datetime import UTC, datetime
+
+        vessel = _make_vessel()  # no timestamp
+        fetched_at = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+        event = _vessel_to_shipping_event(vessel, fetched_at)
+
+        assert event.timestamp == fetched_at


### PR DESCRIPTION
## Summary

- `fetch_tanker_flows()` queries MarineTraffic getVesselsInArea v:8 for 3 energy chokepoints: Strait of Hormuz, Suez Canal, Bosphorus
- `MARINETRAFFIC_API_KEY` absent → WARNING + `[]` (graceful skip, no error)
- Vessels speed ≤ 0.5 knots → `EventType.ANCHORED`; otherwise `EventType.TRANSIT`
- `EventType` StrEnum + `ShippingEvent` Pydantic model added to `models.py`
- Chokepoints defined as `_CHOKEPOINTS` named constant with lat/lon bounding boxes
- `@with_retry()` applied; malformed vessel records logged as WARNING + skipped
- `.env.example` updated with placeholder + comment

## Acceptance Criteria
- [x] `fetch_tanker_flows() -> list[ShippingEvent]` implemented
- [x] Guarded by `MARINETRAFFIC_API_KEY` env var — absent → WARNING + `[]`
- [x] `ShippingEvent` Pydantic model: `vessel_id`, `event_type`, `latitude`, `longitude`, `timestamp`, `source`
- [x] Chokepoint zones as named constants (not magic numbers)
- [x] `@with_retry()` applied
- [x] No-key graceful skip; API errors logged as WARNING
- [x] Type hints on all public functions (mypy strict ✓)
- [x] ≥ 5 unit tests (11 total)
- [x] `.env.example` updated with `MARINETRAFFIC_API_KEY=` placeholder and comment
- [x] `bash scripts/local_check.sh` exits 0 ✓ (299 passed, 2 skipped)

## Test plan
- [x] All 5 local_check.sh stages pass (ruff, black 26.3.1, mypy strict, import scan, 299 unit tests)
- [x] `pytest tests/agents/alternative_data/` — 49 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)