### PR TITLE
feat(schema): strategy_outcomes table — track candidate vs. actual price move (#130)

### DIFF
--- a/db/migrations/add_strategy_outcomes.sql
+++ b/db/migrations/add_strategy_outcomes.sql
@@ -1,0 +1,53 @@
+-- =============================================================================
+-- db/migrations/add_strategy_outcomes.sql
+-- Issue #130 — Phase 3 strategy outcome tracking
+-- =============================================================================
+--
+-- Creates the strategy_outcomes table to record actual price movement of the
+-- underlying instrument after each strategy candidate expires.
+--
+-- Closes the edge score feedback loop: without this table the edge score
+-- heuristic has never been validated against real trade outcomes.
+--
+-- Design notes:
+--   - price_at_expiration and pct_move are nullable; populated by a separate
+--     job that runs after expiration_date. The row is still inserted at
+--     generation time so the pending-outcomes query can discover it.
+--   - UNIQUE (candidate_id) ensures at most one outcome row per candidate.
+--     ON CONFLICT DO UPDATE allows the expiration job to fill in the nullable
+--     columns without inserting a duplicate.
+--   - The table is append-only; rows are never deleted or edited (only
+--     price_at_expiration / pct_move / recorded_at are ever updated).
+--   - TIMESTAMPTZ everywhere → TimescaleDB hypertable conversion requires
+--     zero SQL changes (partition by generated_at).
+--
+-- HUMAN SIGN-OFF REQUIRED before running against any live DB.
+-- Apply:  psql $DATABASE_URL -f db/migrations/add_strategy_outcomes.sql
+-- Verify: \d strategy_outcomes
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- strategy_outcomes
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS strategy_outcomes (
+    id                  BIGSERIAL       PRIMARY KEY,
+    candidate_id        BIGINT          NOT NULL REFERENCES strategy_candidates(id),
+    instrument          TEXT            NOT NULL,
+    structure           TEXT            NOT NULL
+                            CHECK (structure IN ('long_straddle','call_spread','put_spread','calendar_spread')),
+    generated_at        TIMESTAMPTZ     NOT NULL,
+    expiration_date     TIMESTAMPTZ     NOT NULL,
+    price_at_generation FLOAT           NOT NULL,
+    price_at_expiration FLOAT,                       -- NULL until expiration job runs
+    pct_move            FLOAT,                       -- NULL until expiration job runs
+    recorded_at         TIMESTAMPTZ     NOT NULL,
+    CONSTRAINT uq_strategy_outcomes_candidate UNIQUE (candidate_id)
+);
+
+-- Primary lookup: find outcome for a given candidate
+CREATE INDEX IF NOT EXISTS idx_strategy_outcomes_candidate_id
+    ON strategy_outcomes (candidate_id);
+
+-- Expiration job scans: find outcomes due for price resolution
+CREATE INDEX IF NOT EXISTS idx_strategy_outcomes_expiration_date
+    ON strategy_outcomes (expiration_date DESC);

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -27,8 +27,9 @@
 --
 -- Apply:  psql $DATABASE_URL -f db/schema.sql
 -- Verify: \d market_prices    \d options_chain    \d feature_sets
---         \d strategy_candidates    \d eia_inventory    \d detected_events
---         \d insider_trades   \d shipping_events   \d narrative_signals
+--         \d strategy_candidates    \d strategy_outcomes    \d eia_inventory
+--         \d detected_events    \d insider_trades   \d shipping_events
+--         \d narrative_signals
 -- =============================================================================
 
 
@@ -98,6 +99,45 @@ CREATE TABLE IF NOT EXISTS strategy_candidates (
 
 CREATE INDEX IF NOT EXISTS idx_strategy_candidates_generated_edge
     ON strategy_candidates (generated_at DESC, edge_score DESC);
+
+
+-- -----------------------------------------------------------------------------
+-- strategy_outcomes                                                 (Phase 3)
+--
+-- Stores actual price movement outcomes for strategy candidates (issue #130).
+-- Closes the edge score feedback loop — without this table the edge score
+-- heuristic has never been validated against real trade outcomes.
+--
+-- price_at_expiration and pct_move are nullable — populated by a separate job
+-- that runs after expiration_date. The table is append-only; rows are never
+-- deleted or edited (only the nullable columns are ever updated via upsert).
+--
+-- UNIQUE (candidate_id) ensures at most one outcome row per candidate.
+-- ON CONFLICT DO UPDATE allows the expiration job to fill nullable columns
+-- without inserting a duplicate.
+--
+-- Hypertable candidate: partition by generated_at.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS strategy_outcomes (
+    id                  BIGSERIAL       PRIMARY KEY,
+    candidate_id        BIGINT          NOT NULL REFERENCES strategy_candidates(id),
+    instrument          TEXT            NOT NULL,
+    structure           TEXT            NOT NULL
+                            CHECK (structure IN ('long_straddle','call_spread','put_spread','calendar_spread')),
+    generated_at        TIMESTAMPTZ     NOT NULL,
+    expiration_date     TIMESTAMPTZ     NOT NULL,
+    price_at_generation FLOAT           NOT NULL,
+    price_at_expiration FLOAT,                       -- NULL until expiration job runs
+    pct_move            FLOAT,                       -- NULL until expiration job runs
+    recorded_at         TIMESTAMPTZ     NOT NULL,
+    CONSTRAINT uq_strategy_outcomes_candidate UNIQUE (candidate_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_outcomes_candidate_id
+    ON strategy_outcomes (candidate_id);
+
+CREATE INDEX IF NOT EXISTS idx_strategy_outcomes_expiration_date
+    ON strategy_outcomes (expiration_date DESC);
 
 
 -- -----------------------------------------------------------------------------

--- a/src/agents/strategy_evaluation/db.py
+++ b/src/agents/strategy_evaluation/db.py
@@ -5,13 +5,15 @@ PostgreSQL via SQLAlchemy. Schema TimescaleDB-compatible (ESOD Section 4.3).
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 import json
 import logging
+from typing import Any
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
-from src.agents.strategy_evaluation.models import StrategyCandidate
+from src.agents.strategy_evaluation.models import StrategyCandidate, StrategyOutcome
 from src.core.db import get_engine  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -137,3 +139,97 @@ def read_top_candidates(engine: Engine, limit: int = 10) -> list[StrategyCandida
         result.append(candidate)
 
     return result
+
+
+def write_strategy_outcome(outcome: StrategyOutcome, engine: Engine) -> None:
+    """
+    Insert or upsert a single strategy outcome record.
+
+    Uses ON CONFLICT (candidate_id) DO UPDATE so the expiration-price job can
+    fill in price_at_expiration and pct_move on a subsequent call without
+    creating a duplicate row.
+
+    Args:
+        outcome: Validated StrategyOutcome to persist.
+        engine: SQLAlchemy Engine.
+
+    Raises:
+        sqlalchemy.exc.SQLAlchemyError: Propagates on constraint violation or
+            connection failure after logging the exception.
+    """
+    sql = text("""
+        INSERT INTO strategy_outcomes
+            (candidate_id, instrument, structure, generated_at, expiration_date,
+             price_at_generation, price_at_expiration, pct_move, recorded_at)
+        VALUES
+            (:candidate_id, :instrument, :structure, :generated_at, :expiration_date,
+             :price_at_generation, :price_at_expiration, :pct_move, :recorded_at)
+        ON CONFLICT (candidate_id) DO UPDATE SET
+            price_at_expiration = EXCLUDED.price_at_expiration,
+            pct_move            = EXCLUDED.pct_move,
+            recorded_at         = EXCLUDED.recorded_at
+        """)
+    row: dict[str, Any] = {
+        "candidate_id": outcome.candidate_id,
+        "instrument": outcome.instrument,
+        "structure": outcome.structure.value,
+        "generated_at": outcome.generated_at,
+        "expiration_date": outcome.expiration_date,
+        "price_at_generation": outcome.price_at_generation,
+        "price_at_expiration": outcome.price_at_expiration,
+        "pct_move": outcome.pct_move,
+        "recorded_at": outcome.recorded_at,
+    }
+    try:
+        with engine.begin() as conn:
+            conn.execute(sql, row)
+    except Exception:
+        logger.exception("write_strategy_outcome failed for candidate_id=%s", outcome.candidate_id)
+        raise
+
+    logger.info(
+        "Wrote outcome for candidate_id=%s instrument=%s",
+        outcome.candidate_id,
+        outcome.instrument,
+    )
+
+
+def fetch_pending_outcomes(
+    engine: Engine,
+    as_of: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """
+    Return strategy candidates past their expiration date with no recorded outcome.
+
+    Queries strategy_candidates LEFT JOIN strategy_outcomes and returns rows
+    where the outcome has not yet been recorded and the computed expiration date
+    (generated_at + expiration days) is before as_of.
+
+    Args:
+        engine: SQLAlchemy Engine.
+        as_of: Treat this datetime as "now" for expiration comparisons.
+            Defaults to datetime.now(UTC). Pass an explicit value in tests.
+
+    Returns:
+        List of dicts with keys: candidate_id, instrument, structure,
+        generated_at, expiration_date — ready to be passed to a price-fetch job
+        that will call write_strategy_outcome() with the resolved prices.
+    """
+    sql = text("""
+        SELECT
+            sc.id           AS candidate_id,
+            sc.instrument,
+            sc.structure,
+            sc.generated_at,
+            (sc.generated_at + sc.expiration * INTERVAL '1 day')::TIMESTAMPTZ
+                            AS expiration_date
+        FROM  strategy_candidates sc
+        LEFT JOIN strategy_outcomes so ON so.candidate_id = sc.id
+        WHERE so.candidate_id IS NULL
+          AND (sc.generated_at + sc.expiration * INTERVAL '1 day') < :as_of
+        ORDER BY expiration_date ASC
+        """)
+    cutoff = as_of if as_of is not None else datetime.now(tz=UTC)
+    with engine.connect() as conn:
+        rows = conn.execute(sql, {"as_of": cutoff}).mappings().all()
+    return [dict(row) for row in rows]

--- a/src/agents/strategy_evaluation/models.py
+++ b/src/agents/strategy_evaluation/models.py
@@ -14,6 +14,32 @@ from pydantic import BaseModel, Field
 from src.agents.ingestion.models import OptionStructure
 
 
+class StrategyOutcome(BaseModel):
+    """
+    Outcome record for a strategy candidate — tracks actual price move at expiration.
+
+    price_at_expiration and pct_move are nullable until the expiration job
+    resolves them from market data.  The table is append-only; use
+    write_strategy_outcome() to insert or update a single row.
+    """
+
+    candidate_id: int = Field(..., gt=0, description="FK to strategy_candidates.id")
+    instrument: str = Field(..., description="Target instrument ticker, e.g. 'USO'")
+    structure: OptionStructure
+    generated_at: datetime = Field(..., description="UTC timestamp from the source candidate")
+    expiration_date: datetime = Field(..., description="Target expiration as UTC datetime")
+    price_at_generation: float = Field(
+        ..., description="Underlying price when the candidate was generated"
+    )
+    price_at_expiration: float | None = Field(
+        None, description="Underlying price at expiration; None until recorded by expiration job"
+    )
+    pct_move: float | None = Field(
+        None, description="Percentage move from generation to expiration; None until recorded"
+    )
+    recorded_at: datetime = Field(..., description="UTC timestamp when this record was written")
+
+
 class StrategyCandidate(BaseModel):
     """
     Single ranked strategy opportunity (PRD Section 9 output schema).

--- a/tests/agents/strategy_evaluation/test_strategy_outcomes_db.py
+++ b/tests/agents/strategy_evaluation/test_strategy_outcomes_db.py
@@ -1,0 +1,215 @@
+"""
+Unit tests for strategy_outcomes DB functions:
+  write_strategy_outcome() — insert/upsert a single outcome record
+  fetch_pending_outcomes() — return candidates past expiration with no outcome
+
+Uses MagicMock to simulate the SQLAlchemy engine/connection without a real DB.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.agents.ingestion.models import OptionStructure
+from src.agents.strategy_evaluation.db import (
+    fetch_pending_outcomes,
+    write_strategy_outcome,
+)
+from src.agents.strategy_evaluation.models import StrategyOutcome
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2026, 3, 22, 12, 0, 0, tzinfo=UTC)
+_EXPIRY = _NOW + timedelta(days=30)
+
+
+def _make_outcome(
+    candidate_id: int = 1,
+    instrument: str = "USO",
+    price_at_expiration: float | None = None,
+    pct_move: float | None = None,
+) -> StrategyOutcome:
+    return StrategyOutcome(
+        candidate_id=candidate_id,
+        instrument=instrument,
+        structure=OptionStructure.LONG_STRADDLE,
+        generated_at=_NOW,
+        expiration_date=_EXPIRY,
+        price_at_generation=72.50,
+        price_at_expiration=price_at_expiration,
+        pct_move=pct_move,
+        recorded_at=_NOW,
+    )
+
+
+def _make_engine() -> tuple[MagicMock, MagicMock]:
+    """Return (engine, conn) mock pair whose context managers work correctly."""
+    engine = MagicMock()
+    conn = MagicMock()
+    engine.begin.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+    engine.connect.return_value.__enter__ = MagicMock(return_value=conn)
+    engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+    return engine, conn
+
+
+# ---------------------------------------------------------------------------
+# write_strategy_outcome
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStrategyOutcome:
+    def test_insert_executes_with_correct_row(self) -> None:
+        """write_strategy_outcome calls conn.execute once with correct params."""
+        engine, conn = _make_engine()
+        outcome = _make_outcome(candidate_id=42, instrument="XLE")
+        write_strategy_outcome(outcome, engine)
+        conn.execute.assert_called_once()
+        _, row = conn.execute.call_args.args
+        assert row["candidate_id"] == 42
+        assert row["instrument"] == "XLE"
+        assert row["structure"] == "long_straddle"
+        assert row["price_at_generation"] == 72.50
+        assert row["price_at_expiration"] is None
+        assert row["pct_move"] is None
+
+    def test_nullable_fields_passed_through_when_present(self) -> None:
+        """price_at_expiration and pct_move are forwarded when provided."""
+        engine, conn = _make_engine()
+        outcome = _make_outcome(price_at_expiration=79.10, pct_move=0.091)
+        write_strategy_outcome(outcome, engine)
+        _, row = conn.execute.call_args.args
+        assert row["price_at_expiration"] == pytest.approx(79.10)
+        assert row["pct_move"] == pytest.approx(0.091)
+
+    def test_structure_serialized_as_string(self) -> None:
+        """OptionStructure enum is stored as its string value, not the enum object."""
+        engine, conn = _make_engine()
+        outcome = _make_outcome()
+        write_strategy_outcome(outcome, engine)
+        _, row = conn.execute.call_args.args
+        assert isinstance(row["structure"], str)
+        assert row["structure"] == "long_straddle"
+
+    def test_db_exception_propagates(self) -> None:
+        """SQLAlchemy errors are re-raised after logging."""
+        engine = MagicMock()
+        engine.begin.return_value.__enter__ = MagicMock(side_effect=RuntimeError("db down"))
+        engine.begin.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="db down"):
+            write_strategy_outcome(_make_outcome(), engine)
+
+    def test_uses_begin_for_write_transaction(self) -> None:
+        """Write uses engine.begin() (transactional) not engine.connect()."""
+        engine, _ = _make_engine()
+        write_strategy_outcome(_make_outcome(), engine)
+        engine.begin.assert_called_once()
+        engine.connect.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# fetch_pending_outcomes
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPendingOutcomes:
+    def _make_row(
+        self,
+        candidate_id: int = 1,
+        instrument: str = "USO",
+    ) -> MagicMock:
+        row = MagicMock()
+        row.__iter__ = MagicMock(
+            return_value=iter(
+                [
+                    ("candidate_id", candidate_id),
+                    ("instrument", instrument),
+                    ("structure", "long_straddle"),
+                    ("generated_at", _NOW - timedelta(days=40)),
+                    ("expiration_date", _NOW - timedelta(days=10)),
+                ]
+            )
+        )
+        row.keys = MagicMock(
+            return_value=[
+                "candidate_id",
+                "instrument",
+                "structure",
+                "generated_at",
+                "expiration_date",
+            ]
+        )
+        # Support dict(row) via mapping protocol
+        row.__class__ = dict
+        return {
+            "candidate_id": candidate_id,
+            "instrument": instrument,
+            "structure": "long_straddle",
+            "generated_at": _NOW - timedelta(days=40),
+            "expiration_date": _NOW - timedelta(days=10),
+        }
+
+    def _make_engine_with_rows(self, rows: list[dict]) -> tuple[MagicMock, MagicMock]:
+        engine, conn = _make_engine()
+        conn.execute.return_value.mappings.return_value.all.return_value = rows
+        return engine, conn
+
+    def test_returns_list_of_dicts(self) -> None:
+        """fetch_pending_outcomes returns a list of plain dicts."""
+        row = self._make_row(candidate_id=7, instrument="XOM")
+        engine, _ = self._make_engine_with_rows([row])
+        result = fetch_pending_outcomes(engine, as_of=_NOW)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["candidate_id"] == 7
+        assert result[0]["instrument"] == "XOM"
+
+    def test_empty_result_returns_empty_list(self) -> None:
+        """No pending candidates → empty list, no exception."""
+        engine, _ = self._make_engine_with_rows([])
+        result = fetch_pending_outcomes(engine, as_of=_NOW)
+        assert result == []
+
+    def test_as_of_forwarded_to_query(self) -> None:
+        """The as_of parameter is passed to the SQL query as :as_of."""
+        engine, conn = self._make_engine_with_rows([])
+        custom_time = datetime(2026, 1, 1, tzinfo=UTC)
+        fetch_pending_outcomes(engine, as_of=custom_time)
+        _, params = conn.execute.call_args.args
+        assert params["as_of"] == custom_time
+
+    def test_default_as_of_is_now(self) -> None:
+        """Without explicit as_of, a datetime close to now() is used."""
+        engine, conn = self._make_engine_with_rows([])
+        before = datetime.now(tz=UTC)
+        fetch_pending_outcomes(engine)
+        after = datetime.now(tz=UTC)
+        _, params = conn.execute.call_args.args
+        assert before <= params["as_of"] <= after
+
+    def test_multiple_rows_all_returned(self) -> None:
+        """All rows from the query are included in the result."""
+        rows = [self._make_row(candidate_id=i) for i in range(1, 4)]
+        engine, _ = self._make_engine_with_rows(rows)
+        result = fetch_pending_outcomes(engine, as_of=_NOW)
+        assert len(result) == 3
+
+    def test_uses_connect_not_begin(self) -> None:
+        """Read query uses engine.connect() (read-only), not engine.begin()."""
+        engine, _ = self._make_engine_with_rows([])
+        fetch_pending_outcomes(engine, as_of=_NOW)
+        engine.connect.assert_called_once()
+        engine.begin.assert_not_called()
+
+    def test_db_exception_propagates(self) -> None:
+        """Connection failures are re-raised to the caller."""
+        engine = MagicMock()
+        engine.connect.return_value.__enter__ = MagicMock(side_effect=RuntimeError("timeout"))
+        engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+        with pytest.raises(RuntimeError, match="timeout"):
+            fetch_pending_outcomes(engine, as_of=_NOW)

--- a/tests/pipeline/test_pipeline_integration.py
+++ b/tests/pipeline/test_pipeline_integration.py
@@ -162,7 +162,7 @@ def _clean_tables(pg_engine: Engine) -> Generator[None, None, None]:
         conn.execute(
             text(
                 "TRUNCATE market_prices, options_chain, feature_sets,"
-                " strategy_candidates RESTART IDENTITY"
+                " strategy_candidates RESTART IDENTITY CASCADE"
             )
         )
     yield


### PR DESCRIPTION
## Summary

- `strategy_outcomes` table added to `db/schema.sql` and `db/migrations/add_strategy_outcomes.sql`
- Unique constraint on `candidate_id` — one outcome row per candidate; `ON CONFLICT DO UPDATE` allows expiration job to fill nullable fields on second call
- `StrategyOutcome` Pydantic model: `candidate_id` (FK), `instrument`, `structure`, `generated_at`, `expiration_date`, `price_at_generation`, `price_at_expiration` (nullable), `pct_move` (nullable), `recorded_at`
- `write_strategy_outcome()` — INSERT … ON CONFLICT upsert; uses `engine.begin()` (transactional)
- `fetch_pending_outcomes()` — LEFT JOIN finds candidates past their expiration date with no outcome; `as_of` param for testability; returns `list[dict[str, Any]]`
- All TIMESTAMPTZ columns (TimescaleDB-compatible from day one); hypertable candidate: partition by `generated_at`

## Acceptance Criteria
- [x] `strategy_outcomes` table in schema + migration
- [x] Schema: `candidate_id`, `instrument`, `structure`, `generated_at`, `expiration_date`, `price_at_generation`, `price_at_expiration` (nullable), `pct_move` (nullable), `recorded_at`
- [x] Migration script in `db/migrations/`
- [x] `write_strategy_outcome()` — insert or upsert single record
- [x] `fetch_pending_outcomes()` — candidates past expiration with no outcome
- [x] 12 unit tests (5 write, 7 fetch)
- [x] All TIMESTAMPTZ columns
- [x] `pytest -m "not integration"` passes (278 passed); `bash scripts/local_check.sh` exits 0

## Test plan
- [x] `pytest tests/agents/strategy_evaluation/test_strategy_outcomes_db.py` — 12 passed
- [x] All 5 local_check.sh stages: ruff ✓ · black ✓ · mypy strict ✓ · import scan ✓ · 278 unit tests ✓

⚠️ **HUMAN SIGN-OFF REQUIRED** before running `add_strategy_outcomes.sql` against any live DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)